### PR TITLE
test: slop audit B1, collapse per-engine isolation wrapper pairs (#619)

### DIFF
--- a/internal/conformance/boundregistry_test.go
+++ b/internal/conformance/boundregistry_test.go
@@ -112,7 +112,7 @@ var Registry = []Bound{
 
 	// §5 machine identities.
 	bound("machine-credentials-per-sa", "Machine credentials per SA", "ops-spec §5", "service.ErrCredentialCap", "isolation identities_e2e", StatusEnforced,
-		goTest("internal/isolation", "TestMachineCredentialCapSQLite")),
+		goTest("internal/isolation", "TestMachineCredentialCap")),
 
 	// §8 structural bounds.
 	bound("environments-per-project", "Environments per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxEnvironmentsPerProject)", "conformance scenarioDeleteRefusesChildren / env cap", StatusEnforced,
@@ -138,17 +138,17 @@ var Registry = []Bound{
 	bound("per-target-render-total", "Per-target render total", "ops-spec §8", "domain.ErrLimitExceeded (MaxRenderBytesPerTarget)", "service.TestRenderTotalRefusesAnOversizedTarget", StatusEnforced,
 		goTest("internal/service", "TestRenderTotalRefusesAnOversizedTarget")),
 	bound("pending-versions-per-project", "Pending versions per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxPendingPerProject)", "isolation.TestPendingPerProjectCap", StatusEnforced,
-		goTest("internal/isolation", "TestPendingPerProjectCapSQLite")),
+		goTest("internal/isolation", "TestPendingPerProjectCap")),
 	bound("bundle-bytes-entries", "Bundle bytes / entries", "ops-spec §8", "definitions.ErrLimitExceeded (MaxBundle*)", "definitions bundle_test", StatusEnforced,
 		goTest("internal/definitions", "TestParseBoundsRefused")),
 	bound("open-plans-per-project", "Open plans per project", "ops-spec §8", "domain.ErrLimitExceeded (MaxOpenPlansPerProject)", "isolation definitions_e2e", StatusEnforced,
-		goTest("internal/isolation", "TestDefinitionsSQLite")),
+		goTest("internal/isolation", "TestDefinitions")),
 	bound("pins-quota-per-project", "Pins quota per project", "ops-spec §8", "invalidDetail (PinQuota)", "conformance revisions_test", StatusEnforced,
 		goHelper("internal/conformance", "scenarioPinLifecycle")),
 	bound("grants-per-org", "Grants per org", "ops-spec §8", "domain.ErrLimitExceeded (MaxGrantsPerOrg)", "isolation.TestGrantPerOrgCap", StatusEnforced,
-		goTest("internal/isolation", "TestGrantPerOrgCapSQLite")),
+		goTest("internal/isolation", "TestGrantPerOrgCap")),
 	bound("project-storage-high-water", "Per-project storage high-water (warn 1 GiB / refuse 4 GiB)", "ops-spec §8 (§141)", "domain.ErrLimitExceeded (MaxProjectStorageBytes) at publish + doctor/metric/UI-banner warn (ProjectStorageWarnBytes)", "isolation.TestProjectStorageHighWater", StatusEnforced,
-		goTest("internal/isolation", "TestProjectStorageHighWaterSQLite")),
+		goTest("internal/isolation", "TestProjectStorageHighWater")),
 	bound("schema-revision-rate", "Schema-revision rate 60/h per project", "ops-spec §8 (§151)", "admission.ErrOverloaded (uniform 429) via service.Budget", "conformance scenarioSchemaRevisionRateLimit + service.TestBudgetRateWindowSlides", StatusEnforced,
 		goHelper("internal/conformance", "scenarioSchemaRevisionRateLimit")),
 
@@ -182,7 +182,7 @@ var Registry = []Bound{
 	bound("saml-document-bounds", "SAML document bytes / depth / tokens", "ops-catalogue §SAML", "samlsp.ErrDocument* ", "samlsp xml_test", StatusEnforced,
 		goTest("internal/samlsp", "TestParseXMLRefusesPreparseThreats")),
 	bound("scim-wire-body-cap", "SCIM wire body cap", "ops-catalogue §SCIM", "scimproto.ErrBodyTooLarge (api.SCIMBodyBound)", "isolation scim_provider_sequence_test", StatusEnforced,
-		goTest("internal/isolation", "TestSCIMWireAdmissionOverHTTPSQLite")),
+		goTest("internal/isolation", "TestSCIMWireAdmissionOverHTTP")),
 
 	// §6 compose client.
 	bound("run-arg-max-preflight", "run-- ARG_MAX preflight", "ops-spec §6 / inv.8", "composite _SC_ARG_MAX refusal", "compose argmax_test", StatusEnforced,
@@ -190,7 +190,7 @@ var Registry = []Bound{
 
 	// §5 reveal / reauth.
 	bound("protected-environment-reauth-window", "Protected-environment reauth window cap", "ops-spec §5", "service.ErrProtectedWindowCap", "isolation grants_e2e (ErrProtectedWindowCap)", StatusEnforced,
-		goTest("internal/isolation", "TestProtectedEnvironmentSQLite")),
+		goTest("internal/isolation", "TestProtectedEnvironment")),
 }
 
 func TestBoundRegistryIsWellFormed(t *testing.T) {

--- a/internal/importer/live_test.go
+++ b/internal/importer/live_test.go
@@ -19,6 +19,18 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// writeKubeconfig writes a kubeconfig body to path (0600) and points the
+// KUBECONFIG environment variable at it for the duration of the test. The YAML
+// bodies themselves stay at the call sites: each live-import case exercises a
+// distinct kubeconfig shape, and only this write-and-point scaffold is shared.
+func writeKubeconfig(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KUBECONFIG", path)
+}
+
 func TestK8sLiveFixtureImportsSecretPages(t *testing.T) {
 	var requests int
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -63,10 +75,7 @@ users:
   user:
     token: fixture-token
 `, server.URL, contextName, contextName)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	result, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo"})
 	if err != nil {
@@ -130,10 +139,7 @@ users:
 - name: fixture-user
   user: {token: fixture-token}
 `, server.URL)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	_, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo"})
 	if err == nil {
@@ -202,10 +208,7 @@ users:
       - name: EXPECTED_CLUSTER
         value: %q
 `, wrong.URL, selected.URL, helper, selected.URL)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	result, err := RunLive(t.Context(), k8sSource,
 		LiveInput{Context: "selected", Namespace: "demo", Name: "app"})
@@ -256,10 +259,7 @@ users:
       - -c
       - 'if env | grep -q "^HIKYO_"; then exit 71; fi; printf %%s "$KUBERNETES_EXEC_INFO" | grep -q ''"interactive":false'' || exit 72; printf ''{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","status":{"token":"exec-fixture-token"}}'''
 `, server.URL)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 	t.Setenv("HIKYO_TOKEN", "hikyo_token_must_not_reach_exec_plugin")
 
 	result, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo", Name: "app"})
@@ -333,10 +333,7 @@ users:
       command: /bin/sh
       args: [-c, %q]
 `, "touch "+marker)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 	_, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo", Name: "app"})
 	wantCode(t, err, CodeProvenance, marker)
 	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
@@ -375,10 +372,7 @@ users:
       command: /bin/sh
       args: [-c, %q]
 `, server.URL, "touch "+marker+"; exit 72")
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	if _, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo", Name: "app"}); err != nil {
 		t.Fatal(err)
@@ -438,10 +432,7 @@ users:
       interactiveMode: Never
       command: %q
 `, server.URL, helper)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	result, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo", Name: "app"})
 	if err != nil {
@@ -510,10 +501,7 @@ users:
       interactiveMode: Never
       command: %q
 `, server.URL, helper)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	result, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo"})
 	if err != nil {
@@ -545,10 +533,7 @@ users:
       apiVersion: client.authentication.k8s.io/v1
       command: /bin/true
 `
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 	_, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo", Name: "app"})
 	if err == nil {
 		t.Fatal("v1 exec credential without interactiveMode was accepted")
@@ -581,10 +566,7 @@ users:
       command: /bin/sh
       args: [-c, "sleep 1"]
 `, server.URL)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	_, err := RunLive(ctx, k8sSource, LiveInput{Namespace: "demo"})
@@ -614,10 +596,7 @@ users:
       command: /bin/sh
       args: [-c, "while :; do printf 0123456789; done"]
 `
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 	_, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo"})
 	wantCode(t, err, CodeBound)
 	if !strings.Contains(err.Error(), "response exceeds") {
@@ -646,10 +625,7 @@ users:
 - name: fixture-user
   user: {token: fixture-token}
 `, server.URL)
-	if err := os.WriteFile(kubeconfig, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("KUBECONFIG", kubeconfig)
+	writeKubeconfig(t, kubeconfig, config)
 
 	_, err := RunLive(t.Context(), k8sSource, LiveInput{Namespace: "demo", Name: "app"})
 	if err == nil {

--- a/internal/isolation/access_wire_test.go
+++ b/internal/isolation/access_wire_test.go
@@ -161,19 +161,12 @@ func (e accessWireEnv) callAs(t *testing.T, token, method, path string, body any
 	return resp.StatusCode, out
 }
 
-func TestAccessWireUniformitySQLite(t *testing.T) {
-	runAccessWireUniformity(t, seededDB(t, openSQLite))
-}
-func TestAccessWireUniformityPostgres(t *testing.T) {
-	runAccessWireUniformity(t, seededDB(t, openPostgres))
+func TestAccessWireUniformity(t *testing.T) {
+	forEngines(t, runAccessWireUniformity)
 }
 
-func TestSessionClockResolutionReuseSQLite(t *testing.T) {
-	runSessionClockResolutionReuse(t, seededDB(t, openSQLite))
-}
-
-func TestSessionClockResolutionReusePostgres(t *testing.T) {
-	runSessionClockResolutionReuse(t, seededDB(t, openPostgres))
+func TestSessionClockResolutionReuse(t *testing.T) {
+	forEngines(t, runSessionClockResolutionReuse)
 }
 
 // runSessionClockResolutionReuse pins the HTTP seam #512 changes: the
@@ -419,11 +412,8 @@ func runAccessWireUniformity(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestAccessWireQueryTraceSQLite(t *testing.T) {
-	runAccessWireQueryTrace(t, seededDB(t, openSQLite))
-}
-func TestAccessWireQueryTracePostgres(t *testing.T) {
-	runAccessWireQueryTrace(t, seededDB(t, openPostgres))
+func TestAccessWireQueryTrace(t *testing.T) {
+	forEngines(t, runAccessWireQueryTrace)
 }
 
 // runAccessWireQueryTrace is the STRUCTURAL timing control for the new
@@ -536,11 +526,8 @@ func stripMemberManagement(t *testing.T, db *store.DB, p domain.PrincipalID) {
 	execRaw(t, db, `DELETE FROM grants WHERE principal_id = '`+string(p)+`' AND capability = 'manage-members'`)
 }
 
-func TestProjectListingDoesNotReadSiblingsSQLite(t *testing.T) {
-	runProjectListingDoesNotReadSiblings(t, seededDB(t, openSQLite))
-}
-func TestProjectListingDoesNotReadSiblingsPostgres(t *testing.T) {
-	runProjectListingDoesNotReadSiblings(t, seededDB(t, openPostgres))
+func TestProjectListingDoesNotReadSiblings(t *testing.T) {
+	forEngines(t, runProjectListingDoesNotReadSiblings)
 }
 
 // runProjectListingDoesNotReadSiblings catches the overfetch directly: a

--- a/internal/isolation/adapter_multi_target_e2e_test.go
+++ b/internal/isolation/adapter_multi_target_e2e_test.go
@@ -380,10 +380,6 @@ func runMultiTargetSync(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestAdapterMultiTargetSyncSQLite(t *testing.T) {
-	runMultiTargetSync(t, seededDB(t, openSQLite))
-}
-
-func TestAdapterMultiTargetSyncPostgres(t *testing.T) {
-	runMultiTargetSync(t, seededDB(t, openPostgres))
+func TestAdapterMultiTargetSync(t *testing.T) {
+	forEngines(t, runMultiTargetSync)
 }

--- a/internal/isolation/approvals_e2e_test.go
+++ b/internal/isolation/approvals_e2e_test.go
@@ -488,12 +488,8 @@ func runApprovalEdges(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestApprovalEdgesSQLite(t *testing.T) {
-	runApprovalEdges(t, seededDB(t, openSQLite))
-}
-
-func TestApprovalEdgesPostgres(t *testing.T) {
-	runApprovalEdges(t, seededDB(t, openPostgres))
+func TestApprovalEdges(t *testing.T) {
+	forEngines(t, runApprovalEdges)
 }
 
 // runProtectedApprovalBypass proves a protected bypass spends only its bound
@@ -545,12 +541,8 @@ func runProtectedApprovalBypass(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestProtectedApprovalBypassSQLite(t *testing.T) {
-	runProtectedApprovalBypass(t, seededDB(t, openSQLite))
-}
-
-func TestProtectedApprovalBypassPostgres(t *testing.T) {
-	runProtectedApprovalBypass(t, seededDB(t, openPostgres))
+func TestProtectedApprovalBypass(t *testing.T) {
+	forEngines(t, runProtectedApprovalBypass)
 }
 
 // policyIDForEnv returns the current env policy's id via the admin surface.
@@ -618,12 +610,8 @@ func mintReauthedSession(t *testing.T, db *store.DB, principal domain.PrincipalI
 // TestApprovalsLifecycle runs the whole engine end to end. It is the acceptance
 // driver; the audit suite calls runApprovalLifecycle again for the emitter
 // obligation.
-func TestApprovalsLifecycleSQLite(t *testing.T) {
-	runApprovalLifecycle(t, seededDB(t, openSQLite))
-}
-
-func TestApprovalsLifecyclePostgres(t *testing.T) {
-	runApprovalLifecycle(t, seededDB(t, openPostgres))
+func TestApprovalsLifecycle(t *testing.T) {
+	forEngines(t, runApprovalLifecycle)
 }
 
 func runConcurrentApprovalVotes(t *testing.T, db *store.DB) {
@@ -702,12 +690,8 @@ func runConcurrentApprovalVotes(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestConcurrentApprovalVotesSQLite(t *testing.T) {
-	runConcurrentApprovalVotes(t, seededDB(t, openSQLite))
-}
-
-func TestConcurrentApprovalVotesSharedPostgres(t *testing.T) {
-	runConcurrentApprovalVotes(t, seededDB(t, openPostgres))
+func TestConcurrentApprovalVotes(t *testing.T) {
+	forEngines(t, runConcurrentApprovalVotes)
 }
 
 func runApprovalExpiryBatches(t *testing.T, db *store.DB) {
@@ -762,10 +746,6 @@ func runApprovalExpiryBatches(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestApprovalExpiryBatchesSQLite(t *testing.T) {
-	runApprovalExpiryBatches(t, seededDB(t, openSQLite))
-}
-
-func TestApprovalExpiryBatchesPostgres(t *testing.T) {
-	runApprovalExpiryBatches(t, seededDB(t, openPostgres))
+func TestApprovalExpiryBatches(t *testing.T) {
+	forEngines(t, runApprovalExpiryBatches)
 }

--- a/internal/isolation/artifact_admission_wire_test.go
+++ b/internal/isolation/artifact_admission_wire_test.go
@@ -11,12 +11,8 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestArtifactClassAdmissionWireSQLite(t *testing.T) {
-	runArtifactClassAdmissionWire(t, seededDB(t, openSQLite))
-}
-
-func TestArtifactClassAdmissionWirePostgres(t *testing.T) {
-	runArtifactClassAdmissionWire(t, seededDB(t, openPostgres))
+func TestArtifactClassAdmissionWire(t *testing.T) {
+	forEngines(t, runArtifactClassAdmissionWire)
 }
 
 func runArtifactClassAdmissionWire(t *testing.T, db *store.DB) {

--- a/internal/isolation/audit_e2e_test.go
+++ b/internal/isolation/audit_e2e_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -685,12 +684,8 @@ func runAuditSuite(t *testing.T, db *store.DB) {
 	})
 }
 
-func TestAuditCoreSQLite(t *testing.T) {
-	runAuditSuite(t, seededDB(t, openSQLite))
-}
-
-func TestAuditCorePostgres(t *testing.T) {
-	runAuditSuite(t, seededDB(t, openPostgres))
+func TestAuditCore(t *testing.T) {
+	forEngines(t, runAuditSuite)
 }
 
 // TestPostgresAuditExportCommitOrder is #84's regression: sequence allocation
@@ -929,13 +924,7 @@ type exportLineForTest struct {
 // boot. (The fsync leg needs a server restart and is unit-tested through
 // the querier seam in internal/store.)
 func TestPostgresDurabilityBootRefusal(t *testing.T) {
-	dsn := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
-	if dsn == "" {
-		if os.Getenv("CI") != "" {
-			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres durability leg must not silently skip in CI")
-		}
-		t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
-	}
+	dsn := postgresTestDSN(t)
 	derived := derivedDatabase(t, dsn, "_durability")
 	u, err := url.Parse(derived)
 	if err != nil {

--- a/internal/isolation/backup_drill_e2e_test.go
+++ b/internal/isolation/backup_drill_e2e_test.go
@@ -149,14 +149,7 @@ func sqliteTarget(t *testing.T, backupDir, recipient string) drillTarget {
 
 func postgresTarget(t *testing.T, backupDir, recipient string) drillTarget {
 	t.Helper()
-	base := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
-	if base == "" {
-		if os.Getenv("CI") != "" {
-			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres backup drill must not silently skip in CI")
-		}
-		t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
-	}
-	dsn := derivedDatabase(t, base, "_drill")
+	dsn := derivedDatabase(t, postgresTestDSN(t), "_drill")
 	drop := func(t *testing.T) {
 		t.Helper()
 		db, err := store.Open(t.Context(), store.Config{Engine: store.EnginePostgres, DSN: dsn})

--- a/internal/isolation/browser_session_e2e_test.go
+++ b/internal/isolation/browser_session_e2e_test.go
@@ -22,12 +22,8 @@ import (
 // that `VerifyBrowserCSRF` actually consults that verifier rather than
 // believing whatever the caller presented.
 
-func TestBrowserLoginMintsACSRFBoundSessionSQLite(t *testing.T) {
-	runBrowserSessionFlow(t, seededDB(t, openSQLite))
-}
-
-func TestBrowserLoginMintsACSRFBoundSessionPostgres(t *testing.T) {
-	runBrowserSessionFlow(t, seededDB(t, openPostgres))
+func TestBrowserLoginMintsACSRFBoundSession(t *testing.T) {
+	forEngines(t, runBrowserSessionFlow)
 }
 
 func runBrowserSessionFlow(t *testing.T, db *store.DB) {
@@ -133,12 +129,8 @@ func TestUnknownLoginArtifactIsRefusedBeforeVerification(t *testing.T) {
 // The transport half is asserted in internal/server; what needs a datastore is
 // that the SERVICE mints the right grammar, the right clocks and a live CSRF
 // verifier on each of these paths.
-func TestAccountSecurityMutationsPreserveTheBrowserArtifactSQLite(t *testing.T) {
-	runBrowserMutationFlow(t, seededDB(t, openSQLite))
-}
-
-func TestAccountSecurityMutationsPreserveTheBrowserArtifactPostgres(t *testing.T) {
-	runBrowserMutationFlow(t, seededDB(t, openPostgres))
+func TestAccountSecurityMutationsPreserveTheBrowserArtifact(t *testing.T) {
+	forEngines(t, runBrowserMutationFlow)
 }
 
 // browserSessionCheck returns the assertion every reissued browser session
@@ -235,12 +227,8 @@ func runBrowserMutationFlow(t *testing.T, db *store.DB) {
 // this ticket. The existing OIDC lifecycle tests drive them with a CLI session,
 // so a regression there would be invisible — these drive the same two
 // operations from a browser session and assert the artifact survives.
-func TestBrowserFederationPreservesTheArtifactSQLite(t *testing.T) {
-	runBrowserFederationFlow(t, seededDB(t, openSQLite))
-}
-
-func TestBrowserFederationPreservesTheArtifactPostgres(t *testing.T) {
-	runBrowserFederationFlow(t, seededDB(t, openPostgres))
+func TestBrowserFederationPreservesTheArtifact(t *testing.T) {
+	forEngines(t, runBrowserFederationFlow)
 }
 
 func runBrowserFederationFlow(t *testing.T, db *store.DB) {
@@ -293,12 +281,8 @@ func runBrowserFederationFlow(t *testing.T, db *store.DB) {
 // `instance-config` — MFA-mandatory, correct for an operator, absurd in front
 // of a sidebar. So the properties that matter are: a member sees their own
 // orgs, sees nobody else's, and reaches it with an ordinary password session.
-func TestListMineProjectsOnlyTheCallersOwnOrgsSQLite(t *testing.T) {
-	runListMineProjection(t, seededDB(t, openSQLite))
-}
-
-func TestListMineProjectsOnlyTheCallersOwnOrgsPostgres(t *testing.T) {
-	runListMineProjection(t, seededDB(t, openPostgres))
+func TestListMineProjectsOnlyTheCallersOwnOrgs(t *testing.T) {
+	forEngines(t, runListMineProjection)
 }
 
 func runListMineProjection(t *testing.T, db *store.DB) {
@@ -348,12 +332,8 @@ func runListMineProjection(t *testing.T, db *store.DB) {
 // The rail's real caller: an ordinary password session, no second factor. The
 // projection above is exercised through LocalPrincipal; this proves the same
 // answer arrives over a browser session that could not pass `org.list`.
-func TestListMineNeedsNoSecondFactorSQLite(t *testing.T) {
-	runListMineFromABrowserSession(t, seededDB(t, openSQLite))
-}
-
-func TestListMineNeedsNoSecondFactorPostgres(t *testing.T) {
-	runListMineFromABrowserSession(t, seededDB(t, openPostgres))
+func TestListMineNeedsNoSecondFactor(t *testing.T) {
+	forEngines(t, runListMineFromABrowserSession)
 }
 
 func runListMineFromABrowserSession(t *testing.T, db *store.DB) {

--- a/internal/isolation/compose_cli_e2e_test.go
+++ b/internal/isolation/compose_cli_e2e_test.go
@@ -268,7 +268,7 @@ func runComposeCLIDelivery(t *testing.T, engine store.Engine) {
 	}
 }
 
-func TestComposeCLIRenderAndDoctorSQLite(t *testing.T) {
+func TestComposeCLIRenderAndDoctor(t *testing.T) {
 	runComposeCLIRenderAndDoctor(t, store.EngineSQLite)
 }
 
@@ -351,7 +351,7 @@ func runComposeCLIRenderAndDoctor(t *testing.T, engine store.Engine) {
 	assertNoPlaintextUnder(t, work, "postgres://dev")
 }
 
-func TestComposeCLISyncBlastRadiusSQLite(t *testing.T) {
+func TestComposeCLISyncBlastRadius(t *testing.T) {
 	rig := bootComposeRig(t, store.EngineSQLite)
 	_, tokenFile := rig.mintWorkload(t)
 	work := t.TempDir()
@@ -404,7 +404,7 @@ func TestComposeCLISyncBlastRadiusSQLite(t *testing.T) {
 // docker up — the env_file vanished with the tmpfs and the stack is running
 // against nothing (R1-10). `docker compose up -d` is idempotent on an unchanged
 // config hash, so a needless up is harmless; a skipped one is a broken stack.
-func TestComposeCLISyncRematerializesWipedRuntimeSQLite(t *testing.T) {
+func TestComposeCLISyncRematerializesWipedRuntime(t *testing.T) {
 	rig := bootComposeRig(t, store.EngineSQLite)
 	_, tokenFile := rig.mintWorkload(t)
 	work := t.TempDir()
@@ -439,7 +439,7 @@ func TestComposeCLISyncRematerializesWipedRuntimeSQLite(t *testing.T) {
 // TestComposeCLISyncApplyPendingRetry: a sync whose `docker compose up -d` FAILS
 // leaves an apply-pending marker, so the NEXT sync — even with nothing to move —
 // retries the apply and, on success, clears the marker (finding 10).
-func TestComposeCLISyncApplyPendingRetrySQLite(t *testing.T) {
+func TestComposeCLISyncApplyPendingRetry(t *testing.T) {
 	rig := bootComposeRig(t, store.EngineSQLite)
 	_, tokenFile := rig.mintWorkload(t)
 	work := t.TempDir()
@@ -477,7 +477,7 @@ func TestComposeCLISyncApplyPendingRetrySQLite(t *testing.T) {
 	}
 }
 
-func TestComposeCLIReconcileSQLite(t *testing.T) {
+func TestComposeCLIReconcile(t *testing.T) {
 	rig := bootComposeRig(t, store.EngineSQLite)
 	_, tokenFile := rig.mintWorkload(t)
 	work := t.TempDir()

--- a/internal/isolation/definitions_e2e_test.go
+++ b/internal/isolation/definitions_e2e_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestDefinitionsSQLite(t *testing.T) { runDefinitions(t, seededDB(t, openSQLite)) }
-
-func TestDefinitionsPostgres(t *testing.T) { runDefinitions(t, seededDB(t, openPostgres)) }
+func TestDefinitions(t *testing.T) {
+	forEngines(t, runDefinitions)
+}
 
 func runDefinitions(t *testing.T, db *store.DB) {
 	t.Run("export plan apply round trip", func(t *testing.T) { definitionsRoundTrip(t, db) })

--- a/internal/isolation/delivery_e2e_test.go
+++ b/internal/isolation/delivery_e2e_test.go
@@ -27,12 +27,8 @@ import (
 // held — because a test that changed two at once would pass even if the
 // implementation ignored one of them.
 
-func TestDeliveryCursorRoundTripSQLite(t *testing.T) {
-	runDeliveryCursorRoundTrip(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryCursorRoundTripPostgres(t *testing.T) {
-	runDeliveryCursorRoundTrip(t, seededDB(t, openPostgres))
+func TestDeliveryCursorRoundTrip(t *testing.T) {
+	forEngines(t, runDeliveryCursorRoundTrip)
 }
 
 // runDeliveryCursorRoundTrip is the base behaviour: a first fetch delivers, its
@@ -142,12 +138,8 @@ func runDeliveryCursorRoundTrip(t *testing.T, db *store.DB) {
 	// config-only and emits identity.disclosure per delivered value.
 }
 
-func TestOfflineRecordReconciliationSQLite(t *testing.T) {
-	runOfflineRecordReconciliation(t, seededDB(t, openSQLite))
-}
-
-func TestOfflineRecordReconciliationPostgres(t *testing.T) {
-	runOfflineRecordReconciliation(t, seededDB(t, openPostgres))
+func TestOfflineRecordReconciliation(t *testing.T) {
+	forEngines(t, runOfflineRecordReconciliation)
 }
 
 func runOfflineRecordReconciliation(t *testing.T, db *store.DB) {
@@ -198,12 +190,8 @@ func runOfflineRecordReconciliation(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryCursorFalsificationSQLite(t *testing.T) {
-	runDeliveryCursorFalsification(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryCursorFalsificationPostgres(t *testing.T) {
-	runDeliveryCursorFalsification(t, seededDB(t, openPostgres))
+func TestDeliveryCursorFalsification(t *testing.T) {
+	forEngines(t, runDeliveryCursorFalsification)
 }
 
 // runDeliveryCursorFalsification falsifies EACH cursor component
@@ -344,12 +332,8 @@ func runDeliveryCursorFalsification(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryAuthorizationMovementInvalidatesCursorSQLite(t *testing.T) {
-	runAuthorizationMovementInvalidatesCursor(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryAuthorizationMovementInvalidatesCursorPostgres(t *testing.T) {
-	runAuthorizationMovementInvalidatesCursor(t, seededDB(t, openPostgres))
+func TestDeliveryAuthorizationMovementInvalidatesCursor(t *testing.T) {
+	forEngines(t, runAuthorizationMovementInvalidatesCursor)
 }
 
 // runAuthorizationMovementInvalidatesCursor is the same rule from the other
@@ -430,12 +414,8 @@ func runAuthorizationMovementInvalidatesCursor(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryUnauthorizedIsIndistinguishableSQLite(t *testing.T) {
-	runDeliveryUnauthorized(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryUnauthorizedIsIndistinguishablePostgres(t *testing.T) {
-	runDeliveryUnauthorized(t, seededDB(t, openPostgres))
+func TestDeliveryUnauthorizedIsIndistinguishable(t *testing.T) {
+	forEngines(t, runDeliveryUnauthorized)
 }
 
 // runDeliveryUnauthorized is the ADR's "authorization is evaluated on the
@@ -502,7 +482,7 @@ func runDeliveryUnauthorized(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryChangeTokenTracksTheManifestSQLite(t *testing.T) {
+func TestDeliveryChangeTokenTracksTheManifest(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	identityFixtures(t, db)
 	seedDeliveryCatalogue(t, db)
@@ -655,12 +635,8 @@ func advancePinGeneration(t *testing.T, db *store.DB, p domain.PrincipalID, env 
 // Audit attribution). A fetch now delivers PLAINTEXT where the caller is
 // authorized, and records one disclosure per delivered value.
 
-func TestDeliveryDeliversValuesUnderAuthoritySQLite(t *testing.T) {
-	runDeliveryDeliversValues(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryDeliversValuesUnderAuthorityPostgres(t *testing.T) {
-	runDeliveryDeliversValues(t, seededDB(t, openPostgres))
+func TestDeliveryDeliversValuesUnderAuthority(t *testing.T) {
+	forEngines(t, runDeliveryDeliversValues)
 }
 
 // runDeliveryDeliversValues is the per-key value rule made empirical: a config
@@ -764,12 +740,8 @@ func runDeliveryDeliversValues(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryConfigOnlyProjectionSQLite(t *testing.T) {
-	runDeliveryConfigOnlyProjection(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryConfigOnlyProjectionPostgres(t *testing.T) {
-	runDeliveryConfigOnlyProjection(t, seededDB(t, openPostgres))
+func TestDeliveryConfigOnlyProjection(t *testing.T) {
+	forEngines(t, runDeliveryConfigOnlyProjection)
 }
 
 // runDeliveryConfigOnlyProjection pins the server-side authorized term:
@@ -834,12 +806,8 @@ func runDeliveryConfigOnlyProjection(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryAcknowledgedKeysAreRecordedSQLite(t *testing.T) {
-	runDeliveryAcknowledgedKeys(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryAcknowledgedKeysAreRecordedPostgres(t *testing.T) {
-	runDeliveryAcknowledgedKeys(t, seededDB(t, openPostgres))
+func TestDeliveryAcknowledgedKeysAreRecorded(t *testing.T) {
+	forEngines(t, runDeliveryAcknowledgedKeys)
 }
 
 // runDeliveryAcknowledgedKeys pins the loader-control acknowledgement's two
@@ -895,12 +863,8 @@ func runDeliveryAcknowledgedKeys(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryCredentialExpiryIsFiniteOrAbsentSQLite(t *testing.T) {
-	runDeliveryCredentialExpiry(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryCredentialExpiryIsFiniteOrAbsentPostgres(t *testing.T) {
-	runDeliveryCredentialExpiry(t, seededDB(t, openPostgres))
+func TestDeliveryCredentialExpiryIsFiniteOrAbsent(t *testing.T) {
+	forEngines(t, runDeliveryCredentialExpiry)
 }
 
 // runDeliveryCredentialExpiry pins the presenting credential's expiry surfacing:
@@ -972,12 +936,8 @@ func deliveredByName(keys []service.DeliveredKey) map[string]service.DeliveredKe
 	return out
 }
 
-func TestDeliveryPinnedNonCurrentRequiresRevealHistorySQLite(t *testing.T) {
-	runDeliveryPinnedNonCurrent(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryPinnedNonCurrentRequiresRevealHistoryPostgres(t *testing.T) {
-	runDeliveryPinnedNonCurrent(t, seededDB(t, openPostgres))
+func TestDeliveryPinnedNonCurrentRequiresRevealHistory(t *testing.T) {
+	forEngines(t, runDeliveryPinnedNonCurrent)
 }
 
 // runDeliveryPinnedNonCurrent pins the reveal-history branch of the value rule:
@@ -1072,12 +1032,8 @@ func runDeliveryPinnedNonCurrent(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestDeliveryPinnedCurrentBecomingHistoricalInvalidatesCursorSQLite(t *testing.T) {
-	runDeliveryPinnedCurrentBecomingHistorical(t, seededDB(t, openSQLite))
-}
-
-func TestDeliveryPinnedCurrentBecomingHistoricalInvalidatesCursorPostgres(t *testing.T) {
-	runDeliveryPinnedCurrentBecomingHistorical(t, seededDB(t, openPostgres))
+func TestDeliveryPinnedCurrentBecomingHistoricalInvalidatesCursor(t *testing.T) {
+	forEngines(t, runDeliveryPinnedCurrentBecomingHistorical)
 }
 
 // runDeliveryPinnedCurrentBecomingHistorical is the #64 P1: a pin that WAS

--- a/internal/isolation/demo_e2e_test.go
+++ b/internal/isolation/demo_e2e_test.go
@@ -31,9 +31,9 @@ import (
 // test process has no controlling terminal — which is itself the behaviour
 // the non-TTY refusals assert elsewhere.
 
-func TestDemoFlowSQLite(t *testing.T) { runDemoFlow(t, seededDB(t, openSQLite)) }
-
-func TestDemoFlowPostgres(t *testing.T) { runDemoFlow(t, seededDB(t, openPostgres)) }
+func TestDemoFlow(t *testing.T) {
+	forEngines(t, runDemoFlow)
+}
 
 func runDemoFlow(t *testing.T, db *store.DB) {
 	auth := authService(t, db)

--- a/internal/isolation/factors_e2e_test.go
+++ b/internal/isolation/factors_e2e_test.go
@@ -40,6 +40,33 @@ func totpCode(t *testing.T, otpauthURI string, at time.Time) string {
 	return code
 }
 
+// enrolTOTPAndStepUp runs the full first-factor ceremony for the "factor-admin"
+// account: log in over the CLI artifact, enrol TOTP, confirm it 30s later, and
+// step the session up 60s later. It advances the caller's clock (which auth.Now
+// closes over) through the ceremony and returns the stepped-up session token.
+func enrolTOTPAndStepUp(t *testing.T, auth *service.Auth, ctx context.Context, base time.Time, clk *time.Time, password string) string {
+	t.Helper()
+	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	uri, err := auth.EnrolTOTPStart(ctx, login.SessionToken, password)
+	if err != nil {
+		t.Fatalf("enrol start: %v", err)
+	}
+	*clk = base.Add(30 * time.Second)
+	confirmed, err := auth.EnrolTOTPConfirm(ctx, login.SessionToken, totpCode(t, uri, *clk))
+	if err != nil {
+		t.Fatalf("enrol confirm: %v", err)
+	}
+	*clk = base.Add(60 * time.Second)
+	stepped, err := auth.StepUpTOTP(ctx, confirmed.SessionToken, totpCode(t, uri, *clk))
+	if err != nil {
+		t.Fatalf("step-up: %v", err)
+	}
+	return stepped.SessionToken
+}
+
 // bootstrapFactorAdmin adds the environment read needed by factor
 // reauthentication flows to the shared first-administrator fixture. One Auth
 // (one root key) drives the whole flow so sealed material stays readable.
@@ -109,24 +136,16 @@ func runFactorLifecycle(t *testing.T, auth *service.Auth, ctx context.Context, u
 	}
 }
 
-func TestRecoveryCompleteFlowSQLite(t *testing.T) { runRecoveryFlow(t, seededDB(t, openSQLite)) }
-
-func TestRecoveryCompleteFlowPostgres(t *testing.T) { runRecoveryFlow(t, seededDB(t, openPostgres)) }
-
-func TestPasswordReauthEvidenceRejectsReplacedCredentialSQLite(t *testing.T) {
-	runPasswordReauthEvidenceRejectsReplacedCredential(t, seededDB(t, openSQLite))
+func TestRecoveryCompleteFlow(t *testing.T) {
+	forEngines(t, runRecoveryFlow)
 }
 
-func TestPasswordReauthEvidenceRejectsReplacedCredentialPostgres(t *testing.T) {
-	runPasswordReauthEvidenceRejectsReplacedCredential(t, seededDB(t, openPostgres))
+func TestPasswordReauthEvidenceRejectsReplacedCredential(t *testing.T) {
+	forEngines(t, runPasswordReauthEvidenceRejectsReplacedCredential)
 }
 
-func TestRecoveryCodeRegenerationTOTPReplaySQLite(t *testing.T) {
-	runRecoveryCodeRegenerationTOTPReplay(t, seededDB(t, openSQLite))
-}
-
-func TestRecoveryCodeRegenerationTOTPReplayPostgres(t *testing.T) {
-	runRecoveryCodeRegenerationTOTPReplay(t, seededDB(t, openPostgres))
+func TestRecoveryCodeRegenerationTOTPReplay(t *testing.T) {
+	forEngines(t, runRecoveryCodeRegenerationTOTPReplay)
 }
 
 func runPasswordReauthEvidenceRejectsReplacedCredential(t *testing.T, db *store.DB) {
@@ -264,12 +283,8 @@ func runRecoveryFlow(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestAccountSecurityCannotSelfAuthorizeSQLite(t *testing.T) {
-	runSelfAuthorize(t, seededDB(t, openSQLite))
-}
-
-func TestAccountSecurityCannotSelfAuthorizePostgres(t *testing.T) {
-	runSelfAuthorize(t, seededDB(t, openPostgres))
+func TestAccountSecurityCannotSelfAuthorize(t *testing.T) {
+	forEngines(t, runSelfAuthorize)
 }
 
 // runSelfAuthorize asserts an account-security mutation cannot authorize itself:
@@ -316,9 +331,9 @@ func runSelfAuthorize(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestStepUpElevatesSQLite(t *testing.T) { runStepUpElevates(t, seededDB(t, openSQLite)) }
-
-func TestStepUpElevatesPostgres(t *testing.T) { runStepUpElevates(t, seededDB(t, openPostgres)) }
+func TestStepUpElevates(t *testing.T) {
+	forEngines(t, runStepUpElevates)
+}
 
 // runStepUpElevates asserts a password-only session is refused an MFA-mandatory
 // operation and that a TOTP step-up unlocks it.
@@ -364,12 +379,8 @@ func runStepUpElevates(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestTOTPConfirmSameStepSQLite(t *testing.T) {
-	runConfirmSameStep(t, seededDB(t, openSQLite))
-}
-
-func TestTOTPConfirmSameStepPostgres(t *testing.T) {
-	runConfirmSameStep(t, seededDB(t, openPostgres))
+func TestTOTPConfirmSameStep(t *testing.T) {
+	forEngines(t, runConfirmSameStep)
 }
 
 // runConfirmSameStep asserts the code shown in the SAME time step as enrolment
@@ -408,12 +419,8 @@ func runConfirmSameStep(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestTOTPStepUpReplaySQLite(t *testing.T) {
-	runStepUpReplay(t, seededDB(t, openSQLite))
-}
-
-func TestTOTPStepUpReplayPostgres(t *testing.T) {
-	runStepUpReplay(t, seededDB(t, openPostgres))
+func TestTOTPStepUpReplay(t *testing.T) {
+	forEngines(t, runStepUpReplay)
 }
 
 // runStepUpReplay asserts single-use per (account, step): a code that stepped a

--- a/internal/isolation/federation_e2e_test.go
+++ b/internal/isolation/federation_e2e_test.go
@@ -288,12 +288,8 @@ func pinsOf(t *testing.T, s oidctest.Shape) []service.ClaimPin {
 // default must be refused.
 const hikyoAudience = "hikyo://instance"
 
-func TestFederationAgainstEachIssuerTypeSQLite(t *testing.T) {
-	runFederationPerIssuerType(t, seededDB(t, openSQLite))
-}
-
-func TestFederationAgainstEachIssuerTypePostgres(t *testing.T) {
-	runFederationPerIssuerType(t, seededDB(t, openPostgres))
+func TestFederationAgainstEachIssuerType(t *testing.T) {
+	forEngines(t, runFederationPerIssuerType)
 }
 
 // runFederationPerIssuerType is mvp-boundary M1's "[E2E] federation against a
@@ -454,12 +450,8 @@ func engineOpener(db *store.DB) func(*testing.T) *store.DB {
 	return openSQLite
 }
 
-func TestFederationRefusesPullRequestEventsSQLite(t *testing.T) {
-	runPullRequestRefusal(t, seededDB(t, openSQLite))
-}
-
-func TestFederationRefusesPullRequestEventsPostgres(t *testing.T) {
-	runPullRequestRefusal(t, seededDB(t, openPostgres))
+func TestFederationRefusesPullRequestEvents(t *testing.T) {
+	forEngines(t, runPullRequestRefusal)
 }
 
 // runPullRequestRefusal is mvp-boundary M1's "`pull_request` /
@@ -552,12 +544,8 @@ func runPullRequestRefusal(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationJWKSStalenessBoundSQLite(t *testing.T) {
-	runJWKSStalenessBound(t, seededDB(t, openSQLite))
-}
-
-func TestFederationJWKSStalenessBoundPostgres(t *testing.T) {
-	runJWKSStalenessBound(t, seededDB(t, openPostgres))
+func TestFederationJWKSStalenessBound(t *testing.T) {
+	forEngines(t, runJWKSStalenessBound)
 }
 
 // runJWKSStalenessBound is mvp-boundary M1's "JWKS staleness bound under induced
@@ -638,7 +626,7 @@ func runJWKSStalenessBound(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationUnknownKIDRefreshIsRateLimitedSQLite(t *testing.T) {
+func TestFederationUnknownKIDRefreshIsRateLimited(t *testing.T) {
 	runUnknownKIDRateLimit(t, seededDB(t, openSQLite))
 }
 
@@ -709,12 +697,8 @@ func runUnknownKIDRateLimit(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationStaticJWKSSQLite(t *testing.T) {
-	runFederationStaticJWKS(t, seededDB(t, openSQLite))
-}
-
-func TestFederationStaticJWKSPostgres(t *testing.T) {
-	runFederationStaticJWKS(t, seededDB(t, openPostgres))
+func TestFederationStaticJWKS(t *testing.T) {
+	forEngines(t, runFederationStaticJWKS)
 }
 
 func runFederationStaticJWKS(t *testing.T, db *store.DB) {
@@ -762,12 +746,8 @@ func runFederationStaticJWKS(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationKeySourceRoundTripSQLite(t *testing.T) {
-	runFederationKeySourceRoundTrip(t, seededDB(t, openSQLite))
-}
-
-func TestFederationKeySourceRoundTripPostgres(t *testing.T) {
-	runFederationKeySourceRoundTrip(t, seededDB(t, openPostgres))
+func TestFederationKeySourceRoundTrip(t *testing.T) {
+	forEngines(t, runFederationKeySourceRoundTrip)
 }
 
 func runFederationKeySourceRoundTrip(t *testing.T, db *store.DB) {
@@ -828,12 +808,8 @@ func runFederationKeySourceRoundTrip(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationRestorePredicateSQLite(t *testing.T) {
-	runRestorePredicate(t, seededDB(t, openSQLite))
-}
-
-func TestFederationRestorePredicatePostgres(t *testing.T) {
-	runRestorePredicate(t, seededDB(t, openPostgres))
+func TestFederationRestorePredicate(t *testing.T) {
+	forEngines(t, runRestorePredicate)
 }
 
 // runRestorePredicate is the ADR's § Restore `iat` rule: a token presented
@@ -967,7 +943,7 @@ func runRestorePredicate(t *testing.T, db *store.DB) {
 // The hole it closes: a binding pinning only `event_name=push` was accepted, so
 // renaming `acme/prod` and letting someone else claim the path produced the same
 // subject and inherited the Hikyo principal.
-func TestFederationRequiresImmutableIdentifiersSQLite(t *testing.T) {
+func TestFederationRequiresImmutableIdentifiers(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 	github := oidctest.GitHubActionsShape("acme/service", 4242, 77, "refs/heads/main", "push")
@@ -1038,7 +1014,7 @@ func TestFederationRequiresImmutableIdentifiersSQLite(t *testing.T) {
 // `/kubernetes.io/serviceaccount/uid` and NOWHERE else. Without JSON-Pointer pins
 // the ADR's requirement is unsatisfiable against a real token and the only
 // writable bindings are the name-based ones it forbids.
-func TestFederationPinsNestedKubernetesUIDSQLite(t *testing.T) {
+func TestFederationPinsNestedKubernetesUID(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 	shape := oidctest.KubernetesShape("prod", "deployer", "9f2c-uid", "https://kubernetes.default.svc")
@@ -1109,7 +1085,7 @@ func TestFederationPinsNestedKubernetesUIDSQLite(t *testing.T) {
 // `iss`/`sub`/audience/claims authenticate. Both halves are covered — the scheme
 // check on the document-supplied `jwks_uri`, and the redirect policy, because a
 // scheme check alone is defeated by an HTTPS url that 302s to `http://`.
-func TestFederationRefusesPlaintextJWKSSQLite(t *testing.T) {
+func TestFederationRefusesPlaintextJWKS(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 	shape := oidctest.KubernetesShape("prod", "plain", "uid-p", "https://kubernetes.default.svc")
@@ -1170,7 +1146,7 @@ func TestFederationRefusesPlaintextJWKSSQLite(t *testing.T) {
 // a dead issuer must not block validation for a HEALTHY one (per-issuer locking,
 // not one process-wide mutex held across the network call); and the outbound
 // fetch count must stay bounded however many requests arrive.
-func TestFederationOutageDoesNotSerializeIssuersSQLite(t *testing.T) {
+func TestFederationOutageDoesNotSerializeIssuers(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 
@@ -1316,7 +1292,7 @@ func multiCAClient(idps ...*oidctest.IdP) *http.Client {
 // Without it, an administrator who adds a refused audience while a slow
 // verification is in flight has that request complete under the superseded
 // policy — after the update committed.
-func TestFederationIssuerPolicyCannotGoStaleSQLite(t *testing.T) {
+func TestFederationIssuerPolicyCannotGoStale(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 	shape := oidctest.KubernetesShape("prod", "racer", "uid-r", "https://kubernetes.default.svc")
@@ -1355,12 +1331,8 @@ func TestFederationIssuerPolicyCannotGoStaleSQLite(t *testing.T) {
 	}
 }
 
-func TestFederationBindingImmutabilitySQLite(t *testing.T) {
-	runBindingImmutability(t, seededDB(t, openSQLite))
-}
-
-func TestFederationBindingImmutabilityPostgres(t *testing.T) {
-	runBindingImmutability(t, seededDB(t, openPostgres))
+func TestFederationBindingImmutability(t *testing.T) {
+	forEngines(t, runBindingImmutability)
 }
 
 // runBindingImmutability rides both engines because its subject IS storage
@@ -1432,7 +1404,7 @@ func runBindingImmutability(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationClaimTypeIsNotFoldedSQLite(t *testing.T) {
+func TestFederationClaimTypeIsNotFolded(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 	shape := oidctest.GitHubActionsShape("acme/service", 4242, 77, "refs/heads/main", "push")
@@ -1476,7 +1448,7 @@ func TestFederationClaimTypeIsNotFoldedSQLite(t *testing.T) {
 	}
 }
 
-func TestFederationTokenCapsSQLite(t *testing.T) {
+func TestFederationTokenCaps(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	r := newFedRig(t, db)
 	shape := oidctest.KubernetesShape("prod", "capped", "uid-c", "https://kubernetes.default.svc")
@@ -1526,12 +1498,8 @@ func TestFederationTokenCapsSQLite(t *testing.T) {
 	}
 }
 
-func TestFederationTokenAgeCannotExpireMidFlightSQLite(t *testing.T) {
-	runFederationTokenAgeCannotExpireMidFlight(t, seededDB(t, openSQLite))
-}
-
-func TestFederationTokenAgeCannotExpireMidFlightPostgres(t *testing.T) {
-	runFederationTokenAgeCannotExpireMidFlight(t, seededDB(t, openPostgres))
+func TestFederationTokenAgeCannotExpireMidFlight(t *testing.T) {
+	forEngines(t, runFederationTokenAgeCannotExpireMidFlight)
 }
 
 // runFederationTokenAgeCannotExpireMidFlight proves the authoritative,
@@ -1570,12 +1538,8 @@ func runFederationTokenAgeCannotExpireMidFlight(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestFederationIssuerDeleteGuardSQLite(t *testing.T) {
-	runIssuerDeleteGuard(t, seededDB(t, openSQLite))
-}
-
-func TestFederationIssuerDeleteGuardPostgres(t *testing.T) {
-	runIssuerDeleteGuard(t, seededDB(t, openPostgres))
+func TestFederationIssuerDeleteGuard(t *testing.T) {
+	forEngines(t, runIssuerDeleteGuard)
 }
 
 // runIssuerDeleteGuard rides both engines because the guard it tests is half
@@ -1693,12 +1657,8 @@ func runFederationLifecycle(t *testing.T, db *store.DB) {
 	r.idp.SetOffline(false)
 }
 
-func TestFederationBindingIsListedWithItsIdentitySQLite(t *testing.T) {
-	runBindingListedWithIdentity(t, seededDB(t, openSQLite))
-}
-
-func TestFederationBindingIsListedWithItsIdentityPostgres(t *testing.T) {
-	runBindingListedWithIdentity(t, seededDB(t, openPostgres))
+func TestFederationBindingIsListedWithItsIdentity(t *testing.T) {
+	forEngines(t, runBindingListedWithIdentity)
 }
 
 // runBindingListedWithIdentity pins what the credential LISTING carries for a

--- a/internal/isolation/formula_matrix_test.go
+++ b/internal/isolation/formula_matrix_test.go
@@ -147,8 +147,9 @@ func planMatrix(
 	return plans, problems
 }
 
-func TestFormulaMatrixSQLite(t *testing.T)   { runFormulaMatrix(t, seededDB(t, openSQLite)) }
-func TestFormulaMatrixPostgres(t *testing.T) { runFormulaMatrix(t, seededDB(t, openPostgres)) }
+func TestFormulaMatrix(t *testing.T) {
+	forEngines(t, runFormulaMatrix)
+}
 
 // runFormulaMatrix executes the generated matrix against a real datastore
 // through the real chokepoint. It is E2E in the sense that matters for A2: the
@@ -313,11 +314,8 @@ func TestMatrixCoversEveryProofMintingOperation(t *testing.T) {
 // the chokepoint: a principal authorized a moment ago is refused on the very
 // next call once the grant row is gone, with no invalidation step anywhere —
 // because there is nothing to invalidate.
-func TestRevocationIsImmediateSQLite(t *testing.T) {
-	runRevocationIsImmediate(t, seededDB(t, openSQLite))
-}
-func TestRevocationIsImmediatePostgres(t *testing.T) {
-	runRevocationIsImmediate(t, seededDB(t, openPostgres))
+func TestRevocationIsImmediate(t *testing.T) {
+	forEngines(t, runRevocationIsImmediate)
 }
 
 func runRevocationIsImmediate(t *testing.T, db *store.DB) {

--- a/internal/isolation/grants_e2e_test.go
+++ b/internal/isolation/grants_e2e_test.go
@@ -84,8 +84,9 @@ func originCount(t *testing.T, db *store.DB, p domain.PrincipalID, c domain.Capa
 	return n
 }
 
-func TestGrantAuthoritySQLite(t *testing.T)   { runGrantAuthority(t, seededDB(t, openSQLite)) }
-func TestGrantAuthorityPostgres(t *testing.T) { runGrantAuthority(t, seededDB(t, openPostgres)) }
+func TestGrantAuthority(t *testing.T) {
+	forEngines(t, runGrantAuthority)
+}
 
 // runGrantAuthority: `manage-members` at ORG scope may grant a capability the
 // grantor does not hold; the same capability at PROJECT scope may not. This is
@@ -120,8 +121,9 @@ func runGrantAuthority(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestGrantPerOrgCapSQLite(t *testing.T)   { runGrantPerOrgCap(t, seededDB(t, openSQLite)) }
-func TestGrantPerOrgCapPostgres(t *testing.T) { runGrantPerOrgCap(t, seededDB(t, openPostgres)) }
+func TestGrantPerOrgCap(t *testing.T) {
+	forEngines(t, runGrantPerOrgCap)
+}
 
 // runGrantPerOrgCap: the ops-spec § 8 loud sanity cap. Once an org holds
 // MaxGrantsPerOrg grant rows, a new grant is refused by name — the cap exists
@@ -153,8 +155,9 @@ func runGrantPerOrgCap(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestGrantDedupSQLite(t *testing.T)   { runGrantDedup(t, seededDB(t, openSQLite)) }
-func TestGrantDedupPostgres(t *testing.T) { runGrantDedup(t, seededDB(t, openPostgres)) }
+func TestGrantDedup(t *testing.T) {
+	forEngines(t, runGrantDedup)
+}
 
 // runGrantDedup: the table carries no uniqueness over the triple on purpose,
 // so dedup is the API's job. Two grantors granting the same triple leave ONE
@@ -204,11 +207,8 @@ func runGrantDedup(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestGrantRevokeReleasesOneOriginSQLite(t *testing.T) {
-	runGrantRevokeOrigins(t, seededDB(t, openSQLite))
-}
-func TestGrantRevokeReleasesOneOriginPostgres(t *testing.T) {
-	runGrantRevokeOrigins(t, seededDB(t, openPostgres))
+func TestGrantRevokeReleasesOneOrigin(t *testing.T) {
+	forEngines(t, runGrantRevokeOrigins)
 }
 
 // runGrantRevokeOrigins: a revoke releases the origins this surface owns and
@@ -237,8 +237,9 @@ func runGrantRevokeOrigins(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestLockoutInvariantSQLite(t *testing.T)   { runLockoutInvariant(t, seededDB(t, openSQLite)) }
-func TestLockoutInvariantPostgres(t *testing.T) { runLockoutInvariant(t, seededDB(t, openPostgres)) }
+func TestLockoutInvariant(t *testing.T) {
+	forEngines(t, runLockoutInvariant)
+}
 
 // runLockoutInvariant: removing the LAST `manage-members` holder is refused at
 // org scope and at instance scope. An unadministrable org is a support incident
@@ -271,8 +272,9 @@ func runLockoutInvariant(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineAllowlistSQLite(t *testing.T)   { runMachineAllowlist(t, seededDB(t, openSQLite)) }
-func TestMachineAllowlistPostgres(t *testing.T) { runMachineAllowlist(t, seededDB(t, openPostgres)) }
+func TestMachineAllowlist(t *testing.T) {
+	forEngines(t, runMachineAllowlist)
+}
 
 // runMachineAllowlist: the allowlists are NORMATIVE — the grant API refuses,
 // it does not merely document. No machine principal holds `manage-members`,
@@ -330,8 +332,9 @@ func runMachineAllowlist(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestTemplateExpansionSQLite(t *testing.T)   { runTemplateExpansion(t, seededDB(t, openSQLite)) }
-func TestTemplateExpansionPostgres(t *testing.T) { runTemplateExpansion(t, seededDB(t, openPostgres)) }
+func TestTemplateExpansion(t *testing.T) {
+	forEngines(t, runTemplateExpansion)
+}
 
 // runTemplateExpansion: a template expands AT GRANT TIME into independent
 // rows. Nothing stores "the grantee is an admin"; what is stored is the
@@ -415,8 +418,9 @@ func runTemplateExpansion(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMembershipListingSQLite(t *testing.T)   { runMembershipListing(t, seededDB(t, openSQLite)) }
-func TestMembershipListingPostgres(t *testing.T) { runMembershipListing(t, seededDB(t, openPostgres)) }
+func TestMembershipListing(t *testing.T) {
+	forEngines(t, runMembershipListing)
+}
 
 // runMembershipListing: the surface answers per CAPABILITY LINE with its
 // origin chips, which is what makes "who can read production secrets?"
@@ -455,8 +459,9 @@ func runMembershipListing(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestBreakGlassGrantSQLite(t *testing.T)   { runBreakGlassGrant(t, seededDB(t, openSQLite)) }
-func TestBreakGlassGrantPostgres(t *testing.T) { runBreakGlassGrant(t, seededDB(t, openPostgres)) }
+func TestBreakGlassGrant(t *testing.T) {
+	forEngines(t, runBreakGlassGrant)
+}
 
 // runBreakGlassGrant: the local-host recovery path names its grantee principal
 // and capability explicitly, writes a durable recovery record, and carries a
@@ -501,11 +506,8 @@ func runBreakGlassGrant(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestProtectedEnvironmentSQLite(t *testing.T) {
-	runProtectedEnvironment(t, seededDB(t, openSQLite))
-}
-func TestProtectedEnvironmentPostgres(t *testing.T) {
-	runProtectedEnvironment(t, seededDB(t, openPostgres))
+func TestProtectedEnvironment(t *testing.T) {
+	forEngines(t, runProtectedEnvironment)
 }
 
 // runProtectedEnvironment: marking an environment protected CAPS its window at
@@ -592,9 +594,8 @@ func runProtectedEnvironment(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestRevokeKillsSessionSQLite(t *testing.T) { runRevokeKillsSession(t, seededDB(t, openSQLite)) }
-func TestRevokeKillsSessionPostgres(t *testing.T) {
-	runRevokeKillsSession(t, seededDB(t, openPostgres))
+func TestRevokeKillsSession(t *testing.T) {
+	forEngines(t, runRevokeKillsSession)
 }
 
 // runRevokeKillsSession IS the acceptance demo, in the order the criterion
@@ -737,8 +738,9 @@ func TestBreakGlassGrantHasNoNetworkRoute(t *testing.T) {
 	}
 }
 
-func TestLockoutCensusSQLite(t *testing.T)   { runLockoutCensus(t, seededDB(t, openSQLite)) }
-func TestLockoutCensusPostgres(t *testing.T) { runLockoutCensus(t, seededDB(t, openPostgres)) }
+func TestLockoutCensus(t *testing.T) {
+	forEngines(t, runLockoutCensus)
+}
 
 // runLockoutCensus is the regression for the two ways the org census got the
 // lockout invariant wrong, both of which the ordinary fixture cannot show:
@@ -832,9 +834,8 @@ func manageMembersHolders(t *testing.T, db *store.DB, org string) []domain.Princ
 	return out
 }
 
-func TestMachineScopeBoundsSQLite(t *testing.T) { runMachineScopeBounds(t, seededDB(t, openSQLite)) }
-func TestMachineScopeBoundsPostgres(t *testing.T) {
-	runMachineScopeBounds(t, seededDB(t, openPostgres))
+func TestMachineScopeBounds(t *testing.T) {
+	forEngines(t, runMachineScopeBounds)
 }
 
 // runMachineScopeBounds is F1's regression: the normative machine rules bound
@@ -940,11 +941,8 @@ func runMachineScopeBounds(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestGrantLifecycleEventsSQLite(t *testing.T) {
-	runGrantLifecycleEvents(t, seededDB(t, openSQLite))
-}
-func TestGrantLifecycleEventsPostgres(t *testing.T) {
-	runGrantLifecycleEvents(t, seededDB(t, openPostgres))
+func TestGrantLifecycleEvents(t *testing.T) {
+	forEngines(t, runGrantLifecycleEvents)
 }
 
 // runGrantLifecycleEvents is F5's regression: the lifecycle event must match
@@ -1032,11 +1030,8 @@ func runGrantLifecycleEvents(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOriginAddKeepsSessionAliveSQLite(t *testing.T) {
-	runOriginAddKeepsSessionAlive(t, seededDB(t, openSQLite))
-}
-func TestOriginAddKeepsSessionAlivePostgres(t *testing.T) {
-	runOriginAddKeepsSessionAlive(t, seededDB(t, openPostgres))
+func TestOriginAddKeepsSessionAlive(t *testing.T) {
+	forEngines(t, runOriginAddKeepsSessionAlive)
 }
 
 // runOriginAddKeepsSessionAlive is F5's remaining arm: a SECOND origin joining

--- a/internal/isolation/harness_test.go
+++ b/internal/isolation/harness_test.go
@@ -439,15 +439,25 @@ func openSQLite(t *testing.T) *store.DB {
 	return db
 }
 
-func openPostgres(t *testing.T) *store.DB {
+// postgresTestDSN returns the configured base DSN, failing loudly in CI when
+// it is unset (the postgres leg must never vacuously skip there) and skipping
+// locally otherwise. Callers derive their own sibling database from it with
+// derivedDatabase; the raw DSN is returned so the suffix stays at the call site.
+func postgresTestDSN(t *testing.T) string {
 	t.Helper()
 	dsn := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
 	if dsn == "" {
 		if os.Getenv("CI") != "" {
-			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres isolation leg must not silently skip in CI")
+			t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres leg must not silently skip in CI")
 		}
 		t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
 	}
+	return dsn
+}
+
+func openPostgres(t *testing.T) *store.DB {
+	t.Helper()
+	dsn := postgresTestDSN(t)
 	// This harness derives its own database from the configured one:
 	// `go test ./...` runs package binaries in parallel, and sharing one
 	// database with the conformance harness (same tables, drop + migrate +
@@ -514,6 +524,16 @@ func derivedDatabase(t *testing.T, dsn, suffix string) string {
 
 // pq quotes an identifier defensively; derived names come from the DSN.
 func pq(ident string) string { return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"` }
+
+// forEngines runs a probe body on sqlite (always) and on postgres (via
+// HIKYO_TEST_POSTGRES_DSN; CI-fatal when unset, local-skip otherwise — the skip
+// semantics live in openPostgres). The two legs are subtests, so a collapsed
+// TestX matched by the CI planner's ^TestX$ pattern still executes both.
+func forEngines(t *testing.T, run func(t *testing.T, db *store.DB)) {
+	t.Helper()
+	t.Run("sqlite", func(t *testing.T) { run(t, seededDB(t, openSQLite)) })
+	t.Run("postgres", func(t *testing.T) { run(t, seededDB(t, openPostgres)) })
+}
 
 func seededDB(t *testing.T, open func(*testing.T) *store.DB) *store.DB {
 	t.Helper()

--- a/internal/isolation/identities_e2e_test.go
+++ b/internal/isolation/identities_e2e_test.go
@@ -108,19 +108,12 @@ func seedMachineReveal(t *testing.T, db *store.DB, id string, p domain.Principal
 	seedOrigins(t, db)
 }
 
-func TestMachineIdentityLifecycleSQLite(t *testing.T) {
-	runMachineIdentityLifecycle(t, seededDB(t, openSQLite))
-}
-func TestMachineIdentityLifecyclePostgres(t *testing.T) {
-	runMachineIdentityLifecycle(t, seededDB(t, openPostgres))
+func TestMachineIdentityLifecycle(t *testing.T) {
+	forEngines(t, runMachineIdentityLifecycle)
 }
 
-func TestServiceAccountCreateAggregateSQLite(t *testing.T) {
-	runServiceAccountCreateAggregate(t, seededDB(t, openSQLite))
-}
-
-func TestServiceAccountCreateAggregatePostgres(t *testing.T) {
-	runServiceAccountCreateAggregate(t, seededDB(t, openPostgres))
+func TestServiceAccountCreateAggregate(t *testing.T) {
+	forEngines(t, runServiceAccountCreateAggregate)
 }
 
 func runServiceAccountCreateAggregate(t *testing.T, db *store.DB) {
@@ -150,12 +143,8 @@ func runServiceAccountCreateAggregate(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestServiceAccountDeleteAggregateSQLite(t *testing.T) {
-	runServiceAccountDeleteAggregate(t, seededDB(t, openSQLite))
-}
-
-func TestServiceAccountDeleteAggregatePostgres(t *testing.T) {
-	runServiceAccountDeleteAggregate(t, seededDB(t, openPostgres))
+func TestServiceAccountDeleteAggregate(t *testing.T) {
+	forEngines(t, runServiceAccountDeleteAggregate)
 }
 
 func runServiceAccountDeleteAggregate(t *testing.T, db *store.DB) {
@@ -224,12 +213,8 @@ func runServiceAccountDeleteAggregate(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestServiceAccountAggregateRollbackSQLite(t *testing.T) {
-	runServiceAccountAggregateRollback(t, seededDB(t, openSQLite))
-}
-
-func TestServiceAccountAggregateRollbackPostgres(t *testing.T) {
-	runServiceAccountAggregateRollback(t, seededDB(t, openPostgres))
+func TestServiceAccountAggregateRollback(t *testing.T) {
+	forEngines(t, runServiceAccountAggregateRollback)
 }
 
 func runServiceAccountAggregateRollback(t *testing.T, db *store.DB) {
@@ -311,12 +296,8 @@ func assertRowCountsEqual(t *testing.T, db *store.DB, want map[string]int64) {
 	}
 }
 
-func TestServiceAccountDeleteSerializesMintSQLite(t *testing.T) {
-	runServiceAccountDeleteSerializesMint(t, seededDB(t, openSQLite))
-}
-
-func TestServiceAccountDeleteSerializesMintPostgres(t *testing.T) {
-	runServiceAccountDeleteSerializesMint(t, seededDB(t, openPostgres))
+func TestServiceAccountDeleteSerializesMint(t *testing.T) {
+	forEngines(t, runServiceAccountDeleteSerializesMint)
 }
 
 func runServiceAccountDeleteSerializesMint(t *testing.T, db *store.DB) {
@@ -508,11 +489,8 @@ func runMachineIdentityLifecycle(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineCredentialEpochSQLite(t *testing.T) {
-	runMachineCredentialEpoch(t, seededDB(t, openSQLite))
-}
-func TestMachineCredentialEpochPostgres(t *testing.T) {
-	runMachineCredentialEpoch(t, seededDB(t, openPostgres))
+func TestMachineCredentialEpoch(t *testing.T) {
+	forEngines(t, runMachineCredentialEpoch)
 }
 
 // runMachineCredentialEpoch is the restore mechanism, propagated onto
@@ -545,11 +523,8 @@ func runMachineCredentialEpoch(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineLifetimeControlsSQLite(t *testing.T) {
-	runMachineLifetimeControls(t, seededDB(t, openSQLite))
-}
-func TestMachineLifetimeControlsPostgres(t *testing.T) {
-	runMachineLifetimeControls(t, seededDB(t, openPostgres))
+func TestMachineLifetimeControls(t *testing.T) {
+	forEngines(t, runMachineLifetimeControls)
 }
 
 // runMachineLifetimeControls exercises both instance controls and the
@@ -692,11 +667,8 @@ func runMachineLifetimeControls(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineCredentialCapSQLite(t *testing.T) {
-	runMachineCredentialCap(t, seededDB(t, openSQLite))
-}
-func TestMachineCredentialCapPostgres(t *testing.T) {
-	runMachineCredentialCap(t, seededDB(t, openPostgres))
+func TestMachineCredentialCap(t *testing.T) {
+	forEngines(t, runMachineCredentialCap)
 }
 
 // runMachineCredentialCap: overlap rotation needs room, a mint loop does not.
@@ -737,11 +709,8 @@ func runMachineCredentialCap(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMintDisclosureGateSQLite(t *testing.T) {
-	runMintDisclosureGate(t, seededDB(t, openSQLite))
-}
-func TestMintDisclosureGatePostgres(t *testing.T) {
-	runMintDisclosureGate(t, seededDB(t, openPostgres))
+func TestMintDisclosureGate(t *testing.T) {
+	forEngines(t, runMintDisclosureGate)
 }
 
 // runMintDisclosureGate is the acceptance criteria's "manage identities
@@ -852,11 +821,8 @@ func runMintDisclosureGate(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineGrantWideningSQLite(t *testing.T) {
-	runMachineGrantWidening(t, seededDB(t, openSQLite))
-}
-func TestMachineGrantWideningPostgres(t *testing.T) {
-	runMachineGrantWidening(t, seededDB(t, openPostgres))
+func TestMachineGrantWidening(t *testing.T) {
+	forEngines(t, runMachineGrantWidening)
 }
 
 // runMachineGrantWidening is the ADR's third authorization row — the one an
@@ -933,11 +899,8 @@ func runMachineGrantWidening(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineAuthIsUniformSQLite(t *testing.T) {
-	runMachineAuthIsUniform(t, seededDB(t, openSQLite))
-}
-func TestMachineAuthIsUniformPostgres(t *testing.T) {
-	runMachineAuthIsUniform(t, seededDB(t, openPostgres))
+func TestMachineAuthIsUniform(t *testing.T) {
+	forEngines(t, runMachineAuthIsUniform)
 }
 
 // runMachineAuthIsUniform is the tenant-isolation propagation's timing half:
@@ -1008,11 +971,8 @@ func runMachineAuthIsUniform(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineSubtreeConfinementSQLite(t *testing.T) {
-	runMachineSubtreeConfinement(t, seededDB(t, openSQLite))
-}
-func TestMachineSubtreeConfinementPostgres(t *testing.T) {
-	runMachineSubtreeConfinement(t, seededDB(t, openPostgres))
+func TestMachineSubtreeConfinement(t *testing.T) {
+	forEngines(t, runMachineSubtreeConfinement)
 }
 
 // runMachineSubtreeConfinement: "its grants are confined to its owning
@@ -1066,11 +1026,8 @@ func runMachineSubtreeConfinement(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestMachineIdentityIsolationSQLite(t *testing.T) {
-	runMachineIdentityIsolation(t, seededDB(t, openSQLite))
-}
-func TestMachineIdentityIsolationPostgres(t *testing.T) {
-	runMachineIdentityIsolation(t, seededDB(t, openPostgres))
+func TestMachineIdentityIsolation(t *testing.T) {
+	forEngines(t, runMachineIdentityIsolation)
 }
 
 // runMachineIdentityIsolation: a service-account id from another project is

--- a/internal/isolation/instance_connection_e2e_test.go
+++ b/internal/isolation/instance_connection_e2e_test.go
@@ -63,14 +63,8 @@ func mintInstanceConnection(t *testing.T, db *store.DB, id string) string {
 	return value
 }
 
-func TestInstanceConnectionCredentialEndToEndSQLite(t *testing.T) {
-	db := seededDB(t, openSQLite)
-	runInstanceConnectionE2E(t, db)
-}
-
-func TestInstanceConnectionCredentialEndToEndPostgres(t *testing.T) {
-	db := seededDB(t, openPostgres)
-	runInstanceConnectionE2E(t, db)
+func TestInstanceConnectionCredentialEndToEnd(t *testing.T) {
+	forEngines(t, runInstanceConnectionE2E)
 }
 
 func runInstanceConnectionE2E(t *testing.T, db *store.DB) {
@@ -147,7 +141,7 @@ func scopeAtDepth(l domain.Level) domain.Scope {
 // A revoked credential stops authenticating at the very next presentation,
 // uncached — revocation is read in the authenticating transaction, so it bites
 // on the next request rather than at some expiry.
-func TestInstanceConnectionRevocationBitesImmediatelySQLite(t *testing.T) {
+func TestInstanceConnectionRevocationBitesImmediately(t *testing.T) {
 	db := seededDB(t, openSQLite)
 	value := mintInstanceConnection(t, db, "rev")
 

--- a/internal/isolation/invite_e2e_test.go
+++ b/internal/isolation/invite_e2e_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestMemberInviteSQLite(t *testing.T)   { runMemberInvite(t, seededDB(t, openSQLite)) }
-func TestMemberInvitePostgres(t *testing.T) { runMemberInvite(t, seededDB(t, openPostgres)) }
+func TestMemberInvite(t *testing.T) {
+	forEngines(t, runMemberInvite)
+}
 
 // runMemberInvite (#568, human-auth ADR § Identity linking): a manage-members
 // holder invites a human at organisation or instance scope; the account, the
@@ -32,25 +33,7 @@ func runMemberInvite(t *testing.T, db *store.DB) {
 	// The bootstrap administrator holds `operator` (manage-members at instance
 	// scope), which covers org_a by inheritance. Step up: membership writes
 	// are administrative.
-	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	uri, err := auth.EnrolTOTPStart(ctx, login.SessionToken, password)
-	if err != nil {
-		t.Fatalf("enrol start: %v", err)
-	}
-	clk = base.Add(30 * time.Second)
-	confirmed, err := auth.EnrolTOTPConfirm(ctx, login.SessionToken, totpCode(t, uri, clk))
-	if err != nil {
-		t.Fatalf("enrol confirm: %v", err)
-	}
-	clk = base.Add(60 * time.Second)
-	stepped, err := auth.StepUpTOTP(ctx, confirmed.SessionToken, totpCode(t, uri, clk))
-	if err != nil {
-		t.Fatalf("step-up: %v", err)
-	}
-	admin := service.Bearer(stepped.SessionToken)
+	admin := service.Bearer(enrolTOTPAndStepUp(t, auth, ctx, base, &clk, password))
 
 	// Organisation invite with a template: account + grants + authority.
 	inv, err := grants.InviteMember(ctx, admin, service.InviteSpec{

--- a/internal/isolation/machine_reveal_e2e_test.go
+++ b/internal/isolation/machine_reveal_e2e_test.go
@@ -28,9 +28,8 @@ import (
 //     administrator without `reveal` cannot enable it, and both directions are
 //     audited.
 
-func TestMachineRevealOptInSQLite(t *testing.T) { runMachineRevealOptIn(t, seededDB(t, openSQLite)) }
-func TestMachineRevealOptInPostgres(t *testing.T) {
-	runMachineRevealOptIn(t, seededDB(t, openPostgres))
+func TestMachineRevealOptIn(t *testing.T) {
+	forEngines(t, runMachineRevealOptIn)
 }
 
 func runMachineRevealOptIn(t *testing.T, db *store.DB) {

--- a/internal/isolation/machine_reveal_history_e2e_test.go
+++ b/internal/isolation/machine_reveal_history_e2e_test.go
@@ -11,12 +11,8 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestWorkloadRevealHistoryPinSQLite(t *testing.T) {
-	runWorkloadRevealHistoryPin(t, seededDB(t, openSQLite))
-}
-
-func TestWorkloadRevealHistoryPinPostgres(t *testing.T) {
-	runWorkloadRevealHistoryPin(t, seededDB(t, openPostgres))
+func TestWorkloadRevealHistoryPin(t *testing.T) {
+	forEngines(t, runWorkloadRevealHistoryPin)
 }
 
 // runWorkloadRevealHistoryPin exercises the grant and delivery seams together:

--- a/internal/isolation/oidc_e2e_test.go
+++ b/internal/isolation/oidc_e2e_test.go
@@ -204,8 +204,9 @@ func runOIDCMixup(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCMixupSQLite(t *testing.T)   { runOIDCMixup(t, seededDB(t, openSQLite)) }
-func TestOIDCMixupPostgres(t *testing.T) { runOIDCMixup(t, seededDB(t, openPostgres)) }
+func TestOIDCMixup(t *testing.T) {
+	forEngines(t, runOIDCMixup)
+}
 
 // runOIDCByteExactSubject: two subjects differing only in case are two distinct
 // identities, both loginable, never merged.
@@ -231,11 +232,8 @@ func runOIDCByteExactSubject(t *testing.T, db *store.DB) {
 	_ = password
 }
 
-func TestOIDCByteExactSubjectSQLite(t *testing.T) {
-	runOIDCByteExactSubject(t, seededDB(t, openSQLite))
-}
-func TestOIDCByteExactSubjectPostgres(t *testing.T) {
-	runOIDCByteExactSubject(t, seededDB(t, openPostgres))
+func TestOIDCByteExactSubject(t *testing.T) {
+	forEngines(t, runOIDCByteExactSubject)
 }
 
 func oidcRefusedCount(t *testing.T, db *store.DB, cause string) int64 {
@@ -305,8 +303,9 @@ func runOIDCBinding(t *testing.T, db *store.DB) {
 	_ = admin
 }
 
-func TestOIDCBindingSQLite(t *testing.T)   { runOIDCBinding(t, seededDB(t, openSQLite)) }
-func TestOIDCBindingPostgres(t *testing.T) { runOIDCBinding(t, seededDB(t, openPostgres)) }
+func TestOIDCBinding(t *testing.T) {
+	forEngines(t, runOIDCBinding)
+}
 
 // runOIDCReauthRefusals: OIDC reauth refuses when the environment is missing,
 // when the provider has no assurance policy (A5), and when the returned token
@@ -428,11 +427,8 @@ func runOIDCReauthZeroWindow(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCReauthZeroWindowSQLite(t *testing.T) {
-	runOIDCReauthZeroWindow(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthZeroWindowPostgres(t *testing.T) {
-	runOIDCReauthZeroWindow(t, seededDB(t, openPostgres))
+func TestOIDCReauthZeroWindow(t *testing.T) {
+	forEngines(t, runOIDCReauthZeroWindow)
 }
 
 // runOIDCBrowserOverloadMetadata proves admission refusal happens before any
@@ -480,18 +476,12 @@ func runOIDCBrowserOverloadMetadata(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCBrowserOverloadMetadataSQLite(t *testing.T) {
-	runOIDCBrowserOverloadMetadata(t, seededDB(t, openSQLite))
-}
-func TestOIDCBrowserOverloadMetadataPostgres(t *testing.T) {
-	runOIDCBrowserOverloadMetadata(t, seededDB(t, openPostgres))
+func TestOIDCBrowserOverloadMetadata(t *testing.T) {
+	forEngines(t, runOIDCBrowserOverloadMetadata)
 }
 
-func TestOIDCReauthRefusalsSQLite(t *testing.T) {
-	runOIDCReauthRefusals(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthRefusalsPostgres(t *testing.T) {
-	runOIDCReauthRefusals(t, seededDB(t, openPostgres))
+func TestOIDCReauthRefusals(t *testing.T) {
+	forEngines(t, runOIDCReauthRefusals)
 }
 
 func runOIDCDisclosureAndCLIHandoff(t *testing.T, db *store.DB) {
@@ -564,12 +554,8 @@ func runOIDCDisclosureAndCLIHandoff(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCDisclosureAndCLIHandoffSQLite(t *testing.T) {
-	runOIDCDisclosureAndCLIHandoff(t, seededDB(t, openSQLite))
-}
-
-func TestOIDCDisclosureAndCLIHandoffPostgres(t *testing.T) {
-	runOIDCDisclosureAndCLIHandoff(t, seededDB(t, openPostgres))
+func TestOIDCDisclosureAndCLIHandoff(t *testing.T) {
+	forEngines(t, runOIDCDisclosureAndCLIHandoff)
 }
 
 // runOIDCIssuerImmutable: a provider's issuer cannot change on update (A3).
@@ -601,11 +587,8 @@ func runOIDCIssuerImmutable(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCIssuerImmutableSQLite(t *testing.T) {
-	runOIDCIssuerImmutable(t, seededDB(t, openSQLite))
-}
-func TestOIDCIssuerImmutablePostgres(t *testing.T) {
-	runOIDCIssuerImmutable(t, seededDB(t, openPostgres))
+func TestOIDCIssuerImmutable(t *testing.T) {
+	forEngines(t, runOIDCIssuerImmutable)
 }
 
 // runOIDCProviderChangeSweeps: reconfiguring a provider deletes sessions
@@ -634,11 +617,8 @@ func runOIDCProviderChangeSweeps(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCProviderChangeSweepsSQLite(t *testing.T) {
-	runOIDCProviderChangeSweeps(t, seededDB(t, openSQLite))
-}
-func TestOIDCProviderChangeSweepsPostgres(t *testing.T) {
-	runOIDCProviderChangeSweeps(t, seededDB(t, openPostgres))
+func TestOIDCProviderChangeSweeps(t *testing.T) {
+	forEngines(t, runOIDCProviderChangeSweeps)
 }
 
 // --- reauth assurance fixtures (#54 cross-model review R1) ---
@@ -747,11 +727,8 @@ func runOIDCReauthPossession(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCReauthPossessionSQLite(t *testing.T) {
-	runOIDCReauthPossession(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthPossessionPostgres(t *testing.T) {
-	runOIDCReauthPossession(t, seededDB(t, openPostgres))
+func TestOIDCReauthPossession(t *testing.T) {
+	forEngines(t, runOIDCReauthPossession)
 }
 
 // runOIDCReauthEpochInert: an epoch-inert (restored) identity is terminally
@@ -782,11 +759,8 @@ func runOIDCReauthEpochInert(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCReauthEpochInertSQLite(t *testing.T) {
-	runOIDCReauthEpochInert(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthEpochInertPostgres(t *testing.T) {
-	runOIDCReauthEpochInert(t, seededDB(t, openPostgres))
+func TestOIDCReauthEpochInert(t *testing.T) {
+	forEngines(t, runOIDCReauthEpochInert)
 }
 
 // runOIDCReauthProviderRebind: after a provider is replaced for the same
@@ -843,11 +817,8 @@ func runOIDCReauthProviderRebind(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCReauthProviderRebindSQLite(t *testing.T) {
-	runOIDCReauthProviderRebind(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthProviderRebindPostgres(t *testing.T) {
-	runOIDCReauthProviderRebind(t, seededDB(t, openPostgres))
+func TestOIDCReauthProviderRebind(t *testing.T) {
+	forEngines(t, runOIDCReauthProviderRebind)
 }
 
 // runOIDCReauthDowngrade: a reauth must be same-or-stronger than the session it
@@ -889,11 +860,8 @@ func runOIDCReauthDowngrade(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCReauthDowngradeSQLite(t *testing.T) {
-	runOIDCReauthDowngrade(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthDowngradePostgres(t *testing.T) {
-	runOIDCReauthDowngrade(t, seededDB(t, openPostgres))
+func TestOIDCReauthDowngrade(t *testing.T) {
+	forEngines(t, runOIDCReauthDowngrade)
 }
 
 // runOIDCReauthProviderRace: a provider reconfigure that lands during the code
@@ -937,11 +905,8 @@ func runOIDCReauthProviderRace(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCReauthProviderRaceSQLite(t *testing.T) {
-	runOIDCReauthProviderRace(t, seededDB(t, openSQLite))
-}
-func TestOIDCReauthProviderRacePostgres(t *testing.T) {
-	runOIDCReauthProviderRace(t, seededDB(t, openPostgres))
+func TestOIDCReauthProviderRace(t *testing.T) {
+	forEngines(t, runOIDCReauthProviderRace)
 }
 
 // runOIDCLoginProviderRace: a provider reconfigure that lands during a login's
@@ -996,11 +961,8 @@ func runOIDCLoginProviderRace(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCLoginProviderRaceSQLite(t *testing.T) {
-	runOIDCLoginProviderRace(t, seededDB(t, openSQLite))
-}
-func TestOIDCLoginProviderRacePostgres(t *testing.T) {
-	runOIDCLoginProviderRace(t, seededDB(t, openPostgres))
+func TestOIDCLoginProviderRace(t *testing.T) {
+	forEngines(t, runOIDCLoginProviderRace)
 }
 
 // runOIDCLoginProviderDeleteRace: deleting a provider during a login's code
@@ -1058,11 +1020,8 @@ func runOIDCLoginProviderDeleteRace(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCLoginProviderDeleteRaceSQLite(t *testing.T) {
-	runOIDCLoginProviderDeleteRace(t, seededDB(t, openSQLite))
-}
-func TestOIDCLoginProviderDeleteRacePostgres(t *testing.T) {
-	runOIDCLoginProviderDeleteRace(t, seededDB(t, openPostgres))
+func TestOIDCLoginProviderDeleteRace(t *testing.T) {
+	forEngines(t, runOIDCLoginProviderDeleteRace)
 }
 
 // runOIDCProviderDeleteCascade proves the FK cascade (A14) is the atomic
@@ -1096,11 +1055,8 @@ func runOIDCProviderDeleteCascade(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCProviderDeleteCascadeSQLite(t *testing.T) {
-	runOIDCProviderDeleteCascade(t, seededDB(t, openSQLite))
-}
-func TestOIDCProviderDeleteCascadePostgres(t *testing.T) {
-	runOIDCProviderDeleteCascade(t, seededDB(t, openPostgres))
+func TestOIDCProviderDeleteCascade(t *testing.T) {
+	forEngines(t, runOIDCProviderDeleteCascade)
 }
 
 // runOIDCIATRejected: an ID token whose iat is in the future beyond the skew is
@@ -1146,5 +1102,6 @@ func runOIDCIATRejected(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestOIDCIATRejectedSQLite(t *testing.T)   { runOIDCIATRejected(t, seededDB(t, openSQLite)) }
-func TestOIDCIATRejectedPostgres(t *testing.T) { runOIDCIATRejected(t, seededDB(t, openPostgres)) }
+func TestOIDCIATRejected(t *testing.T) {
+	forEngines(t, runOIDCIATRejected)
+}

--- a/internal/isolation/pending_cap_e2e_test.go
+++ b/internal/isolation/pending_cap_e2e_test.go
@@ -11,11 +11,8 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestPendingPerProjectCapSQLite(t *testing.T) {
-	runPendingPerProjectCap(t, seededDB(t, openSQLite))
-}
-func TestPendingPerProjectCapPostgres(t *testing.T) {
-	runPendingPerProjectCap(t, seededDB(t, openPostgres))
+func TestPendingPerProjectCap(t *testing.T) {
+	forEngines(t, runPendingPerProjectCap)
 }
 
 // runPendingPerProjectCap: the ops-spec § 8 loud cap on pending versions per

--- a/internal/isolation/probes_test.go
+++ b/internal/isolation/probes_test.go
@@ -1025,10 +1025,6 @@ func runSuite(t *testing.T, db *store.DB) {
 	t.Run("read_snapshot_stability", func(t *testing.T) { runReadSnapshotStability(t, db) })
 }
 
-func TestIsolationSQLite(t *testing.T) {
-	runSuite(t, seededDB(t, openSQLite))
-}
-
-func TestIsolationPostgres(t *testing.T) {
-	runSuite(t, seededDB(t, openPostgres))
+func TestIsolation(t *testing.T) {
+	forEngines(t, runSuite)
 }

--- a/internal/isolation/project_storage_e2e_test.go
+++ b/internal/isolation/project_storage_e2e_test.go
@@ -10,11 +10,8 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
-func TestProjectStorageHighWaterSQLite(t *testing.T) {
-	runProjectStorageHighWater(t, seededDB(t, openSQLite))
-}
-func TestProjectStorageHighWaterPostgres(t *testing.T) {
-	runProjectStorageHighWater(t, seededDB(t, openPostgres))
+func TestProjectStorageHighWater(t *testing.T) {
+	forEngines(t, runProjectStorageHighWater)
 }
 
 // runProjectStorageHighWater is the ops-spec § 8 / § 141 per-project storage

--- a/internal/isolation/reauth_e2e_test.go
+++ b/internal/isolation/reauth_e2e_test.go
@@ -141,20 +141,12 @@ func targetedAdapterReauthIntent(t *testing.T, operation authz.Operation, enviro
 	return intent
 }
 
-func TestAdapterReauthWindowExactBindingSQLite(t *testing.T) {
-	runAdapterReauthWindowExactBinding(t, seededDB(t, openSQLite))
+func TestAdapterReauthWindowExactBinding(t *testing.T) {
+	forEngines(t, runAdapterReauthWindowExactBinding)
 }
 
-func TestAdapterReauthWindowExactBindingPostgres(t *testing.T) {
-	runAdapterReauthWindowExactBinding(t, seededDB(t, openPostgres))
-}
-
-func TestInvalidReauthWindowBindingSQLite(t *testing.T) {
-	runInvalidReauthWindowBinding(t, seededDB(t, openSQLite))
-}
-
-func TestInvalidReauthWindowBindingPostgres(t *testing.T) {
-	runInvalidReauthWindowBinding(t, seededDB(t, openPostgres))
+func TestInvalidReauthWindowBinding(t *testing.T) {
+	forEngines(t, runInvalidReauthWindowBinding)
 }
 
 func runInvalidReauthWindowBinding(t *testing.T, db *store.DB) {
@@ -190,28 +182,16 @@ func runInvalidReauthWindowBinding(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestAdapterReauthTOTPMixedPolicySQLite(t *testing.T) {
-	runAdapterReauthTOTPMixedPolicy(t, seededDB(t, openSQLite))
+func TestAdapterReauthTOTPMixedPolicy(t *testing.T) {
+	forEngines(t, runAdapterReauthTOTPMixedPolicy)
 }
 
-func TestAdapterReauthTOTPMixedPolicyPostgres(t *testing.T) {
-	runAdapterReauthTOTPMixedPolicy(t, seededDB(t, openPostgres))
+func TestAdapterReauthWebAuthnBindsFullEnvironmentSet(t *testing.T) {
+	forEngines(t, runAdapterReauthWebAuthnBindsFullEnvironmentSet)
 }
 
-func TestAdapterReauthWebAuthnBindsFullEnvironmentSetSQLite(t *testing.T) {
-	runAdapterReauthWebAuthnBindsFullEnvironmentSet(t, seededDB(t, openSQLite))
-}
-
-func TestAdapterReauthWebAuthnBindsFullEnvironmentSetPostgres(t *testing.T) {
-	runAdapterReauthWebAuthnBindsFullEnvironmentSet(t, seededDB(t, openPostgres))
-}
-
-func TestCLIAdapterReauthHandoffSQLite(t *testing.T) {
-	runCLIAdapterReauthHandoff(t, seededDB(t, openSQLite))
-}
-
-func TestCLIAdapterReauthHandoffPostgres(t *testing.T) {
-	runCLIAdapterReauthHandoff(t, seededDB(t, openPostgres))
+func TestCLIAdapterReauthHandoff(t *testing.T) {
+	forEngines(t, runCLIAdapterReauthHandoff)
 }
 
 func runCLIAdapterReauthHandoff(t *testing.T, db *store.DB) {
@@ -357,8 +337,7 @@ func runAdapterReauthWebAuthnBindsFullEnvironmentSet(t *testing.T, db *store.DB)
 	auth.ReauthHardCap = 10 * time.Minute
 	ctx := t.Context()
 	device := webauthntest.New(waRPID, waOrigin)
-	token = enrolPasskey(t, auth, ctx, token, waPassword, device)
-	token = stepUpPasskey(t, auth, ctx, token, device)
+	token = enrolPasskeyAndStepUp(t, auth, ctx, token, waPassword, device)
 	execRaw(t, db, `INSERT INTO environments (id, org_id, project_id, name, note, protected, reauth_window_seconds, created_at, display_order) VALUES ('env_adapter_zero', 'org_a', 'prj_a1', 'adapter-zero', '', TRUE, 0, `+ts+`, 2)`)
 	environments := []string{"env_prod", "env_adapter_zero"}
 	options, err := auth.ReauthPasskeyStart(ctx, token, targetedAdapterReauthIntent(t, authz.OpAdapterConfigure, "env_adapter_zero", environments))
@@ -484,11 +463,8 @@ func runAdapterReauthWindowExactBinding(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestReauthConsumeSingleDecisionSQLite(t *testing.T) {
-	runReauthConsumeSingleDecision(t, seededDB(t, openSQLite))
-}
-func TestReauthConsumeSingleDecisionPostgres(t *testing.T) {
-	runReauthConsumeSingleDecision(t, seededDB(t, openPostgres))
+func TestReauthConsumeSingleDecision(t *testing.T) {
+	forEngines(t, runReauthConsumeSingleDecision)
 }
 
 // runReauthConsumeSingleDecision: a 0-effective-window WebAuthn ceremony opens a
@@ -545,11 +521,8 @@ func runReauthConsumeSingleDecision(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestReauthConsumeSlidingHardCapSQLite(t *testing.T) {
-	runReauthConsumeSlidingHardCap(t, seededDB(t, openSQLite))
-}
-func TestReauthConsumeSlidingHardCapPostgres(t *testing.T) {
-	runReauthConsumeSlidingHardCap(t, seededDB(t, openPostgres))
+func TestReauthConsumeSlidingHardCap(t *testing.T) {
+	forEngines(t, runReauthConsumeSlidingHardCap)
 }
 
 // runReauthConsumeSlidingHardCap: at a non-zero effective window a WebAuthn reauth
@@ -566,8 +539,7 @@ func runReauthConsumeSlidingHardCap(t *testing.T, db *store.DB) {
 	auth.ReauthHardCap = 10 * time.Minute
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
-	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
-	token = stepUpPasskey(t, auth, ctx, token, dev)
+	token = enrolPasskeyAndStepUp(t, auth, ctx, token, waPassword, dev)
 
 	ropts, err := auth.ReauthPasskeyStart(ctx, token, disclosureReauthIntent(t, service.PurposeReveal, "env_prod", []string{"key_a"}))
 	if err != nil {
@@ -617,11 +589,8 @@ func runReauthConsumeSlidingHardCap(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestReauthWebAuthnOpenClampsHardCapSQLite(t *testing.T) {
-	runReauthWebAuthnOpenClampsHardCap(t, seededDB(t, openSQLite))
-}
-func TestReauthWebAuthnOpenClampsHardCapPostgres(t *testing.T) {
-	runReauthWebAuthnOpenClampsHardCap(t, seededDB(t, openPostgres))
+func TestReauthWebAuthnOpenClampsHardCap(t *testing.T) {
+	forEngines(t, runReauthWebAuthnOpenClampsHardCap)
 }
 
 // runReauthWebAuthnOpenClampsHardCap (A2 residual): the WebAuthn opener clamps
@@ -636,8 +605,7 @@ func runReauthWebAuthnOpenClampsHardCap(t *testing.T, db *store.DB) {
 	auth.ReauthHardCap = 10 * time.Minute
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
-	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
-	token = stepUpPasskey(t, auth, ctx, token, dev)
+	token = enrolPasskeyAndStepUp(t, auth, ctx, token, waPassword, dev)
 
 	ropts, err := auth.ReauthPasskeyStart(ctx, token, disclosureReauthIntent(t, service.PurposeReveal, "env_prod", []string{"key_a"}))
 	if err != nil {
@@ -665,11 +633,8 @@ func runReauthWebAuthnOpenClampsHardCap(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestReauthSlideUsesEffectiveWindowSQLite(t *testing.T) {
-	runReauthSlideUsesEffectiveWindow(t, seededDB(t, openSQLite))
-}
-func TestReauthSlideUsesEffectiveWindowPostgres(t *testing.T) {
-	runReauthSlideUsesEffectiveWindow(t, seededDB(t, openPostgres))
+func TestReauthSlideUsesEffectiveWindow(t *testing.T) {
+	forEngines(t, runReauthSlideUsesEffectiveWindow)
 }
 
 // runReauthSlideUsesEffectiveWindow (NEW HIGH): the slide amount is resolved
@@ -688,8 +653,7 @@ func runReauthSlideUsesEffectiveWindow(t *testing.T, db *store.DB) {
 	auth.ReauthHardCap = 30 * time.Minute
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
-	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
-	token = stepUpPasskey(t, auth, ctx, token, dev)
+	token = enrolPasskeyAndStepUp(t, auth, ctx, token, waPassword, dev)
 
 	ropts, err := auth.ReauthPasskeyStart(ctx, token, disclosureReauthIntent(t, service.PurposeReveal, "env_prod", []string{"key_a"}))
 	if err != nil {
@@ -730,11 +694,8 @@ func runReauthSlideUsesEffectiveWindow(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestReauthConsumeInvalidationFailsClosedSQLite(t *testing.T) {
-	runReauthConsumeInvalidationFailsClosed(t, seededDB(t, openSQLite))
-}
-func TestReauthConsumeInvalidationFailsClosedPostgres(t *testing.T) {
-	runReauthConsumeInvalidationFailsClosed(t, seededDB(t, openPostgres))
+func TestReauthConsumeInvalidationFailsClosed(t *testing.T) {
+	forEngines(t, runReauthConsumeInvalidationFailsClosed)
 }
 
 // runReauthConsumeInvalidationFailsClosed (A1): a disclosure that reads a live
@@ -756,8 +717,7 @@ func runReauthConsumeInvalidationFailsClosed(t *testing.T, db *store.DB) {
 	auth.ReauthHardCap = 10 * time.Minute
 	ctx := t.Context()
 	dev := webauthntest.New(waRPID, waOrigin)
-	token = enrolPasskey(t, auth, ctx, token, waPassword, dev)
-	token = stepUpPasskey(t, auth, ctx, token, dev)
+	token = enrolPasskeyAndStepUp(t, auth, ctx, token, waPassword, dev)
 
 	ropts, err := auth.ReauthPasskeyStart(ctx, token, disclosureReauthIntent(t, service.PurposeReveal, "env_prod", []string{"key_a"}))
 	if err != nil {
@@ -781,11 +741,8 @@ func runReauthConsumeInvalidationFailsClosed(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestReauthTOTPZeroWindowSQLite(t *testing.T) {
-	runReauthTOTPZeroWindow(t, seededDB(t, openSQLite))
-}
-func TestReauthTOTPZeroWindowPostgres(t *testing.T) {
-	runReauthTOTPZeroWindow(t, seededDB(t, openPostgres))
+func TestReauthTOTPZeroWindow(t *testing.T) {
+	forEngines(t, runReauthTOTPZeroWindow)
 }
 
 // runReauthTOTPZeroWindow: TOTP cannot bind the enumerated unit, so at a 0
@@ -837,11 +794,8 @@ func runReauthTOTPZeroWindow(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestLowerEffectiveWindowStrandingSQLite(t *testing.T) {
-	runLowerEffectiveWindowStranding(t, seededDB(t, openSQLite))
-}
-func TestLowerEffectiveWindowStrandingPostgres(t *testing.T) {
-	runLowerEffectiveWindowStranding(t, seededDB(t, openPostgres))
+func TestLowerEffectiveWindowStranding(t *testing.T) {
+	forEngines(t, runLowerEffectiveWindowStranding)
 }
 
 // runLowerEffectiveWindowStranding (finding B6): lowering an environment's
@@ -888,11 +842,8 @@ func runLowerEffectiveWindowStranding(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestCredentialResetNetworkSQLite(t *testing.T) {
-	runCredentialResetNetwork(t, seededDB(t, openSQLite))
-}
-func TestCredentialResetNetworkPostgres(t *testing.T) {
-	runCredentialResetNetwork(t, seededDB(t, openPostgres))
+func TestCredentialResetNetwork(t *testing.T) {
+	forEngines(t, runCredentialResetNetwork)
 }
 
 // grantInstanceCapability seeds a capability the bootstrap template no longer
@@ -927,25 +878,7 @@ func runCredentialResetNetwork(t *testing.T, db *store.DB) {
 	ctx := t.Context()
 
 	// Step the admin up to multi-factor: credential-reset is MFA-mandatory.
-	login, err := auth.LocalLogin(ctx, "factor-admin", password, service.ArtifactCLI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	uri, err := auth.EnrolTOTPStart(ctx, login.SessionToken, password)
-	if err != nil {
-		t.Fatalf("enrol start: %v", err)
-	}
-	clk = base.Add(30 * time.Second)
-	confirmed, err := auth.EnrolTOTPConfirm(ctx, login.SessionToken, totpCode(t, uri, clk))
-	if err != nil {
-		t.Fatalf("enrol confirm: %v", err)
-	}
-	clk = base.Add(60 * time.Second)
-	stepped, err := auth.StepUpTOTP(ctx, confirmed.SessionToken, totpCode(t, uri, clk))
-	if err != nil {
-		t.Fatalf("step-up: %v", err)
-	}
-	adminToken := stepped.SessionToken
+	adminToken := enrolTOTPAndStepUp(t, auth, ctx, base, &clk, password)
 
 	// An org-bounded target: grants within org_a, no instance capability.
 	execRaw(t, db, "INSERT INTO principals (id, kind, created_at) VALUES ('usr_target', 'human', "+ts+")")
@@ -998,11 +931,8 @@ func runCredentialResetNetwork(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestCredentialResetMFAMandatorySQLite(t *testing.T) {
-	runCredentialResetMFAMandatory(t, seededDB(t, openSQLite))
-}
-func TestCredentialResetMFAMandatoryPostgres(t *testing.T) {
-	runCredentialResetMFAMandatory(t, seededDB(t, openPostgres))
+func TestCredentialResetMFAMandatory(t *testing.T) {
+	forEngines(t, runCredentialResetMFAMandatory)
 }
 
 // runCredentialResetMFAMandatory (B1/B3): the network reset route authorizes
@@ -1087,12 +1017,8 @@ func blobLit(db *store.DB, b []byte) string {
 	return `x'` + string(sb) + `'`
 }
 
-func TestCLIDisclosureReauthHandoffSQLite(t *testing.T) {
-	runCLIDisclosureReauthHandoff(t, seededDB(t, openSQLite))
-}
-
-func TestCLIDisclosureReauthHandoffPostgres(t *testing.T) {
-	runCLIDisclosureReauthHandoff(t, seededDB(t, openPostgres))
+func TestCLIDisclosureReauthHandoff(t *testing.T) {
+	forEngines(t, runCLIDisclosureReauthHandoff)
 }
 
 // runCLIDisclosureReauthHandoff: the handoff carries a DISCLOSURE purpose
@@ -1208,12 +1134,8 @@ func runCLIDisclosureReauthHandoff(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestCLIDisclosureHandoffPasskeyBindingSQLite(t *testing.T) {
-	runCLIDisclosureHandoffPasskeyBinding(t, seededDB(t, openSQLite))
-}
-
-func TestCLIDisclosureHandoffPasskeyBindingPostgres(t *testing.T) {
-	runCLIDisclosureHandoffPasskeyBinding(t, seededDB(t, openPostgres))
+func TestCLIDisclosureHandoffPasskeyBinding(t *testing.T) {
+	forEngines(t, runCLIDisclosureHandoffPasskeyBinding)
 }
 
 // runCLIDisclosureHandoffPasskeyBinding is the 0-window handoff, the case the

--- a/internal/isolation/remote_e2e_test.go
+++ b/internal/isolation/remote_e2e_test.go
@@ -539,32 +539,19 @@ func runCorruptSnapshot(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestRemoteCorruptSnapshotFailsLoudSQLite(t *testing.T) {
-	runCorruptSnapshot(t, seededDB(t, openSQLite))
+func TestRemoteCorruptSnapshotFailsLoud(t *testing.T) {
+	forEngines(t, runCorruptSnapshot)
 }
 
-func TestRemoteCorruptSnapshotFailsLoudPostgres(t *testing.T) {
-	runCorruptSnapshot(t, seededDB(t, openPostgres))
+func TestRemoteCoalescingIsScoped(t *testing.T) {
+	forEngines(t, runScopedCoalescing)
 }
 
-func TestRemoteCoalescingIsScopedSQLite(t *testing.T) {
-	runScopedCoalescing(t, seededDB(t, openSQLite))
-}
-
-func TestRemoteCoalescingIsScopedPostgres(t *testing.T) {
-	runScopedCoalescing(t, seededDB(t, openPostgres))
-}
-
-func TestRemoteLifecycleSQLite(t *testing.T) {
-	db := seededDB(t, openSQLite)
-	runRemoteLifecycle(t, db)
-	assertRemoteEventsEmitted(t, db)
-}
-
-func TestRemoteLifecyclePostgres(t *testing.T) {
-	db := seededDB(t, openPostgres)
-	runRemoteLifecycle(t, db)
-	assertRemoteEventsEmitted(t, db)
+func TestRemoteLifecycle(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		runRemoteLifecycle(t, db)
+		assertRemoteEventsEmitted(t, db)
+	})
 }
 
 // assertRemoteEventsEmitted is the per-engine half of the closure invariant.

--- a/internal/isolation/retention_cli_e2e_test.go
+++ b/internal/isolation/retention_cli_e2e_test.go
@@ -273,14 +273,7 @@ func retentionAppConfig(t *testing.T, engine store.Engine) *config.Config {
 
 	storeCfg := config.Datastore{Engine: config.EngineSQLite, Path: filepath.Join(t.TempDir(), "retention-cli.db")}
 	if engine == store.EnginePostgres {
-		dsn := os.Getenv("HIKYO_TEST_POSTGRES_DSN")
-		if dsn == "" {
-			if os.Getenv("CI") != "" {
-				t.Fatal("CI run without HIKYO_TEST_POSTGRES_DSN: the postgres retention CLI leg must not silently skip in CI")
-			}
-			t.Skip("HIKYO_TEST_POSTGRES_DSN not set")
-		}
-		dsn = derivedDatabase(t, dsn, "_retention_cli")
+		dsn := derivedDatabase(t, postgresTestDSN(t), "_retention_cli")
 		reset, err := store.Open(t.Context(), store.Config{Engine: store.EnginePostgres, DSN: dsn})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/isolation/retention_gc_e2e_test.go
+++ b/internal/isolation/retention_gc_e2e_test.go
@@ -15,52 +15,28 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
 
-func TestRetentionGCC6SQLite(t *testing.T) {
-	runRetentionGCC6(t, seededDB(t, openSQLite))
+func TestRetentionGCC6(t *testing.T) {
+	forEngines(t, runRetentionGCC6)
 }
 
-func TestRetentionGCC6Postgres(t *testing.T) {
-	runRetentionGCC6(t, seededDB(t, openPostgres))
+func TestRetentionPinSubsecondBoundary(t *testing.T) {
+	forEngines(t, runRetentionPinSubsecondBoundary)
 }
 
-func TestRetentionPinSubsecondBoundarySQLite(t *testing.T) {
-	runRetentionPinSubsecondBoundary(t, seededDB(t, openSQLite))
+func TestPinReleaseRetentionConsequence(t *testing.T) {
+	forEngines(t, runPinReleaseRetentionConsequence)
 }
 
-func TestRetentionPinSubsecondBoundaryPostgres(t *testing.T) {
-	runRetentionPinSubsecondBoundary(t, seededDB(t, openPostgres))
+func TestPinReleaseConcurrentGC(t *testing.T) {
+	forEngines(t, runPinReleaseConcurrentGC)
 }
 
-func TestPinReleaseRetentionConsequenceSQLite(t *testing.T) {
-	runPinReleaseRetentionConsequence(t, seededDB(t, openSQLite))
+func TestRetentionFailedSweepAudit(t *testing.T) {
+	forEngines(t, runRetentionFailedSweepAudit)
 }
 
-func TestPinReleaseRetentionConsequencePostgres(t *testing.T) {
-	runPinReleaseRetentionConsequence(t, seededDB(t, openPostgres))
-}
-
-func TestPinReleaseConcurrentGCPostgres(t *testing.T) {
-	runPinReleaseConcurrentGC(t, seededDB(t, openPostgres))
-}
-
-func TestPinReleaseConcurrentGCSQLite(t *testing.T) {
-	runPinReleaseConcurrentGC(t, seededDB(t, openSQLite))
-}
-
-func TestRetentionFailedSweepAuditSQLite(t *testing.T) {
-	runRetentionFailedSweepAudit(t, seededDB(t, openSQLite))
-}
-
-func TestRetentionFailedSweepAuditPostgres(t *testing.T) {
-	runRetentionFailedSweepAudit(t, seededDB(t, openPostgres))
-}
-
-func TestRetentionFailedSweepCountsObservedCandidatesSQLite(t *testing.T) {
-	runRetentionFailedSweepCountsObservedCandidates(t, seededDB(t, openSQLite))
-}
-
-func TestRetentionFailedSweepCountsObservedCandidatesPostgres(t *testing.T) {
-	runRetentionFailedSweepCountsObservedCandidates(t, seededDB(t, openPostgres))
+func TestRetentionFailedSweepCountsObservedCandidates(t *testing.T) {
+	forEngines(t, runRetentionFailedSweepCountsObservedCandidates)
 }
 
 func runRetentionFailedSweepAudit(t *testing.T, db *store.DB) {

--- a/internal/isolation/reveal_ceremony_e2e_test.go
+++ b/internal/isolation/reveal_ceremony_e2e_test.go
@@ -177,11 +177,8 @@ func disclosureRows(t *testing.T, db *store.DB) int64 {
 	return queryInt(t, db, "SELECT COUNT(*) FROM audit_tenant_events WHERE type = 'disclosure.value_revealed'")
 }
 
-func TestTOTPOpensARevealWindowSQLite(t *testing.T) {
-	runTOTPOpensARevealWindow(t, seededDB(t, openSQLite))
-}
-func TestTOTPOpensARevealWindowPostgres(t *testing.T) {
-	runTOTPOpensARevealWindow(t, seededDB(t, openPostgres))
+func TestTOTPOpensARevealWindow(t *testing.T) {
+	forEngines(t, runTOTPOpensARevealWindow)
 }
 
 // runTOTPOpensARevealWindow is the possession-factor SUCCESS path.
@@ -274,11 +271,8 @@ func ceremonyCode(t *testing.T, otpauthURI string, at time.Time) string {
 	return code
 }
 
-func TestRevealNeedsACeremonySQLite(t *testing.T) {
-	runRevealNeedsACeremony(t, seededDB(t, openSQLite))
-}
-func TestRevealNeedsACeremonyPostgres(t *testing.T) {
-	runRevealNeedsACeremony(t, seededDB(t, openPostgres))
+func TestRevealNeedsACeremony(t *testing.T) {
+	forEngines(t, runRevealNeedsACeremony)
 }
 
 // runRevealNeedsACeremony: the sliding half. A disclosure with no window is
@@ -368,11 +362,8 @@ func runRevealNeedsACeremony(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestZeroWindowForcesAPasskeyPerDisclosureSQLite(t *testing.T) {
-	runZeroWindowForcesAPasskeyPerDisclosure(t, seededDB(t, openSQLite))
-}
-func TestZeroWindowForcesAPasskeyPerDisclosurePostgres(t *testing.T) {
-	runZeroWindowForcesAPasskeyPerDisclosure(t, seededDB(t, openPostgres))
+func TestZeroWindowForcesAPasskeyPerDisclosure(t *testing.T) {
+	forEngines(t, runZeroWindowForcesAPasskeyPerDisclosure)
 }
 
 // runZeroWindowForcesAPasskeyPerDisclosure is mvp-boundary A5's [E2E] line:
@@ -434,11 +425,8 @@ func runZeroWindowForcesAPasskeyPerDisclosure(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestProtectedEnvironmentCapsTheWindowAtZeroSQLite(t *testing.T) {
-	runProtectedEnvironmentCapsTheWindow(t, seededDB(t, openSQLite))
-}
-func TestProtectedEnvironmentCapsTheWindowAtZeroPostgres(t *testing.T) {
-	runProtectedEnvironmentCapsTheWindow(t, seededDB(t, openPostgres))
+func TestProtectedEnvironmentCapsTheWindowAtZero(t *testing.T) {
+	forEngines(t, runProtectedEnvironmentCapsTheWindow)
 }
 
 // runProtectedEnvironmentCapsTheWindow: the protected flag is not a second
@@ -500,11 +488,8 @@ func runProtectedEnvironmentCapsTheWindow(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestCopySourceTakesTheCeremonySQLite(t *testing.T) {
-	runCopySourceTakesTheCeremony(t, seededDB(t, openSQLite))
-}
-func TestCopySourceTakesTheCeremonyPostgres(t *testing.T) {
-	runCopySourceTakesTheCeremony(t, seededDB(t, openPostgres))
+func TestCopySourceTakesTheCeremony(t *testing.T) {
+	forEngines(t, runCopySourceTakesTheCeremony)
 }
 
 // runCopySourceTakesTheCeremony: copy is a disclosure by proxy — the material
@@ -565,12 +550,8 @@ func runCopySourceTakesTheCeremony(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestRestorePinAndProtectedPublishTakeCeremoniesSQLite(t *testing.T) {
-	runRestorePinAndProtectedPublishTakeCeremonies(t, seededDB(t, openSQLite))
-}
-
-func TestRestorePinAndProtectedPublishTakeCeremoniesPostgres(t *testing.T) {
-	runRestorePinAndProtectedPublishTakeCeremonies(t, seededDB(t, openPostgres))
+func TestRestorePinAndProtectedPublishTakeCeremonies(t *testing.T) {
+	forEngines(t, runRestorePinAndProtectedPublishTakeCeremonies)
 }
 
 func runRestorePinAndProtectedPublishTakeCeremonies(t *testing.T, db *store.DB) {
@@ -647,11 +628,8 @@ func runRestorePinAndProtectedPublishTakeCeremonies(t *testing.T, db *store.DB) 
 	}
 }
 
-func TestAMachineNeverReauthenticatesSQLite(t *testing.T) {
-	runAMachineNeverReauthenticates(t, seededDB(t, openSQLite))
-}
-func TestAMachineNeverReauthenticatesPostgres(t *testing.T) {
-	runAMachineNeverReauthenticates(t, seededDB(t, openPostgres))
+func TestAMachineNeverReauthenticates(t *testing.T) {
+	forEngines(t, runAMachineNeverReauthenticates)
 }
 
 // runAMachineNeverReauthenticates: "the token IS the credential and there is
@@ -729,11 +707,8 @@ func runAMachineNeverReauthenticates(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestProtectedDestinationRefusesAConfirmationFlagSQLite(t *testing.T) {
-	runProtectedDestinationRefusesAConfirmationFlag(t, seededDB(t, openSQLite))
-}
-func TestProtectedDestinationRefusesAConfirmationFlagPostgres(t *testing.T) {
-	runProtectedDestinationRefusesAConfirmationFlag(t, seededDB(t, openPostgres))
+func TestProtectedDestinationRefusesAConfirmationFlag(t *testing.T) {
+	forEngines(t, runProtectedDestinationRefusesAConfirmationFlag)
 }
 
 // runProtectedDestinationRefusesAConfirmationFlag (review R1 finding 1): a
@@ -787,11 +762,8 @@ func runProtectedDestinationRefusesAConfirmationFlag(t *testing.T, db *store.DB)
 	}
 }
 
-func TestACeremonyIsBoundToItsPurposeSQLite(t *testing.T) {
-	runACeremonyIsBoundToItsPurpose(t, seededDB(t, openSQLite))
-}
-func TestACeremonyIsBoundToItsPurposePostgres(t *testing.T) {
-	runACeremonyIsBoundToItsPurpose(t, seededDB(t, openPostgres))
+func TestACeremonyIsBoundToItsPurpose(t *testing.T) {
+	forEngines(t, runACeremonyIsBoundToItsPurpose)
 }
 
 // runACeremonyIsBoundToItsPurpose (review R1 finding 3): "purpose-bound" has to
@@ -834,11 +806,8 @@ func runACeremonyIsBoundToItsPurpose(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestTheTOTPRouteIsNotAnEnvironmentOracleSQLite(t *testing.T) {
-	runTheTOTPRouteIsNotAnEnvironmentOracle(t, seededDB(t, openSQLite))
-}
-func TestTheTOTPRouteIsNotAnEnvironmentOraclePostgres(t *testing.T) {
-	runTheTOTPRouteIsNotAnEnvironmentOracle(t, seededDB(t, openPostgres))
+func TestTheTOTPRouteIsNotAnEnvironmentOracle(t *testing.T) {
+	forEngines(t, runTheTOTPRouteIsNotAnEnvironmentOracle)
 }
 
 // runTheTOTPRouteIsNotAnEnvironmentOracle (review R1 finding 4): the route
@@ -873,11 +842,8 @@ func runTheTOTPRouteIsNotAnEnvironmentOracle(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestConcurrentCeremoniesSupersedeSQLite(t *testing.T) {
-	runConcurrentCeremoniesSupersede(t, seededDB(t, openSQLite))
-}
-func TestConcurrentCeremoniesSupersedePostgres(t *testing.T) {
-	runConcurrentCeremoniesSupersede(t, seededDB(t, openPostgres))
+func TestConcurrentCeremoniesSupersede(t *testing.T) {
+	forEngines(t, runConcurrentCeremoniesSupersede)
 }
 
 // runConcurrentCeremoniesSupersede (review R1 finding 6): two tabs finishing a
@@ -955,11 +921,8 @@ func runConcurrentCeremoniesSupersede(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestAWindowExpiringDuringACopyIsNotSpentSQLite(t *testing.T) {
-	runAWindowExpiringDuringACopyIsNotSpent(t, seededDB(t, openSQLite))
-}
-func TestAWindowExpiringDuringACopyIsNotSpentPostgres(t *testing.T) {
-	runAWindowExpiringDuringACopyIsNotSpent(t, seededDB(t, openPostgres))
+func TestAWindowExpiringDuringACopyIsNotSpent(t *testing.T) {
+	forEngines(t, runAWindowExpiringDuringACopyIsNotSpent)
 }
 
 // runAWindowExpiringDuringACopyIsNotSpent (review R1 finding 2): consumption
@@ -1028,11 +991,8 @@ func runAWindowExpiringDuringACopyIsNotSpent(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestThePasskeyRouteIsNotAnEnvironmentOracleSQLite(t *testing.T) {
-	runThePasskeyRouteIsNotAnEnvironmentOracle(t, seededDB(t, openSQLite))
-}
-func TestThePasskeyRouteIsNotAnEnvironmentOraclePostgres(t *testing.T) {
-	runThePasskeyRouteIsNotAnEnvironmentOracle(t, seededDB(t, openPostgres))
+func TestThePasskeyRouteIsNotAnEnvironmentOracle(t *testing.T) {
+	forEngines(t, runThePasskeyRouteIsNotAnEnvironmentOracle)
 }
 
 // runThePasskeyRouteIsNotAnEnvironmentOracle (review R2): the passkey reauth

--- a/internal/isolation/saml_e2e_test.go
+++ b/internal/isolation/saml_e2e_test.go
@@ -304,12 +304,8 @@ func runSAMLLoginReplay(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestSAMLLoginReplaySQLite(t *testing.T) {
-	runSAMLLoginReplay(t, seededDB(t, openSQLite))
-}
-
-func TestSAMLLoginReplayPostgres(t *testing.T) {
-	runSAMLLoginReplay(t, seededDB(t, openPostgres))
+func TestSAMLLoginReplay(t *testing.T) {
+	forEngines(t, runSAMLLoginReplay)
 }
 
 func runSAMLProviderRecreation(t *testing.T, db *store.DB) {
@@ -370,12 +366,8 @@ func runSAMLProviderRecreation(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestSAMLProviderRecreationSQLite(t *testing.T) {
-	runSAMLProviderRecreation(t, seededDB(t, openSQLite))
-}
-
-func TestSAMLProviderRecreationPostgres(t *testing.T) {
-	runSAMLProviderRecreation(t, seededDB(t, openPostgres))
+func TestSAMLProviderRecreation(t *testing.T) {
+	forEngines(t, runSAMLProviderRecreation)
 }
 
 func runSAMLSPKeyLifecycle(t *testing.T, db *store.DB) {
@@ -442,10 +434,6 @@ func runSAMLSPKeyLifecycle(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestSAMLSPKeyLifecycleSQLite(t *testing.T) {
-	runSAMLSPKeyLifecycle(t, seededDB(t, openSQLite))
-}
-
-func TestSAMLSPKeyLifecyclePostgres(t *testing.T) {
-	runSAMLSPKeyLifecycle(t, seededDB(t, openPostgres))
+func TestSAMLSPKeyLifecycle(t *testing.T) {
+	forEngines(t, runSAMLSPKeyLifecycle)
 }

--- a/internal/isolation/scanning_sweep_e2e_test.go
+++ b/internal/isolation/scanning_sweep_e2e_test.go
@@ -214,12 +214,8 @@ type sweepEnv struct {
 // already consumed the first-admin slot). It emits its own scanning events, so
 // it does not need the audit closure gate to give those types an emitter —
 // runScanningLifecycle already does that.
-func TestScanningCanarySweepSQLite(t *testing.T) {
-	runScanningCanarySweep(t, seededDB(t, openSQLite))
-}
-
-func TestScanningCanarySweepPostgres(t *testing.T) {
-	runScanningCanarySweep(t, seededDB(t, openPostgres))
+func TestScanningCanarySweep(t *testing.T) {
+	forEngines(t, runScanningCanarySweep)
 }
 
 // runScanningCanarySweep is SS4.a made real: it plants the canary, drives every

--- a/internal/isolation/scim_audit_coverage_test.go
+++ b/internal/isolation/scim_audit_coverage_test.go
@@ -22,11 +22,8 @@ import (
 // TestSCIMOriginTupleIsExact is SC3.a: every expanded capability row carries a
 // `scim` origin whose FULL (binding, mapping row, group) tuple is exact. A
 // substring match on the mapping id proved only that something mentioned it.
-func TestSCIMOriginTupleIsExactSQLite(t *testing.T) {
-	runSCIMOriginTupleIsExact(t, seededDB(t, openSQLite))
-}
-func TestSCIMOriginTupleIsExactPostgres(t *testing.T) {
-	runSCIMOriginTupleIsExact(t, seededDB(t, openPostgres))
+func TestSCIMOriginTupleIsExact(t *testing.T) {
+	forEngines(t, runSCIMOriginTupleIsExact)
 }
 
 func runSCIMOriginTupleIsExact(t *testing.T, db *store.DB) {
@@ -82,9 +79,8 @@ func runSCIMOriginTupleIsExact(t *testing.T, db *store.DB) {
 
 // TestSCIMMultiGroupUnion is SC3.c: a user in several mapped groups gets the
 // additive UNION, and losing one group leaves the other's grants standing.
-func TestSCIMMultiGroupUnionSQLite(t *testing.T) { runSCIMMultiGroupUnion(t, seededDB(t, openSQLite)) }
-func TestSCIMMultiGroupUnionPostgres(t *testing.T) {
-	runSCIMMultiGroupUnion(t, seededDB(t, openPostgres))
+func TestSCIMMultiGroupUnion(t *testing.T) {
+	forEngines(t, runSCIMMultiGroupUnion)
 }
 
 func runSCIMMultiGroupUnion(t *testing.T, db *store.DB) {
@@ -152,11 +148,8 @@ func runSCIMMultiGroupUnion(t *testing.T, db *store.DB) {
 // TestSCIMMappingWidenAndNarrow is SC3.e and SC3.f: widening grants the newly
 // covered capabilities in the AUTHORING transaction, and narrowing releases the
 // no-longer-covered part — both without any sync in between.
-func TestSCIMMappingWidenAndNarrowSQLite(t *testing.T) {
-	runSCIMMappingWidenAndNarrow(t, seededDB(t, openSQLite))
-}
-func TestSCIMMappingWidenAndNarrowPostgres(t *testing.T) {
-	runSCIMMappingWidenAndNarrow(t, seededDB(t, openPostgres))
+func TestSCIMMappingWidenAndNarrow(t *testing.T) {
+	forEngines(t, runSCIMMappingWidenAndNarrow)
 }
 
 func runSCIMMappingWidenAndNarrow(t *testing.T, db *store.DB) {
@@ -244,12 +237,8 @@ func runSCIMMappingWidenAndNarrow(t *testing.T, db *store.DB) {
 // conditional half of the release settlement policy. Narrowing can release an
 // origin without changing effective authority when another mapping still holds
 // every affected grant row; that must not kill the user's sessions.
-func TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvanceSQLite(t *testing.T) {
-	runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t, seededDB(t, openSQLite))
-}
-
-func TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvancePostgres(t *testing.T) {
-	runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t, seededDB(t, openPostgres))
+func TestSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t *testing.T) {
+	forEngines(t, runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance)
 }
 
 func runSCIMMappingNarrowingWithoutAuthorityDeltaDoesNotAdvance(t *testing.T, db *store.DB) {
@@ -514,11 +503,8 @@ func auditCount(t *testing.T, db *store.DB, typ string) int64 {
 
 // TestSCIMStalenessThreshold is SC4.a: staleness raises AND clears, and it is a
 // THRESHOLD — a binding is not stale the moment it exists.
-func TestSCIMStalenessThresholdSQLite(t *testing.T) {
-	runSCIMStalenessThreshold(t, seededDB(t, openSQLite))
-}
-func TestSCIMStalenessThresholdPostgres(t *testing.T) {
-	runSCIMStalenessThreshold(t, seededDB(t, openPostgres))
+func TestSCIMStalenessThreshold(t *testing.T) {
+	forEngines(t, runSCIMStalenessThreshold)
 }
 
 func runSCIMStalenessThreshold(t *testing.T, db *store.DB) {
@@ -583,11 +569,8 @@ func runSCIMStalenessThreshold(t *testing.T, db *store.DB) {
 // TestSCIMAttentionStatePairs is SC4.i: EVERY attention state is entered and
 // cleared with its audit pair. A state that can be entered and not left is a
 // permanent warning nobody can act on.
-func TestSCIMAttentionStatePairsSQLite(t *testing.T) {
-	runSCIMAttentionStatePairs(t, seededDB(t, openSQLite))
-}
-func TestSCIMAttentionStatePairsPostgres(t *testing.T) {
-	runSCIMAttentionStatePairs(t, seededDB(t, openPostgres))
+func TestSCIMAttentionStatePairs(t *testing.T) {
+	forEngines(t, runSCIMAttentionStatePairs)
 }
 
 func runSCIMAttentionStatePairs(t *testing.T, db *store.DB) {
@@ -986,11 +969,8 @@ func sampleFor(f audit.FieldSpec) any {
 // TestSCIMRedactsIdPStrings is SC4.m: an identity-provider-supplied string that
 // happens to look like a bearer token must be REDACTED before it lands in the
 // trail. The identity provider is an attacker-influencable source.
-func TestSCIMRedactsIdPStringsSQLite(t *testing.T) {
-	runSCIMRedactsIdPStrings(t, seededDB(t, openSQLite))
-}
-func TestSCIMRedactsIdPStringsPostgres(t *testing.T) {
-	runSCIMRedactsIdPStrings(t, seededDB(t, openPostgres))
+func TestSCIMRedactsIdPStrings(t *testing.T) {
+	forEngines(t, runSCIMRedactsIdPStrings)
 }
 
 func runSCIMRedactsIdPStrings(t *testing.T, db *store.DB) {

--- a/internal/isolation/scim_concurrency_test.go
+++ b/internal/isolation/scim_concurrency_test.go
@@ -32,11 +32,8 @@ func barrier(n int) (start chan struct{}, done *sync.WaitGroup) {
 // TestSCIMBindingUniquenessRace is SC1.m: two concurrent creates for one
 // (org, provider) resolve to ONE row, and the loser is refused with the named
 // conflict rather than being reconciled in application code.
-func TestSCIMBindingUniquenessRaceSQLite(t *testing.T) {
-	runSCIMBindingUniquenessRace(t, seededDB(t, openSQLite))
-}
-func TestSCIMBindingUniquenessRacePostgres(t *testing.T) {
-	runSCIMBindingUniquenessRace(t, seededDB(t, openPostgres))
+func TestSCIMBindingUniquenessRace(t *testing.T) {
+	forEngines(t, runSCIMBindingUniquenessRace)
 }
 
 func runSCIMBindingUniquenessRace(t *testing.T, db *store.DB) {
@@ -88,11 +85,8 @@ func runSCIMBindingUniquenessRace(t *testing.T, db *store.DB) {
 // identity at once yield ONE account. §5.2's constraint arbitrates and "the
 // loser retries and attaches" — so BOTH calls must succeed, and both resources
 // must point at one account.
-func TestSCIMConcurrentDuplicateCreateSQLite(t *testing.T) {
-	runSCIMConcurrentDuplicateCreate(t, seededDB(t, openSQLite))
-}
-func TestSCIMConcurrentDuplicateCreatePostgres(t *testing.T) {
-	runSCIMConcurrentDuplicateCreate(t, seededDB(t, openPostgres))
+func TestSCIMConcurrentDuplicateCreate(t *testing.T) {
+	forEngines(t, runSCIMConcurrentDuplicateCreate)
 }
 
 func runSCIMConcurrentDuplicateCreate(t *testing.T, db *store.DB) {
@@ -241,11 +235,8 @@ func scimBindingInOrg(t *testing.T, db *store.DB, org domain.OrgID, slug string)
 // released, then the connection retired, then the directory and the binding
 // gone. An end-state assertion cannot tell a correct order from a wrong one
 // that happens to converge, so the order itself is observed.
-func TestSCIMTeardownPhaseOrderSQLite(t *testing.T) {
-	runSCIMTeardownPhaseOrder(t, seededDB(t, openSQLite))
-}
-func TestSCIMTeardownPhaseOrderPostgres(t *testing.T) {
-	runSCIMTeardownPhaseOrder(t, seededDB(t, openPostgres))
+func TestSCIMTeardownPhaseOrder(t *testing.T) {
+	forEngines(t, runSCIMTeardownPhaseOrder)
 }
 
 func runSCIMTeardownPhaseOrder(t *testing.T, db *store.DB) {
@@ -443,11 +434,8 @@ func runSCIMTeardownPhaseOrder(t *testing.T, db *store.DB) {
 // hypothetically unserialized second transaction has a wide window to enter and
 // be caught. Without it the race would have to lose a coin flip to fail, and a
 // fixture that only sometimes sees the defect is not a fixture.
-func TestSCIMPerBindingSerializationOrderSQLite(t *testing.T) {
-	runSCIMPerBindingSerializationOrder(t, seededDB(t, openSQLite))
-}
-func TestSCIMPerBindingSerializationOrderPostgres(t *testing.T) {
-	runSCIMPerBindingSerializationOrder(t, seededDB(t, openPostgres))
+func TestSCIMPerBindingSerializationOrder(t *testing.T) {
+	forEngines(t, runSCIMPerBindingSerializationOrder)
 }
 
 func runSCIMPerBindingSerializationOrder(t *testing.T, db *store.DB) {
@@ -617,11 +605,8 @@ func runSCIMPerBindingSerializationOrder(t *testing.T, db *store.DB) {
 // same serialized phase as the wire surface. The operations are exercised one
 // at a time so a missing pair names the exact caller that escaped the common
 // preamble.
-func TestSCIMAdminMutationsMarkSerializedPhaseSQLite(t *testing.T) {
-	runSCIMAdminMutationsMarkSerializedPhase(t, seededDB(t, openSQLite))
-}
-func TestSCIMAdminMutationsMarkSerializedPhasePostgres(t *testing.T) {
-	runSCIMAdminMutationsMarkSerializedPhase(t, seededDB(t, openPostgres))
+func TestSCIMAdminMutationsMarkSerializedPhase(t *testing.T) {
+	forEngines(t, runSCIMAdminMutationsMarkSerializedPhase)
 }
 
 func runSCIMAdminMutationsMarkSerializedPhase(t *testing.T, db *store.DB) {
@@ -689,11 +674,8 @@ func runSCIMAdminMutationsMarkSerializedPhase(t *testing.T, db *store.DB) {
 // TestSCIMSyncInvalidatesSessions is SC4.d: "being granted anything logs you
 // out, and a sync is a granter". A group-driven grant advances the affected
 // human's session generation and sweeps their sessions.
-func TestSCIMSyncInvalidatesSessionsSQLite(t *testing.T) {
-	runSCIMSyncInvalidatesSessions(t, seededDB(t, openSQLite))
-}
-func TestSCIMSyncInvalidatesSessionsPostgres(t *testing.T) {
-	runSCIMSyncInvalidatesSessions(t, seededDB(t, openPostgres))
+func TestSCIMSyncInvalidatesSessions(t *testing.T) {
+	forEngines(t, runSCIMSyncInvalidatesSessions)
 }
 
 func runSCIMSyncInvalidatesSessions(t *testing.T, db *store.DB) {

--- a/internal/isolation/scim_credential_test.go
+++ b/internal/isolation/scim_credential_test.go
@@ -16,11 +16,8 @@ import (
 // in one place — the mint gate, display-once, overlap rotation, revocation
 // biting at the NEXT request, the lifetime ceiling, and indefinite refused
 // while the instance has not opted in.
-func TestSCIMCredentialLifecycleSQLite(t *testing.T) {
-	runSCIMCredentialLifecycle(t, seededDB(t, openSQLite))
-}
-func TestSCIMCredentialLifecyclePostgres(t *testing.T) {
-	runSCIMCredentialLifecycle(t, seededDB(t, openPostgres))
+func TestSCIMCredentialLifecycle(t *testing.T) {
+	forEngines(t, runSCIMCredentialLifecycle)
 }
 
 func runSCIMCredentialLifecycle(t *testing.T, db *store.DB) {

--- a/internal/isolation/scim_e2e_test.go
+++ b/internal/isolation/scim_e2e_test.go
@@ -85,11 +85,8 @@ func newSCIMBinding(t *testing.T, db *store.DB, slug string) (string, string) {
 }
 
 // TestSCIMBindingLifecycle proves §1's tenancy rules and §7's structural grant.
-func TestSCIMBindingLifecycleSQLite(t *testing.T) {
-	runSCIMBindingLifecycle(t, seededDB(t, openSQLite))
-}
-func TestSCIMBindingLifecyclePostgres(t *testing.T) {
-	runSCIMBindingLifecycle(t, seededDB(t, openPostgres))
+func TestSCIMBindingLifecycle(t *testing.T) {
+	forEngines(t, runSCIMBindingLifecycle)
 }
 
 func runSCIMBindingLifecycle(t *testing.T, db *store.DB) {
@@ -160,8 +157,9 @@ func runSCIMBindingLifecycle(t *testing.T, db *store.DB) {
 
 // TestSCIMUserLifecycle walks §5.4's transition table: create, attribute
 // update, deactivate, reactivate, delete, re-create.
-func TestSCIMUserLifecycleSQLite(t *testing.T)   { runSCIMUserLifecycle(t, seededDB(t, openSQLite)) }
-func TestSCIMUserLifecyclePostgres(t *testing.T) { runSCIMUserLifecycle(t, seededDB(t, openPostgres)) }
+func TestSCIMUserLifecycle(t *testing.T) {
+	forEngines(t, runSCIMUserLifecycle)
+}
 
 func runSCIMUserLifecycle(t *testing.T, db *store.DB) {
 	s := scimSvc(db)
@@ -301,11 +299,8 @@ func runSCIMUserLifecycle(t *testing.T, db *store.DB) {
 
 // TestSCIMMappingReconciliation proves §2's overlap rules, §3's immediate
 // application and blast warnings, and §4's hand-mutation refusal.
-func TestSCIMMappingReconciliationSQLite(t *testing.T) {
-	runSCIMMappingReconciliation(t, seededDB(t, openSQLite))
-}
-func TestSCIMMappingReconciliationPostgres(t *testing.T) {
-	runSCIMMappingReconciliation(t, seededDB(t, openPostgres))
+func TestSCIMMappingReconciliation(t *testing.T) {
+	forEngines(t, runSCIMMappingReconciliation)
 }
 
 func runSCIMMappingReconciliation(t *testing.T, db *store.DB) {
@@ -416,11 +411,8 @@ func runSCIMMappingReconciliation(t *testing.T, db *store.DB) {
 
 // TestSCIMLockoutRetention proves §2.4: the SCIM-side release CONVERTS rather
 // than refusing, and the cure releases the retention deterministically.
-func TestSCIMLockoutRetentionSQLite(t *testing.T) {
-	runSCIMLockoutRetention(t, seededDB(t, openSQLite))
-}
-func TestSCIMLockoutRetentionPostgres(t *testing.T) {
-	runSCIMLockoutRetention(t, seededDB(t, openPostgres))
+func TestSCIMLockoutRetention(t *testing.T) {
+	forEngines(t, runSCIMLockoutRetention)
 }
 
 func runSCIMLockoutRetention(t *testing.T, db *store.DB) {
@@ -505,11 +497,8 @@ func runSCIMLockoutRetention(t *testing.T, db *store.DB) {
 // TestSCIMProviderFailClosed proves §1: while the referenced provider is
 // disabled or removed, the binding's ENTIRE wire surface refuses — read and
 // write alike — state is preserved, and the attention state names it.
-func TestSCIMProviderFailClosedSQLite(t *testing.T) {
-	runSCIMProviderFailClosed(t, seededDB(t, openSQLite))
-}
-func TestSCIMProviderFailClosedPostgres(t *testing.T) {
-	runSCIMProviderFailClosed(t, seededDB(t, openPostgres))
+func TestSCIMProviderFailClosed(t *testing.T) {
+	forEngines(t, runSCIMProviderFailClosed)
 }
 
 func runSCIMProviderFailClosed(t *testing.T, db *store.DB) {
@@ -834,11 +823,8 @@ func jsonTypeOf(v any) string {
 // TestSCIMPutReplacementSemantics is SC1's PUT clause (§8): omitted mutable
 // attributes clear to their defaults, an omitted `active` REACTIVATES, the
 // subject source is EXEMPT from replacement, and `groups` is ignored on input.
-func TestSCIMPutReplacementSemanticsSQLite(t *testing.T) {
-	runSCIMPutReplacementSemantics(t, seededDB(t, openSQLite))
-}
-func TestSCIMPutReplacementSemanticsPostgres(t *testing.T) {
-	runSCIMPutReplacementSemantics(t, seededDB(t, openPostgres))
+func TestSCIMPutReplacementSemantics(t *testing.T) {
+	forEngines(t, runSCIMPutReplacementSemantics)
 }
 
 func runSCIMPutReplacementSemantics(t *testing.T, db *store.DB) {
@@ -1017,9 +1003,8 @@ func runSCIMPutReplacementSemantics(t *testing.T, db *store.DB) {
 // are delivery/display metadata ONLY — never matched, never a linking key
 // (§5.2). A pushed email equal to an existing unrelated account's email must
 // NOT attach to it.
-func TestSCIMEmailNeverLinksSQLite(t *testing.T) { runSCIMEmailNeverLinks(t, seededDB(t, openSQLite)) }
-func TestSCIMEmailNeverLinksPostgres(t *testing.T) {
-	runSCIMEmailNeverLinks(t, seededDB(t, openPostgres))
+func TestSCIMEmailNeverLinks(t *testing.T) {
+	forEngines(t, runSCIMEmailNeverLinks)
 }
 
 func runSCIMEmailNeverLinks(t *testing.T, db *store.DB) {
@@ -1063,11 +1048,8 @@ func runSCIMEmailNeverLinks(t *testing.T, db *store.DB) {
 // unique and the ADR's closed uniqueness mapping names only `userName` and a
 // subject-source collision, so two same-named groups coexist and the
 // `displayName eq` probe answers with both.
-func TestSCIMGroupDisplayNameIsNotUniqueSQLite(t *testing.T) {
-	runSCIMGroupDisplayNameIsNotUnique(t, seededDB(t, openSQLite))
-}
-func TestSCIMGroupDisplayNameIsNotUniquePostgres(t *testing.T) {
-	runSCIMGroupDisplayNameIsNotUnique(t, seededDB(t, openPostgres))
+func TestSCIMGroupDisplayNameIsNotUnique(t *testing.T) {
+	forEngines(t, runSCIMGroupDisplayNameIsNotUnique)
 }
 
 func runSCIMGroupDisplayNameIsNotUnique(t *testing.T, db *store.DB) {
@@ -1108,11 +1090,8 @@ func runSCIMGroupDisplayNameIsNotUnique(t *testing.T, db *store.DB) {
 // other identity provider's assertion, and nothing about it needs a human
 // decision. Widening the flag to cover it would send an operator looking for a
 // manual grant that does not exist.
-func TestSCIMManualRemainsMeansManualSQLite(t *testing.T) {
-	runSCIMManualRemainsMeansManual(t, seededDB(t, openSQLite))
-}
-func TestSCIMManualRemainsMeansManualPostgres(t *testing.T) {
-	runSCIMManualRemainsMeansManual(t, seededDB(t, openPostgres))
+func TestSCIMManualRemainsMeansManual(t *testing.T) {
+	forEngines(t, runSCIMManualRemainsMeansManual)
 }
 
 func runSCIMManualRemainsMeansManual(t *testing.T, db *store.DB) {

--- a/internal/isolation/scim_invariants_test.go
+++ b/internal/isolation/scim_invariants_test.go
@@ -105,11 +105,8 @@ func TestSCIMWireIsNotMFAMandatory(t *testing.T) {
 // operation". A provisioning credential authenticates the IdP's wire and
 // nothing else: presented as a human session artifact it must be refused, and
 // refused UNIFORMLY — indistinguishable from a value that names nothing.
-func TestSCIMCredentialIsRejectedOnNonSCIMOperationsSQLite(t *testing.T) {
-	runSCIMCredentialRejected(t, seededDB(t, openSQLite))
-}
-func TestSCIMCredentialIsRejectedOnNonSCIMOperationsPostgres(t *testing.T) {
-	runSCIMCredentialRejected(t, seededDB(t, openPostgres))
+func TestSCIMCredentialIsRejectedOnNonSCIMOperations(t *testing.T) {
+	forEngines(t, runSCIMCredentialRejected)
 }
 
 func runSCIMCredentialRejected(t *testing.T, db *store.DB) {
@@ -280,11 +277,8 @@ func TestSCIMOriginKindsAreNotHumanReleasable(t *testing.T) {
 // identity link), which is why the assertion is on the RESOLUTION path — the
 // lookup that decides between them — and not on the whole transaction: the
 // branch is what must be indistinguishable, not the work each branch does.
-func TestSCIMCreateIsOneQueryPathSQLite(t *testing.T) {
-	runSCIMCreateIsOneQueryPath(t, seededDB(t, openSQLite))
-}
-func TestSCIMCreateIsOneQueryPathPostgres(t *testing.T) {
-	runSCIMCreateIsOneQueryPath(t, seededDB(t, openPostgres))
+func TestSCIMCreateIsOneQueryPath(t *testing.T) {
+	forEngines(t, runSCIMCreateIsOneQueryPath)
 }
 
 func runSCIMCreateIsOneQueryPath(t *testing.T, db *store.DB) {
@@ -440,11 +434,8 @@ func removeRun(trace, run []string) ([]string, bool) {
 // initial push emits 500 `scim.user_provisioned` events plus their grant
 // events, per-event, durably". The aggregation licence covers
 // authentication-failure floods only.
-func TestSCIMPushEmitsPerEventSQLite(t *testing.T) {
-	runSCIMPushEmitsPerEvent(t, seededDB(t, openSQLite))
-}
-func TestSCIMPushEmitsPerEventPostgres(t *testing.T) {
-	runSCIMPushEmitsPerEvent(t, seededDB(t, openPostgres))
+func TestSCIMPushEmitsPerEvent(t *testing.T) {
+	forEngines(t, runSCIMPushEmitsPerEvent)
 }
 
 func runSCIMPushEmitsPerEvent(t *testing.T, db *store.DB) {

--- a/internal/isolation/scim_login_e2e_test.go
+++ b/internal/isolation/scim_login_e2e_test.go
@@ -25,11 +25,8 @@ import (
 
 // TestSCIMProvisionThenLoginOIDC is the OKTA-SHAPED fixture: the subject source
 // value IS the OIDC `sub`, consumed as opaque bytes.
-func TestSCIMProvisionThenLoginOIDCSQLite(t *testing.T) {
-	runSCIMProvisionThenLoginOIDC(t, seededDB(t, openSQLite))
-}
-func TestSCIMProvisionThenLoginOIDCPostgres(t *testing.T) {
-	runSCIMProvisionThenLoginOIDC(t, seededDB(t, openPostgres))
+func TestSCIMProvisionThenLoginOIDC(t *testing.T) {
+	forEngines(t, runSCIMProvisionThenLoginOIDC)
 }
 
 func runSCIMProvisionThenLoginOIDC(t *testing.T, db *store.DB) {
@@ -109,11 +106,8 @@ func runSCIMProvisionThenLoginOIDC(t *testing.T, db *store.DB) {
 // encoder-equality test: get the profile wrong — a qualifier declared absent
 // that the assertion carries, say — and the two subjects differ and the login
 // finds nothing.
-func TestSCIMProvisionThenLoginSAMLSQLite(t *testing.T) {
-	runSCIMProvisionThenLoginSAML(t, seededDB(t, openSQLite))
-}
-func TestSCIMProvisionThenLoginSAMLPostgres(t *testing.T) {
-	runSCIMProvisionThenLoginSAML(t, seededDB(t, openPostgres))
+func TestSCIMProvisionThenLoginSAML(t *testing.T) {
+	forEngines(t, runSCIMProvisionThenLoginSAML)
 }
 
 const samlSPEntityID = "https://hikyo.test/api/v1/auth/saml"
@@ -198,9 +192,8 @@ func samlLoginAs(t *testing.T, auth *service.Auth, idp *samltest.IdP, nameID str
 
 // TestSCIMTwoBindingRace is SC3's named fixture: two bindings contending on ONE
 // shared grant row. No lost origin, no premature revocation.
-func TestSCIMTwoBindingRaceSQLite(t *testing.T) { runSCIMTwoBindingRace(t, seededDB(t, openSQLite)) }
-func TestSCIMTwoBindingRacePostgres(t *testing.T) {
-	runSCIMTwoBindingRace(t, seededDB(t, openPostgres))
+func TestSCIMTwoBindingRace(t *testing.T) {
+	forEngines(t, runSCIMTwoBindingRace)
 }
 
 func runSCIMTwoBindingRace(t *testing.T, db *store.DB) {
@@ -334,11 +327,8 @@ func runSCIMTwoBindingRace(t *testing.T, db *store.DB) {
 // concurrent pushes". The property asserted is the observable one: concurrent
 // pushes to ONE binding lose no write. Every wire transaction takes the binding
 // row's write lock as its first act (`wireTx`), so they serialize behind it.
-func TestSCIMPerBindingSerializationSQLite(t *testing.T) {
-	runSCIMPerBindingSerialization(t, seededDB(t, openSQLite))
-}
-func TestSCIMPerBindingSerializationPostgres(t *testing.T) {
-	runSCIMPerBindingSerialization(t, seededDB(t, openPostgres))
+func TestSCIMPerBindingSerialization(t *testing.T) {
+	forEngines(t, runSCIMPerBindingSerialization)
 }
 
 func runSCIMPerBindingSerialization(t *testing.T, db *store.DB) {
@@ -404,11 +394,8 @@ func runSCIMPerBindingSerialization(t *testing.T, db *store.DB) {
 // §9.1's sentence is precise about this: re-assertion "rebuilds exactly what
 // the IdP currently asserts". Reconciliation refuses archived truth; it does
 // not get to destroy live truth.
-func TestSCIMReconcileKeepsFreshOriginsSQLite(t *testing.T) {
-	runSCIMReconcileKeepsFreshOrigins(t, seededDB(t, openSQLite))
-}
-func TestSCIMReconcileKeepsFreshOriginsPostgres(t *testing.T) {
-	runSCIMReconcileKeepsFreshOrigins(t, seededDB(t, openPostgres))
+func TestSCIMReconcileKeepsFreshOrigins(t *testing.T) {
+	forEngines(t, runSCIMReconcileKeepsFreshOrigins)
 }
 
 func runSCIMReconcileKeepsFreshOrigins(t *testing.T, db *store.DB) {
@@ -525,8 +512,9 @@ func runSCIMReconcileKeepsFreshOrigins(t *testing.T, db *store.DB) {
 // dropped at reconciliation commit" — is blocked on #76's quarantine/commit
 // flow and is pinned by TestSCIMRestoreOriginDropIsBlockedOn76 below, which
 // fails loudly the day that flow exists.
-func TestSCIMRestoreDrillSQLite(t *testing.T)   { runSCIMRestoreDrill(t, seededDB(t, openSQLite)) }
-func TestSCIMRestoreDrillPostgres(t *testing.T) { runSCIMRestoreDrill(t, seededDB(t, openPostgres)) }
+func TestSCIMRestoreDrill(t *testing.T) {
+	forEngines(t, runSCIMRestoreDrill)
+}
 
 func runSCIMRestoreDrill(t *testing.T, db *store.DB) {
 	ctx := t.Context()

--- a/internal/isolation/scim_provider_sequence_test.go
+++ b/internal/isolation/scim_provider_sequence_test.go
@@ -444,8 +444,9 @@ func assertSCIM501(t *testing.T, body map[string]any) {
 // creates, and for every group runs `displayName eq` before it creates or
 // updates — so the probe-then-write pairs here are the connector's own control
 // flow, not a test's convenience.
-func TestSCIMOktaSequenceSQLite(t *testing.T)   { runSCIMOktaSequence(t, seededDB(t, openSQLite)) }
-func TestSCIMOktaSequencePostgres(t *testing.T) { runSCIMOktaSequence(t, seededDB(t, openPostgres)) }
+func TestSCIMOktaSequence(t *testing.T) {
+	forEngines(t, runSCIMOktaSequence)
+}
 
 func runSCIMOktaSequence(t *testing.T, db *store.DB) {
 	_, _, call := scimWireServer(t, db, "okta")
@@ -669,11 +670,8 @@ func runSCIMOktaSequence(t *testing.T, db *store.DB) {
 // contract-layer constraint on a SCIM parameter would answer an unauthenticated
 // caller with a Hikyo 400 — telling them their request was malformed before they
 // proved they may ask — instead of the uniform 401.
-func TestSCIMWireRefusesNothingBeforeAuthenticatingSQLite(t *testing.T) {
-	runSCIMWireAuthBeforeValidation(t, seededDB(t, openSQLite))
-}
-func TestSCIMWireRefusesNothingBeforeAuthenticatingPostgres(t *testing.T) {
-	runSCIMWireAuthBeforeValidation(t, seededDB(t, openPostgres))
+func TestSCIMWireRefusesNothingBeforeAuthenticating(t *testing.T) {
+	forEngines(t, runSCIMWireAuthBeforeValidation)
 }
 
 func runSCIMWireAuthBeforeValidation(t *testing.T, db *store.DB) {
@@ -746,8 +744,9 @@ func runSCIMWireAuthBeforeValidation(t *testing.T, db *store.DB) {
 // rather than `userName`, it sends `active` as the STRINGS "True"/"False", and
 // it sends pathless PATCH value objects rather than attribute paths. Each of
 // those is a fixture here, driven over the wire.
-func TestSCIMEntraSequenceSQLite(t *testing.T)   { runSCIMEntraSequence(t, seededDB(t, openSQLite)) }
-func TestSCIMEntraSequencePostgres(t *testing.T) { runSCIMEntraSequence(t, seededDB(t, openPostgres)) }
+func TestSCIMEntraSequence(t *testing.T) {
+	forEngines(t, runSCIMEntraSequence)
+}
 
 func runSCIMEntraSequence(t *testing.T, db *store.DB) {
 	_, _, call := scimWireServer(t, db, "entra")
@@ -886,11 +885,8 @@ func runSCIMEntraSequence(t *testing.T, db *store.DB) {
 // parse fixtures in internal/scimproto prove the parser; this proves the
 // transport carries the parser's verdict out unaltered, which is a different
 // claim and the one an identity provider actually experiences.
-func TestSCIMPatchMatrixOverTheWireSQLite(t *testing.T) {
-	runSCIMPatchMatrixOverTheWire(t, seededDB(t, openSQLite))
-}
-func TestSCIMPatchMatrixOverTheWirePostgres(t *testing.T) {
-	runSCIMPatchMatrixOverTheWire(t, seededDB(t, openPostgres))
+func TestSCIMPatchMatrixOverTheWire(t *testing.T) {
+	forEngines(t, runSCIMPatchMatrixOverTheWire)
 }
 
 func runSCIMPatchMatrixOverTheWire(t *testing.T, db *store.DB) {
@@ -1164,11 +1160,8 @@ func runSCIMPatchMatrixOverTheWire(t *testing.T, db *store.DB) {
 // the bytes an identity provider actually receives, canonicalized so that
 // legitimately-differing VALUES (ids, timestamps, names) collapse to their
 // types and any difference in the field SET survives.
-func TestSCIMWireAttachIsIndistinguishableSQLite(t *testing.T) {
-	runSCIMWireAttachIsIndistinguishable(t, seededDB(t, openSQLite))
-}
-func TestSCIMWireAttachIsIndistinguishablePostgres(t *testing.T) {
-	runSCIMWireAttachIsIndistinguishable(t, seededDB(t, openPostgres))
+func TestSCIMWireAttachIsIndistinguishable(t *testing.T) {
+	forEngines(t, runSCIMWireAttachIsIndistinguishable)
 }
 
 func runSCIMWireAttachIsIndistinguishable(t *testing.T, db *store.DB) {
@@ -1269,11 +1262,8 @@ func writeJSONShape(b *strings.Builder, v any) {
 // and a binding that declared nothing of the sort refuses that same URN by
 // name. Before this, any URN was a valid subject source, discovery advertised
 // only the enterprise extension, and the renderer echoed whatever arrived.
-func TestSCIMDeclaredExtensionsAreTheClosedTruthSQLite(t *testing.T) {
-	runSCIMDeclaredExtensions(t, seededDB(t, openSQLite))
-}
-func TestSCIMDeclaredExtensionsAreTheClosedTruthPostgres(t *testing.T) {
-	runSCIMDeclaredExtensions(t, seededDB(t, openPostgres))
+func TestSCIMDeclaredExtensionsAreTheClosedTruth(t *testing.T) {
+	forEngines(t, runSCIMDeclaredExtensions)
 }
 
 func runSCIMDeclaredExtensions(t *testing.T, db *store.DB) {
@@ -1403,11 +1393,8 @@ func runSCIMDeclaredExtensions(t *testing.T, db *store.DB) {
 // NO-OP: an identity provider re-asserting current truth on every
 // reconciliation cycle must not bump `meta.lastModified` or emit an update
 // event. A trail full of updates that updated nothing is a trail nobody reads.
-func TestSCIMPresenceAndNoOpSQLite(t *testing.T) {
-	runSCIMPresenceAndNoOp(t, seededDB(t, openSQLite))
-}
-func TestSCIMPresenceAndNoOpPostgres(t *testing.T) {
-	runSCIMPresenceAndNoOp(t, seededDB(t, openPostgres))
+func TestSCIMPresenceAndNoOp(t *testing.T) {
+	forEngines(t, runSCIMPresenceAndNoOp)
 }
 
 func runSCIMPresenceAndNoOp(t *testing.T, db *store.DB) {
@@ -1516,11 +1503,8 @@ func runSCIMPresenceAndNoOp(t *testing.T, db *store.DB) {
 // RESPONSES: exact status and exact body bytes for a revoked credential versus
 // one that names nothing, the page bound answered as a clamp rather than a
 // refusal, and the body bound answered by name.
-func TestSCIMWireAdmissionOverHTTPSQLite(t *testing.T) {
-	runSCIMWireAdmissionOverHTTP(t, seededDB(t, openSQLite))
-}
-func TestSCIMWireAdmissionOverHTTPPostgres(t *testing.T) {
-	runSCIMWireAdmissionOverHTTP(t, seededDB(t, openPostgres))
+func TestSCIMWireAdmissionOverHTTP(t *testing.T) {
+	forEngines(t, runSCIMWireAdmissionOverHTTP)
 }
 
 func runSCIMWireAdmissionOverHTTP(t *testing.T, db *store.DB) {
@@ -1671,11 +1655,8 @@ func randomUserName(t *testing.T) string {
 //  3. and the annotation did not leak: a real directory read still emits its
 //     `scim.directory_read`, so this is an exemption for the manual, not for
 //     the tenant data beside it.
-func TestSCIMDiscoveryIsAnnotatedNotSilentSQLite(t *testing.T) {
-	runSCIMDiscoveryIsAnnotatedNotSilent(t, seededDB(t, openSQLite))
-}
-func TestSCIMDiscoveryIsAnnotatedNotSilentPostgres(t *testing.T) {
-	runSCIMDiscoveryIsAnnotatedNotSilent(t, seededDB(t, openPostgres))
+func TestSCIMDiscoveryIsAnnotatedNotSilent(t *testing.T) {
+	forEngines(t, runSCIMDiscoveryIsAnnotatedNotSilent)
 }
 
 // TestSCIMWireMismatchOverDiscovery is SC1.l over the WIRE: a credential
@@ -1688,11 +1669,8 @@ func TestSCIMDiscoveryIsAnnotatedNotSilentPostgres(t *testing.T) {
 // any operation authorizes, is its ENTIRE audit linkage. Nothing else exercises
 // the mismatch path over a route whose operation carries no audit declaration,
 // so nothing else would notice if narrowing that declaration broke the refusal.
-func TestSCIMWireMismatchOverDiscoverySQLite(t *testing.T) {
-	runSCIMWireMismatchOverDiscovery(t, seededDB(t, openSQLite))
-}
-func TestSCIMWireMismatchOverDiscoveryPostgres(t *testing.T) {
-	runSCIMWireMismatchOverDiscovery(t, seededDB(t, openPostgres))
+func TestSCIMWireMismatchOverDiscovery(t *testing.T) {
+	forEngines(t, runSCIMWireMismatchOverDiscovery)
 }
 
 func runSCIMWireMismatchOverDiscovery(t *testing.T, db *store.DB) {

--- a/internal/isolation/scim_wire_coverage_test.go
+++ b/internal/isolation/scim_wire_coverage_test.go
@@ -19,8 +19,9 @@ import (
 
 // TestSCIMWirePaging is SC1.d: the RFC ListResponse fields, 1-based paging, and
 // an out-of-range page answering an EMPTY resource list with a TRUTHFUL total.
-func TestSCIMWirePagingSQLite(t *testing.T)   { runSCIMWirePaging(t, seededDB(t, openSQLite)) }
-func TestSCIMWirePagingPostgres(t *testing.T) { runSCIMWirePaging(t, seededDB(t, openPostgres)) }
+func TestSCIMWirePaging(t *testing.T) {
+	forEngines(t, runSCIMWirePaging)
+}
 
 func runSCIMWirePaging(t *testing.T, db *store.DB) {
 	s := scimSvc(db)
@@ -87,8 +88,9 @@ func runSCIMWirePaging(t *testing.T, db *store.DB) {
 
 // TestSCIMWireAdmission is SC4.c: bounded page and body refusals by name, and
 // the uniform unknown-versus-revoked answer.
-func TestSCIMWireAdmissionSQLite(t *testing.T)   { runSCIMWireAdmission(t, seededDB(t, openSQLite)) }
-func TestSCIMWireAdmissionPostgres(t *testing.T) { runSCIMWireAdmission(t, seededDB(t, openPostgres)) }
+func TestSCIMWireAdmission(t *testing.T) {
+	forEngines(t, runSCIMWireAdmission)
+}
 
 func runSCIMWireAdmission(t *testing.T, db *store.DB) {
 	s := scimSvc(db)
@@ -153,11 +155,8 @@ func probeSCIMCredential(t *testing.T, s *service.SCIM, token, bindingID string)
 // TestSCIMPatchAtomicityOverTheWire is SC1.f through the SERVICE, not only the
 // parser: a request whose first operation is valid and whose second is not must
 // commit NOTHING.
-func TestSCIMPatchAtomicityOverTheWireSQLite(t *testing.T) {
-	runSCIMPatchAtomicityOverTheWire(t, seededDB(t, openSQLite))
-}
-func TestSCIMPatchAtomicityOverTheWirePostgres(t *testing.T) {
-	runSCIMPatchAtomicityOverTheWire(t, seededDB(t, openPostgres))
+func TestSCIMPatchAtomicityOverTheWire(t *testing.T) {
+	forEngines(t, runSCIMPatchAtomicityOverTheWire)
 }
 
 func runSCIMPatchAtomicityOverTheWire(t *testing.T, db *store.DB) {
@@ -215,9 +214,8 @@ func runSCIMPatchAtomicityOverTheWire(t *testing.T, db *store.DB) {
 // TestSCIMTransitionTable is SC2.g: every §5.4 row with a real POSTCONDITION.
 // The earlier fixtures walked the transitions with nothing mapped, so update,
 // reactivate and delete were no-ops that could not fail.
-func TestSCIMTransitionTableSQLite(t *testing.T) { runSCIMTransitionTable(t, seededDB(t, openSQLite)) }
-func TestSCIMTransitionTablePostgres(t *testing.T) {
-	runSCIMTransitionTable(t, seededDB(t, openPostgres))
+func TestSCIMTransitionTable(t *testing.T) {
+	forEngines(t, runSCIMTransitionTable)
 }
 
 func runSCIMTransitionTable(t *testing.T, db *store.DB) {
@@ -341,11 +339,8 @@ func scimOriginCount(t *testing.T, db *store.DB, p domain.PrincipalID) int64 {
 // TestSCIMZeroAuthorityOnCreate is SC2.c: a provisioned account has NO session,
 // NO assurance and NO credential — asserted by ATTEMPTING authenticated
 // operations, not by counting rows.
-func TestSCIMZeroAuthorityOnCreateSQLite(t *testing.T) {
-	runSCIMZeroAuthorityOnCreate(t, seededDB(t, openSQLite))
-}
-func TestSCIMZeroAuthorityOnCreatePostgres(t *testing.T) {
-	runSCIMZeroAuthorityOnCreate(t, seededDB(t, openPostgres))
+func TestSCIMZeroAuthorityOnCreate(t *testing.T) {
+	forEngines(t, runSCIMZeroAuthorityOnCreate)
 }
 
 func runSCIMZeroAuthorityOnCreate(t *testing.T, db *store.DB) {
@@ -408,11 +403,8 @@ func runSCIMZeroAuthorityOnCreate(t *testing.T, db *store.DB) {
 // TestSCIMProvisionThenLoginSAMLEmailCarve is the other half of SC2.b: the
 // Entra shape admitted under the `emailAddress` NameID carve, proving the
 // carve COMPOSES with the subject derivation unchanged.
-func TestSCIMProvisionThenLoginSAMLEmailCarveSQLite(t *testing.T) {
-	runSCIMProvisionThenLoginSAMLEmailCarve(t, seededDB(t, openSQLite))
-}
-func TestSCIMProvisionThenLoginSAMLEmailCarvePostgres(t *testing.T) {
-	runSCIMProvisionThenLoginSAMLEmailCarve(t, seededDB(t, openPostgres))
+func TestSCIMProvisionThenLoginSAMLEmailCarve(t *testing.T) {
+	forEngines(t, runSCIMProvisionThenLoginSAMLEmailCarve)
 }
 
 const samlEmailFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
@@ -515,11 +507,8 @@ func samlLoginAsFormat(t *testing.T, auth *service.Auth, idp *samltest.IdP, name
 // TestSCIMManualRemainderWording is SC2.i's other half: the attention state is
 // not enough — the surface must carry the HONEST wording the ADR insists on,
 // that the manual grants remain usable including after a fresh login.
-func TestSCIMManualRemainderWordingSQLite(t *testing.T) {
-	runSCIMManualRemainderWording(t, seededDB(t, openSQLite))
-}
-func TestSCIMManualRemainderWordingPostgres(t *testing.T) {
-	runSCIMManualRemainderWording(t, seededDB(t, openPostgres))
+func TestSCIMManualRemainderWording(t *testing.T) {
+	forEngines(t, runSCIMManualRemainderWording)
 }
 
 func runSCIMManualRemainderWording(t *testing.T, db *store.DB) {

--- a/internal/isolation/webauthn_e2e_test.go
+++ b/internal/isolation/webauthn_e2e_test.go
@@ -80,6 +80,15 @@ func enrolPasskey(t *testing.T, auth *service.Auth, ctx context.Context, token, 
 	return res.SessionToken
 }
 
+// enrolPasskeyAndStepUp enrols a passkey (proof = the current password) and
+// immediately steps the resulting session up through the device, returning the
+// stepped-up token — the prologue every passkey reauth ceremony shares before
+// its own ReauthPasskeyStart intent.
+func enrolPasskeyAndStepUp(t *testing.T, auth *service.Auth, ctx context.Context, token, password string, dev *webauthntest.Device) string {
+	t.Helper()
+	return stepUpPasskey(t, auth, ctx, enrolPasskey(t, auth, ctx, token, password, dev), dev)
+}
+
 // discoverableLogin runs a full passkey login with the device.
 func discoverableLogin(t *testing.T, auth *service.Auth, ctx context.Context, dev *webauthntest.Device) (service.LoginResult, error) {
 	t.Helper()
@@ -94,8 +103,9 @@ func discoverableLogin(t *testing.T, auth *service.Auth, ctx context.Context, de
 	return auth.PasskeyLoginFinish(ctx, assertion)
 }
 
-func TestWebAuthnRoundtripSQLite(t *testing.T)   { runWebAuthnRoundtrip(t, seededDB(t, openSQLite)) }
-func TestWebAuthnRoundtripPostgres(t *testing.T) { runWebAuthnRoundtrip(t, seededDB(t, openPostgres)) }
+func TestWebAuthnRoundtrip(t *testing.T) {
+	forEngines(t, runWebAuthnRoundtrip)
+}
 
 // runWebAuthnRoundtrip: enrol a passkey (proof = the pre-existing password),
 // then log in with one gesture. The session carries method local-passkey and a
@@ -169,8 +179,9 @@ func runWebAuthnRoundtrip(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnUVRefusedSQLite(t *testing.T)   { runWebAuthnUVRefused(t, seededDB(t, openSQLite)) }
-func TestWebAuthnUVRefusedPostgres(t *testing.T) { runWebAuthnUVRefused(t, seededDB(t, openPostgres)) }
+func TestWebAuthnUVRefused(t *testing.T) {
+	forEngines(t, runWebAuthnUVRefused)
+}
 
 // runWebAuthnUVRefused: an assertion whose UV bit is not set is refused. UV is
 // required on every ceremony and re-asserted server-side.
@@ -195,8 +206,9 @@ func runWebAuthnUVRefused(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnCloneSQLite(t *testing.T)   { runWebAuthnClone(t, seededDB(t, openSQLite)) }
-func TestWebAuthnClonePostgres(t *testing.T) { runWebAuthnClone(t, seededDB(t, openPostgres)) }
+func TestWebAuthnClone(t *testing.T) {
+	forEngines(t, runWebAuthnClone)
+}
 
 // runWebAuthnClone: a sign-count regression on a non-backup credential disables
 // it, sweeps every session it minted and audits passkey_cloned, before refusing
@@ -240,11 +252,8 @@ func runWebAuthnClone(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnSyncedNotFlaggedSQLite(t *testing.T) {
-	runWebAuthnSyncedNotFlagged(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnSyncedNotFlaggedPostgres(t *testing.T) {
-	runWebAuthnSyncedNotFlagged(t, seededDB(t, openPostgres))
+func TestWebAuthnSyncedNotFlagged(t *testing.T) {
+	forEngines(t, runWebAuthnSyncedNotFlagged)
 }
 
 // runWebAuthnSyncedNotFlagged: a backup-eligible (synced) credential whose
@@ -332,9 +341,8 @@ func runWebAuthnPasskeyOnly(t *testing.T, open func(*testing.T) *store.DB) {
 	})
 }
 
-func TestWebAuthnEnrolProofSQLite(t *testing.T) { runWebAuthnEnrolProof(t, seededDB(t, openSQLite)) }
-func TestWebAuthnEnrolProofPostgres(t *testing.T) {
-	runWebAuthnEnrolProof(t, seededDB(t, openPostgres))
+func TestWebAuthnEnrolProof(t *testing.T) {
+	forEngines(t, runWebAuthnEnrolProof)
 }
 
 // runWebAuthnEnrolProof: a new passkey cannot authorize its own enrolment — the
@@ -362,11 +370,8 @@ func runWebAuthnEnrolProof(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnStepUpReauthSQLite(t *testing.T) {
-	runWebAuthnStepUpReauth(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnStepUpReauthPostgres(t *testing.T) {
-	runWebAuthnStepUpReauth(t, seededDB(t, openPostgres))
+func TestWebAuthnStepUpReauth(t *testing.T) {
+	forEngines(t, runWebAuthnStepUpReauth)
 }
 
 // runWebAuthnStepUpReauth: a passkey elevates a password session in place
@@ -433,11 +438,8 @@ func runWebAuthnStepUpReauth(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnReauthBindingMismatchSQLite(t *testing.T) {
-	runWebAuthnReauthBindingMismatch(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnReauthBindingMismatchPostgres(t *testing.T) {
-	runWebAuthnReauthBindingMismatch(t, seededDB(t, openPostgres))
+func TestWebAuthnReauthBindingMismatch(t *testing.T) {
+	forEngines(t, runWebAuthnReauthBindingMismatch)
 }
 
 // runWebAuthnReauthBindingMismatch is the reauth-binding regression (A3): a
@@ -473,11 +475,8 @@ func runWebAuthnReauthBindingMismatch(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnDeleteAccountScopedSQLite(t *testing.T) {
-	runWebAuthnDeleteAccountScoped(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnDeleteAccountScopedPostgres(t *testing.T) {
-	runWebAuthnDeleteAccountScoped(t, seededDB(t, openPostgres))
+func TestWebAuthnDeleteAccountScoped(t *testing.T) {
+	forEngines(t, runWebAuthnDeleteAccountScoped)
 }
 
 // runWebAuthnDeleteAccountScoped is the IDOR regression (B1): the credential
@@ -521,11 +520,8 @@ func runWebAuthnDeleteAccountScoped(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnLoginNoAccountThrottleSQLite(t *testing.T) {
-	runWebAuthnLoginNoAccountThrottle(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnLoginNoAccountThrottlePostgres(t *testing.T) {
-	runWebAuthnLoginNoAccountThrottle(t, seededDB(t, openPostgres))
+func TestWebAuthnLoginNoAccountThrottle(t *testing.T) {
+	forEngines(t, runWebAuthnLoginNoAccountThrottle)
 }
 
 // runWebAuthnLoginNoAccountThrottle is the login-DoS regression (A2): a bad
@@ -559,11 +555,8 @@ func runWebAuthnLoginNoAccountThrottle(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnLoginHandleMismatchSQLite(t *testing.T) {
-	runWebAuthnLoginHandleMismatch(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnLoginHandleMismatchPostgres(t *testing.T) {
-	runWebAuthnLoginHandleMismatch(t, seededDB(t, openPostgres))
+func TestWebAuthnLoginHandleMismatch(t *testing.T) {
+	forEngines(t, runWebAuthnLoginHandleMismatch)
 }
 
 // runWebAuthnLoginHandleMismatch: the lookup resolves the account from the
@@ -587,11 +580,8 @@ func runWebAuthnLoginHandleMismatch(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnStepUpThrottleSQLite(t *testing.T) {
-	runWebAuthnStepUpThrottle(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnStepUpThrottlePostgres(t *testing.T) {
-	runWebAuthnStepUpThrottle(t, seededDB(t, openPostgres))
+func TestWebAuthnStepUpThrottle(t *testing.T) {
+	forEngines(t, runWebAuthnStepUpThrottle)
 }
 
 // runWebAuthnStepUpThrottle proves step-up no longer bypasses admission (A2):
@@ -630,11 +620,8 @@ func runWebAuthnStepUpThrottle(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestWebAuthnCeremonyExpirySQLite(t *testing.T) {
-	runWebAuthnCeremonyExpiry(t, seededDB(t, openSQLite))
-}
-func TestWebAuthnCeremonyExpiryPostgres(t *testing.T) {
-	runWebAuthnCeremonyExpiry(t, seededDB(t, openPostgres))
+func TestWebAuthnCeremonyExpiry(t *testing.T) {
+	forEngines(t, runWebAuthnCeremonyExpiry)
 }
 
 // runWebAuthnCeremonyExpiry is the ceremony-lifetime regression (A3): a login
@@ -667,11 +654,8 @@ func runWebAuthnCeremonyExpiry(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestRecoveryLastCodePasswordlessSQLite(t *testing.T) {
-	runRecoveryLastCodePasswordless(t, seededDB(t, openSQLite))
-}
-func TestRecoveryLastCodePasswordlessPostgres(t *testing.T) {
-	runRecoveryLastCodePasswordless(t, seededDB(t, openPostgres))
+func TestRecoveryLastCodePasswordless(t *testing.T) {
+	forEngines(t, runRecoveryLastCodePasswordless)
 }
 
 // runRecoveryLastCodePasswordless is the recovery-floor regression (A1):

--- a/internal/isolation/workspace_stepup_test.go
+++ b/internal/isolation/workspace_stepup_test.go
@@ -379,12 +379,8 @@ func assertReauthWindow(t *testing.T, db *store.DB, sessionID, envID string) {
 	}
 }
 
-func TestWorkspaceAssuranceAndStepUpSQLite(t *testing.T) {
-	runWorkspaceAssuranceAndStepUp(t, seededDB(t, openSQLite))
-}
-
-func TestWorkspaceAssuranceAndStepUpPostgres(t *testing.T) {
-	runWorkspaceAssuranceAndStepUp(t, seededDB(t, openPostgres))
+func TestWorkspaceAssuranceAndStepUp(t *testing.T) {
+	forEngines(t, runWorkspaceAssuranceAndStepUp)
 }
 
 // The bounds this path opens its window under are the human-auth service's own,
@@ -493,12 +489,8 @@ func runStepUpBindingIsConsumed(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestStepUpBindingIsConsumedSQLite(t *testing.T) {
-	runStepUpBindingIsConsumed(t, seededDB(t, openSQLite))
-}
-
-func TestStepUpBindingIsConsumedPostgres(t *testing.T) {
-	runStepUpBindingIsConsumed(t, seededDB(t, openPostgres))
+func TestStepUpBindingIsConsumed(t *testing.T) {
+	forEngines(t, runStepUpBindingIsConsumed)
 }
 
 // The approve page reads the transaction purpose and any step-up binding back
@@ -587,12 +579,8 @@ func runShowHandoffReturnsBoundPolicy(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestShowHandoffReturnsBoundPolicySQLite(t *testing.T) {
-	runShowHandoffReturnsBoundPolicy(t, seededDB(t, openSQLite))
-}
-
-func TestShowHandoffReturnsBoundPolicyPostgres(t *testing.T) {
-	runShowHandoffReturnsBoundPolicy(t, seededDB(t, openPostgres))
+func TestShowHandoffReturnsBoundPolicy(t *testing.T) {
+	forEngines(t, runShowHandoffReturnsBoundPolicy)
 }
 
 // A workspace step-up for the reveal operation must be spendable by the real
@@ -654,12 +642,8 @@ func runStepUpRevealIsSpentByValuePath(t *testing.T, db *store.DB) {
 	}
 }
 
-func TestStepUpRevealIsSpentByValuePathSQLite(t *testing.T) {
-	runStepUpRevealIsSpentByValuePath(t, seededDB(t, openSQLite))
-}
-
-func TestStepUpRevealIsSpentByValuePathPostgres(t *testing.T) {
-	runStepUpRevealIsSpentByValuePath(t, seededDB(t, openPostgres))
+func TestStepUpRevealIsSpentByValuePath(t *testing.T) {
+	forEngines(t, runStepUpRevealIsSpentByValuePath)
 }
 
 // The fresh-ceremony gate, driven through a REAL factor verification rather


### PR DESCRIPTION
Part of #619. PR B1: Go test structure in internal/isolation. Test-only, no production change.

## What
- 210 `TestXSQLite`/`TestXPostgres` 3-line wrapper pairs become one `TestX` with `sqlite`/`postgres` subtests via a new `forEngines` helper. The CI name-sharded planner still runs both legs (`^TestX$` matches the parent; verified locally: planner top-level 530 to 320, both subtests execute).
- One `postgresTestDSN` helper for the repeated DSN gate; shared factor-enrolment prologues; `writeKubeconfig` in importer/live_test.go.
- 15 engine-agnostic SQLite-only tests drop the suffix. Pairs that differ (blob literals, custody targets, raw open funcs) left as-is.
- -617 LOC across 43 test files.

## Verification
- vet, gofmt, staticcheck clean; sqlite full isolation suite green (0 failures); postgres legs pass uncontended (CI runs them on dedicated per-job databases).
- Cross-model (Codex) review before merge.