### PR TITLE
refactor(service): slop audit C-service, extract shared helpers, dedupe fixtures (#619)

### DIFF
--- a/internal/isolation/audit_e2e_test.go
+++ b/internal/isolation/audit_e2e_test.go
@@ -73,6 +73,9 @@ func (c *auditUpdateControl) Submit(_ context.Context, req updater.Request) (upd
 }
 func (c *auditUpdateControl) Job(context.Context, string) (updater.Job, error) { return c.job, nil }
 func (c *auditUpdateControl) AcknowledgeOutcome(context.Context, string) error { return nil }
+func (c *auditUpdateControl) PendingOutcomes(context.Context) ([]updater.Job, error) {
+	return nil, nil
+}
 
 func runAuditSuite(t *testing.T, db *store.DB) {
 	audits := &service.Audits{DB: db}

--- a/internal/service/adapter_selection.go
+++ b/internal/service/adapter_selection.go
@@ -108,11 +108,7 @@ func (s *Adapters) resolveTargetKeys(ctx context.Context, actor Actor, scope dom
 	}
 	var catalogue []store.CatalogueKey
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -35,10 +35,38 @@ type Adapters struct {
 }
 
 func (s *Adapters) now() time.Time {
-	if s.Now != nil {
-		return s.Now().UTC()
+	return nowOr(s.Now)
+}
+
+// requireProjectScope enforces the project-scoped precondition shared by the
+// adapter and dynamic-provider operations: a project must be addressed, no
+// environment may be pinned, and every supplied id must be non-empty. msg is the
+// operation's own invalid-argument message, preserved verbatim per call site.
+func requireProjectScope(scope domain.Scope, msg string, ids ...string) error {
+	bad := scope.Project == "" || scope.Env != ""
+	for _, id := range ids {
+		bad = bad || id == ""
 	}
-	return time.Now().UTC()
+	if bad {
+		return fmt.Errorf("%w: %s", domain.ErrInvalid, msg)
+	}
+	return nil
+}
+
+// auditSuperseded records the EventAdapterSuperseded audit event when a newly
+// enqueued job displaced a prior one. prev is the superseded job id; an empty
+// prev means nothing was superseded and no event is written.
+func auditSuperseded(ctx context.Context, r store.Repos, proof authz.Proof, principal domain.PrincipalID, targetID, prev, next string) error {
+	if prev == "" {
+		return nil
+	}
+	event, err := domainEvent(ctx, audit.EventAdapterSuperseded, principal,
+		audit.Object{Type: "adapter-target", ID: targetID},
+		audit.Payload{"previous_job_id": prev, "job_id": next})
+	if err != nil {
+		return err
+	}
+	return r.Audit().InsertTenant(ctx, proof, event)
 }
 
 type AdapterTargetView struct {
@@ -128,11 +156,7 @@ func (s *Adapters) environmentCreateAudit(actor Actor, scope domain.Scope, targe
 	before := func(ctx context.Context) error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 			now := store.CanonTime(s.now())
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 			if err != nil {
 				return err
 			}
@@ -161,11 +185,7 @@ func (s *Adapters) environmentCreateAudit(actor Actor, scope domain.Scope, targe
 		}
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 			now := store.CanonTime(s.now())
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 			if err != nil {
 				return err
 			}
@@ -257,6 +277,23 @@ func (s *Adapters) providerGate(actor Actor, operation authz.Operation, projectS
 	}
 }
 
+// gate builds a provider callback that authorizes op against scope in its own
+// read transaction, minted per call. Unlike providerGate it performs no
+// separate push check; it is the single-operation gate used by TestTarget and
+// Plan, where the addressed scope is the only thing to authorize.
+func (s *Adapters) gate(actor Actor, op authz.Operation, scope domain.Scope) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return tx.Read(ctx, s.DB, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+			caller, err := actor.resolve(ctx, az, s.now())
+			if err != nil {
+				return err
+			}
+			_, err = az.Authorize(ctx, caller, op, scope)
+			return err
+		})
+	}
+}
+
 func (s *Adapters) requireAdapterCeremony(ctx context.Context, az *authz.TxAuthorizer, caller authz.Identity, projectScope domain.Scope, environmentIDs []string, operation authz.Operation, now time.Time) error {
 	intent, err := newReauthIntentForAdapterOperation(operation, environmentIDs)
 	if err != nil {
@@ -286,8 +323,6 @@ func (s *Adapters) requireAdapterCeremony(ctx context.Context, az *authz.TxAutho
 
 func adapterCeremonyError(environmentID string, err error) error {
 	switch {
-	case err == nil:
-		return nil
 	case errors.Is(err, ErrNoReauthWindow), errors.Is(err, ErrReauthWindowExpired), errors.Is(err, ErrReauthUnitMismatch), errors.Is(err, ErrReauthWindowSpent):
 		return fmt.Errorf("%w (%s)", ErrReauthRequired, environmentID)
 	default:
@@ -298,8 +333,7 @@ func adapterCeremonyError(environmentID string, err error) error {
 func adapterEnvironmentSet(environmentIDs []string, additional ...string) []string {
 	out := append([]string(nil), environmentIDs...)
 	out = append(out, additional...)
-	slices.Sort(out)
-	return slices.Compact(out)
+	return canonicalSet(out)
 }
 
 func (s *Adapters) consumeAdapterCeremony(ctx context.Context, actor Actor, scope domain.Scope, environmentIDs []string, operation authz.Operation, now time.Time) (authz.Identity, error) {
@@ -377,11 +411,7 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 	}
 	var out AdapterView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 		if err != nil {
 			return err
 		}
@@ -410,16 +440,12 @@ func (s *Adapters) Create(ctx context.Context, actor Actor, scope domain.Scope, 
 }
 
 func (s *Adapters) Get(ctx context.Context, actor Actor, scope domain.Scope, adapterID string) (AdapterView, error) {
-	if scope.Project == "" || scope.Env != "" || adapterID == "" {
-		return AdapterView{}, fmt.Errorf("%w: adapter show requires project scope and adapter id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter show requires project scope and adapter id", adapterID); err != nil {
+		return AdapterView{}, err
 	}
 	var out AdapterView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterInspect, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterInspect, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -442,26 +468,18 @@ func (s *Adapters) Get(ctx context.Context, actor Actor, scope domain.Scope, ada
 			}
 			out.TargetConflicts[target.ID] = conflicts
 		}
-		ev, err := domainEvent(ctx, audit.EventAdapterInspect, caller.Principal, audit.Object{Type: "adapter", ID: adapterID}, audit.Payload{"row_count": 1})
-		if err != nil {
-			return err
-		}
-		return r.Audit().InsertTenant(ctx, p, ev)
+		return insertInspected(ctx, r, p, caller.Principal, audit.EventAdapterInspect, audit.Object{Type: "adapter", ID: adapterID}, 1)
 	})
 	return out, err
 }
 
 func (s *Adapters) List(ctx context.Context, actor Actor, scope domain.Scope) ([]AdapterView, error) {
-	if scope.Project == "" || scope.Env != "" {
-		return nil, fmt.Errorf("%w: adapter list requires project scope", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter list requires project scope"); err != nil {
+		return nil, err
 	}
 	var out []AdapterView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterInspect, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterInspect, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -487,18 +505,14 @@ func (s *Adapters) List(ctx context.Context, actor Actor, scope domain.Scope) ([
 			}
 			out = append(out, view)
 		}
-		ev, err := domainEvent(ctx, audit.EventAdapterInspect, caller.Principal, audit.Object{Type: "adapter-list", ID: string(scope.Project)}, audit.Payload{"row_count": len(out)})
-		if err != nil {
-			return err
-		}
-		return r.Audit().InsertTenant(ctx, p, ev)
+		return insertInspected(ctx, r, p, caller.Principal, audit.EventAdapterInspect, audit.Object{Type: "adapter-list", ID: string(scope.Project)}, int64(len(out)))
 	})
 	return out, err
 }
 
 func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scope, adapterID string, input AdapterTargetInput) (store.AdapterTarget, error) {
-	if scope.Project == "" || scope.Env != "" || adapterID == "" || input.EnvironmentID == "" {
-		return store.AdapterTarget{}, fmt.Errorf("%w: target add requires adapter, environment, destination, and keys", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "target add requires adapter, environment, destination, and keys", adapterID, input.EnvironmentID); err != nil {
+		return store.AdapterTarget{}, err
 	}
 	if err := s.resolveTargetKeys(ctx, actor, scope, &input); err != nil {
 		return store.AdapterTarget{}, err
@@ -511,11 +525,7 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 	var authorizedEnvironments []string
 	now := store.CanonTime(s.now())
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -534,11 +544,7 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 		return store.AdapterTarget{}, err
 	}
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -581,11 +587,7 @@ func (s *Adapters) AddTarget(ctx context.Context, actor Actor, scope domain.Scop
 	}
 	var out store.AdapterTarget
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 		if err != nil {
 			return err
 		}
@@ -632,11 +634,7 @@ func (s *Adapters) prepareTargetMutation(ctx context.Context, actor Actor, scope
 	}
 	var move bool
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		_, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -660,8 +658,8 @@ func (s *Adapters) prepareTargetMutation(ctx context.Context, actor Actor, scope
 // move decision. The decision and selected mutation share one write transaction,
 // so a concurrent target mutation cannot bypass scrub-before-switch.
 func (s *Adapters) ApplyTargetMutation(ctx context.Context, actor Actor, scope domain.Scope, request UpdateAdapterTargetRequest, keepRemote bool) (TargetMutationResult, error) {
-	if scope.Project == "" || scope.Env != "" {
-		return nil, fmt.Errorf("%w: target mutation requires project scope", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "target mutation requires project scope"); err != nil {
+		return nil, err
 	}
 	if err := s.resolveTargetKeys(ctx, actor, scope, &request.Target); err != nil {
 		return nil, err
@@ -692,11 +690,7 @@ func (s *Adapters) ApplyTargetMutation(ctx context.Context, actor Actor, scope d
 	var rateCharged bool
 	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			p, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+			caller, p, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 			if err != nil {
 				return err
 			}
@@ -794,17 +788,8 @@ func (s *Adapters) applyTargetUpdate(ctx context.Context, r store.Repos, az *aut
 	if err := r.Audit().InsertTenant(ctx, proof, requested); err != nil {
 		return store.AdapterTarget{}, err
 	}
-	if updated.Enqueue.SupersededJobID != "" {
-		superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-			audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
-				"previous_job_id": updated.Enqueue.SupersededJobID, "job_id": updated.Enqueue.JobID,
-			})
-		if err != nil {
-			return store.AdapterTarget{}, err
-		}
-		if err := r.Audit().InsertTenant(ctx, proof, superseded); err != nil {
-			return store.AdapterTarget{}, err
-		}
+	if err := auditSuperseded(ctx, r, proof, caller.Principal, request.TargetID, updated.Enqueue.SupersededJobID, updated.Enqueue.JobID); err != nil {
+		return store.AdapterTarget{}, err
 	}
 	if updated.Target.Keys, err = r.Adapters().TargetKeys(ctx, proof, request.TargetID); err != nil {
 		return store.AdapterTarget{}, err
@@ -817,11 +802,7 @@ func (s *Adapters) preflightTargetRouting(ctx context.Context, actor Actor, scop
 	var record store.AdapterRecord
 	var ciphertext []byte
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		_, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -909,17 +890,8 @@ func (s *Adapters) applyTargetMove(ctx context.Context, r store.Repos, az *authz
 	if err := r.Audit().InsertTenant(ctx, proof, configured); err != nil {
 		return store.AdapterRouteMoveResult{}, err
 	}
-	if out.SupersededJobID != "" {
-		superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-			audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
-				"previous_job_id": out.SupersededJobID, "job_id": out.JobID,
-			})
-		if err != nil {
-			return store.AdapterRouteMoveResult{}, err
-		}
-		if err := r.Audit().InsertTenant(ctx, proof, superseded); err != nil {
-			return store.AdapterRouteMoveResult{}, err
-		}
+	if err := auditSuperseded(ctx, r, proof, caller.Principal, request.TargetID, out.SupersededJobID, out.JobID); err != nil {
+		return store.AdapterRouteMoveResult{}, err
 	}
 	if keepRemote {
 		scrubbed, err := domainEvent(ctx, audit.EventAdapterScrub, caller.Principal,
@@ -971,11 +943,7 @@ func (s *Adapters) MoveOrigin(ctx context.Context, actor Actor, scope domain.Sco
 	var out store.AdapterRouteMoveBatch
 	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 			if err != nil {
 				return err
 			}
@@ -1014,17 +982,8 @@ func (s *Adapters) MoveOrigin(ctx context.Context, actor Actor, scope domain.Sco
 				return err
 			}
 			for _, target := range out.Targets {
-				if target.SupersededJobID != "" {
-					superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-						audit.Object{Type: "adapter-target", ID: target.TargetID}, audit.Payload{
-							"previous_job_id": target.SupersededJobID, "job_id": target.JobID,
-						})
-					if err != nil {
-						return err
-					}
-					if err := r.Audit().InsertTenant(ctx, proof, superseded); err != nil {
-						return err
-					}
+				if err := auditSuperseded(ctx, r, proof, caller.Principal, target.TargetID, target.SupersededJobID, target.JobID); err != nil {
+					return err
 				}
 				if keepRemote {
 					scrubbed, err := domainEvent(ctx, audit.EventAdapterScrub, caller.Principal,
@@ -1044,16 +1003,12 @@ func (s *Adapters) MoveOrigin(ctx context.Context, actor Actor, scope domain.Sco
 }
 
 func (s *Adapters) Move(ctx context.Context, actor Actor, scope domain.Scope, moveID string) (store.AdapterMove, error) {
-	if scope.Project == "" || scope.Env != "" || moveID == "" {
-		return store.AdapterMove{}, fmt.Errorf("%w: adapter move show requires project scope and move id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter move show requires project scope and move id", moveID); err != nil {
+		return store.AdapterMove{}, err
 	}
 	var out store.AdapterMove
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterInspect, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterInspect, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -1061,27 +1016,19 @@ func (s *Adapters) Move(ctx context.Context, actor Actor, scope domain.Scope, mo
 		if err != nil {
 			return err
 		}
-		event, err := domainEvent(ctx, audit.EventAdapterInspect, caller.Principal, audit.Object{Type: "adapter-move", ID: moveID}, audit.Payload{"row_count": 1})
-		if err != nil {
-			return err
-		}
-		return r.Audit().InsertTenant(ctx, proof, event)
+		return insertInspected(ctx, r, proof, caller.Principal, audit.EventAdapterInspect, audit.Object{Type: "adapter-move", ID: moveID}, 1)
 	})
 	return out, err
 }
 
 func (s *Adapters) CancelMove(ctx context.Context, actor Actor, scope domain.Scope, moveID string) (store.AdapterMove, error) {
-	if scope.Project == "" || scope.Env != "" || moveID == "" {
-		return store.AdapterMove{}, fmt.Errorf("%w: adapter move cancellation requires project scope and move id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter move cancellation requires project scope and move id", moveID); err != nil {
+		return store.AdapterMove{}, err
 	}
 	now := store.CanonTime(s.now())
 	var out store.AdapterMove
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 		if err != nil {
 			return err
 		}
@@ -1119,11 +1066,7 @@ func (s *Adapters) ResumeTargetMove(ctx context.Context, actor Actor, scope doma
 	now := store.CanonTime(s.now())
 	var out store.AdapterMove
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 		if err != nil {
 			return err
 		}
@@ -1186,11 +1129,7 @@ func (s *Adapters) ResumeOriginMove(ctx context.Context, actor Actor, scope doma
 	now := store.CanonTime(s.now())
 	var out store.AdapterMove
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 		if err != nil {
 			return err
 		}
@@ -1238,8 +1177,8 @@ func (s *Adapters) ResumeOriginMove(ctx context.Context, actor Actor, scope doma
 }
 
 func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Scope, targetID string) (store.AdapterEnqueueResult, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return store.AdapterEnqueueResult{}, fmt.Errorf("%w: manual adapter sync requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "manual adapter sync requires project scope and target id", targetID); err != nil {
+		return store.AdapterEnqueueResult{}, err
 	}
 	// § 179 adapter sync/trigger concurrency: 4 per org. Held for the enqueue.
 	release, err := s.Budget.acquire(budgetAdapter, budgetKeys{Org: scope.Org})
@@ -1252,11 +1191,7 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 	var rateCharged bool
 	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterSync, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterSync, scope, now)
 			if err != nil {
 				return err
 			}
@@ -1291,17 +1226,7 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 			if err := r.Audit().InsertTenant(ctx, proof, requested); err != nil {
 				return err
 			}
-			if result.SupersededJobID == "" {
-				return nil
-			}
-			superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: targetID}, audit.Payload{
-					"previous_job_id": result.SupersededJobID, "job_id": result.JobID,
-				})
-			if err != nil {
-				return err
-			}
-			return r.Audit().InsertTenant(ctx, proof, superseded)
+			return auditSuperseded(ctx, r, proof, caller.Principal, targetID, result.SupersededJobID, result.JobID)
 		})
 	})
 	return result, err
@@ -1312,18 +1237,14 @@ func (s *Adapters) SyncTarget(ctx context.Context, actor Actor, scope domain.Sco
 // reauthentication ceremony, exactly like credential revocation. The ledger
 // is untouched: resume needs no re-adoption.
 func (s *Adapters) PauseTarget(ctx context.Context, actor Actor, scope domain.Scope, targetID string) (store.AdapterTarget, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return store.AdapterTarget{}, fmt.Errorf("%w: adapter target pause requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter target pause requires project scope and target id", targetID); err != nil {
+		return store.AdapterTarget{}, err
 	}
 	now := store.CanonTime(s.now())
 	var out store.AdapterTarget
 	err := retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, now)
 			if err != nil {
 				return err
 			}
@@ -1350,17 +1271,7 @@ func (s *Adapters) PauseTarget(ctx context.Context, actor Actor, scope domain.Sc
 			if err := r.Audit().InsertTenant(ctx, proof, ev); err != nil {
 				return err
 			}
-			if result.SupersededJobID == "" {
-				return nil
-			}
-			superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: targetID}, audit.Payload{
-					"previous_job_id": result.SupersededJobID, "job_id": "",
-				})
-			if err != nil {
-				return err
-			}
-			return r.Audit().InsertTenant(ctx, proof, superseded)
+			return auditSuperseded(ctx, r, proof, caller.Principal, targetID, result.SupersededJobID, "")
 		})
 	})
 	if err != nil {
@@ -1373,8 +1284,8 @@ func (s *Adapters) PauseTarget(ctx context.Context, actor Actor, scope domain.Sc
 // pushes again, so it carries the manual-sync formula and ceremony; the
 // result names the published revision the converge reaches.
 func (s *Adapters) ResumeTarget(ctx context.Context, actor Actor, scope domain.Scope, targetID string) (store.AdapterResumeResult, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return store.AdapterResumeResult{}, fmt.Errorf("%w: adapter target resume requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter target resume requires project scope and target id", targetID); err != nil {
+		return store.AdapterResumeResult{}, err
 	}
 	release, err := s.Budget.acquire(budgetAdapter, budgetKeys{Org: scope.Org})
 	if err != nil {
@@ -1386,11 +1297,7 @@ func (s *Adapters) ResumeTarget(ctx context.Context, actor Actor, scope domain.S
 	var rateCharged bool
 	err = retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterSync, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterSync, scope, now)
 			if err != nil {
 				return err
 			}
@@ -1422,25 +1329,15 @@ func (s *Adapters) ResumeTarget(ctx context.Context, actor Actor, scope domain.S
 			if err := r.Audit().InsertTenant(ctx, proof, requested); err != nil {
 				return err
 			}
-			if result.Enqueue.SupersededJobID == "" {
-				return nil
-			}
-			superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal,
-				audit.Object{Type: "adapter-target", ID: targetID}, audit.Payload{
-					"previous_job_id": result.Enqueue.SupersededJobID, "job_id": result.Enqueue.JobID,
-				})
-			if err != nil {
-				return err
-			}
-			return r.Audit().InsertTenant(ctx, proof, superseded)
+			return auditSuperseded(ctx, r, proof, caller.Principal, targetID, result.Enqueue.SupersededJobID, result.Enqueue.JobID)
 		})
 	})
 	return result, err
 }
 
 func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Scope, targetID string) (adapter.Connection, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return adapter.Connection{}, fmt.Errorf("%w: adapter connection test requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter connection test requires project scope and target id", targetID); err != nil {
+		return adapter.Connection{}, err
 	}
 	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpAdapterTest, scope)
 	if err != nil {
@@ -1448,11 +1345,7 @@ func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Sco
 	}
 	var material store.AdapterPlanMaterial
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterTest, scope)
+		_, proof, err := authorize(ctx, az, actor, authz.OpAdapterTest, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -1479,30 +1372,16 @@ func (s *Adapters) TestTarget(ctx context.Context, actor Actor, scope domain.Sco
 		return adapter.Connection{}, err
 	}
 	defer lease.Release()
-	providerGate := func(gateCtx context.Context) error {
-		return tx.Read(gateCtx, s.DB, func(gateCtx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(gateCtx, az, s.now())
-			if err != nil {
-				return err
-			}
-			_, err = az.Authorize(gateCtx, caller, authz.OpAdapterTest, scope)
-			return err
-		})
-	}
 	connection, err := lease.Module.TestConnection(ctx, adapter.ConnectionRequest{
 		Config: adapter.Config{Origin: material.Target.Origin}, Destination: adapterTarget(material.Target).Destination,
-		Access: adapter.Access{Credential: string(credential)}, Gate: providerGate,
+		Access: adapter.Access{Credential: string(credential)}, Gate: s.gate(actor, authz.OpAdapterTest, scope),
 	})
 	if err != nil {
 		return adapter.Connection{}, err
 	}
 	now := store.CanonTime(s.now())
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterTest, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterTest, scope, now)
 		if err != nil {
 			return err
 		}
@@ -1605,8 +1484,8 @@ func (s *Adapters) ReplaceCredential(ctx context.Context, actor Actor, scope dom
 }
 
 func (s *Adapters) RevokeCredential(ctx context.Context, actor Actor, scope domain.Scope, adapterID string) (store.AdapterCredentialResult, error) {
-	if scope.Project == "" || scope.Env != "" || adapterID == "" {
-		return store.AdapterCredentialResult{}, fmt.Errorf("%w: credential revocation requires project scope and adapter id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "credential revocation requires project scope and adapter id", adapterID); err != nil {
+		return store.AdapterCredentialResult{}, err
 	}
 	now := store.CanonTime(s.now())
 	return tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (store.AdapterCredentialResult, error) {
@@ -1641,18 +1520,22 @@ func (s *Adapters) buildModule(provider adapter.Provider, origin, credential str
 	return s.ModuleFactory(provider, adapter.Config{Origin: origin}, credential)
 }
 
-func (s *Adapters) providerForAdapter(ctx context.Context, actor Actor, scope domain.Scope, adapterID string) (string, error) {
+// providerFor authorizes OpAdapterConfigure on scope, resolves the adapter id
+// via adapterID (which may run its own lookups under the same proof), and
+// returns that adapter's provider name. It is the shared body of
+// providerForAdapter and providerForMove.
+func (s *Adapters) providerFor(ctx context.Context, actor Actor, scope domain.Scope, adapterID func(context.Context, store.ReadRepos, authz.Proof) (string, error)) (string, error) {
 	var provider string
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
+		_, proof, err := authorize(ctx, az, actor, authz.OpAdapterConfigure, scope, s.now())
 		if err != nil {
 			return err
 		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
+		id, err := adapterID(ctx, r, proof)
 		if err != nil {
 			return err
 		}
-		record, _, err := r.Adapters().Configuration(ctx, proof, adapterID)
+		record, _, err := r.Adapters().Configuration(ctx, proof, id)
 		if err != nil {
 			return err
 		}
@@ -1662,29 +1545,20 @@ func (s *Adapters) providerForAdapter(ctx context.Context, actor Actor, scope do
 	return provider, err
 }
 
+func (s *Adapters) providerForAdapter(ctx context.Context, actor Actor, scope domain.Scope, adapterID string) (string, error) {
+	return s.providerFor(ctx, actor, scope, func(context.Context, store.ReadRepos, authz.Proof) (string, error) {
+		return adapterID, nil
+	})
+}
+
 func (s *Adapters) providerForMove(ctx context.Context, actor Actor, scope domain.Scope, moveID string) (string, error) {
-	var provider string
-	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpAdapterConfigure, scope)
-		if err != nil {
-			return err
-		}
+	return s.providerFor(ctx, actor, scope, func(ctx context.Context, r store.ReadRepos, proof authz.Proof) (string, error) {
 		move, err := r.Adapters().Move(ctx, proof, moveID)
 		if err != nil {
-			return err
+			return "", err
 		}
-		record, _, err := r.Adapters().Configuration(ctx, proof, move.AdapterID)
-		if err != nil {
-			return err
-		}
-		provider = record.Provider
-		return nil
+		return move.AdapterID, nil
 	})
-	return provider, err
 }
 
 func adapterTarget(target store.AdapterTarget) adapter.Target {
@@ -1695,8 +1569,8 @@ func adapterTarget(target store.AdapterTarget) adapter.Target {
 }
 
 func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, targetID string) (AdapterPlanResult, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return AdapterPlanResult{}, fmt.Errorf("%w: adapter plan requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter plan requires project scope and target id", targetID); err != nil {
+		return AdapterPlanResult{}, err
 	}
 	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpAdapterPlan, scope)
 	if err != nil {
@@ -1704,11 +1578,7 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 	}
 	var material store.AdapterPlanMaterial
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterPlan, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpAdapterPlan, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -1735,17 +1605,7 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 		return AdapterPlanResult{}, err
 	}
 	defer lease.Release()
-	providerGate := func(gateCtx context.Context) error {
-		return tx.Read(gateCtx, s.DB, func(gateCtx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(gateCtx, az, s.now())
-			if err != nil {
-				return err
-			}
-			_, err = az.Authorize(gateCtx, caller, authz.OpAdapterPlan, scope)
-			return err
-		})
-	}
-	plan, err := lease.Module.Plan(ctx, adapter.PlanRequest{Config: adapter.Config{Origin: material.Target.Origin}, Target: adapterTarget(material.Target), Manifest: material.Manifest, Ledger: material.Ledger, Gate: providerGate})
+	plan, err := lease.Module.Plan(ctx, adapter.PlanRequest{Config: adapter.Config{Origin: material.Target.Origin}, Target: adapterTarget(material.Target), Manifest: material.Manifest, Ledger: material.Ledger, Gate: s.gate(actor, authz.OpAdapterPlan, scope)})
 	if err != nil {
 		return AdapterPlanResult{}, err
 	}
@@ -1755,11 +1615,7 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 	}
 	now := store.CanonTime(s.now())
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterPlan, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterPlan, scope, now)
 		if err != nil {
 			return err
 		}
@@ -1796,16 +1652,12 @@ func (s *Adapters) Plan(ctx context.Context, actor Actor, scope domain.Scope, ta
 }
 
 func (s *Adapters) InspectTarget(ctx context.Context, actor Actor, scope domain.Scope, targetID string) (AdapterTargetView, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return AdapterTargetView{}, fmt.Errorf("%w: adapter target inspection requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter target inspection requires project scope and target id", targetID); err != nil {
+		return AdapterTargetView{}, err
 	}
 	var out AdapterTargetView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterInspect, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterInspect, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -1831,11 +1683,7 @@ func (s *Adapters) InspectTarget(ctx context.Context, actor Actor, scope domain.
 		if out.Target.Provider == "github-actions" && out.Target.DestinationKind == string(adapter.Environment) {
 			out.Workflow = "environment: " + strconv.Quote(out.Target.DestinationEnvironment) + "\n" + out.Workflow
 		}
-		ev, err := domainEvent(ctx, audit.EventAdapterInspect, caller.Principal, audit.Object{Type: "adapter-target", ID: targetID}, audit.Payload{"row_count": 1})
-		if err != nil {
-			return err
-		}
-		return r.Audit().InsertTenant(ctx, p, ev)
+		return insertInspected(ctx, r, p, caller.Principal, audit.EventAdapterInspect, audit.Object{Type: "adapter-target", ID: targetID}, 1)
 	})
 	return out, err
 }
@@ -1859,11 +1707,7 @@ func (s *Adapters) Adopt(ctx context.Context, actor Actor, scope domain.Scope, r
 	now := store.CanonTime(s.now())
 	var out AdoptAdapterResult
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpAdapterAdopt, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpAdapterAdopt, scope, now)
 		if err != nil {
 			return err
 		}
@@ -1905,16 +1749,8 @@ func (s *Adapters) Adopt(ctx context.Context, actor Actor, scope domain.Scope, r
 		if err := r.Audit().InsertTenant(ctx, p, ev); err != nil {
 			return err
 		}
-		if result.SupersededJobID != "" {
-			superseded, err := domainEvent(ctx, audit.EventAdapterSuperseded, caller.Principal, audit.Object{Type: "adapter-target", ID: request.TargetID}, audit.Payload{
-				"previous_job_id": result.SupersededJobID, "job_id": result.JobID,
-			})
-			if err != nil {
-				return err
-			}
-			if err := r.Audit().InsertTenant(ctx, p, superseded); err != nil {
-				return err
-			}
+		if err := auditSuperseded(ctx, r, p, caller.Principal, request.TargetID, result.SupersededJobID, result.JobID); err != nil {
+			return err
 		}
 		out = AdoptAdapterResult{Generation: result.Generation, JobID: result.JobID}
 		return nil
@@ -1923,18 +1759,14 @@ func (s *Adapters) Adopt(ctx context.Context, actor Actor, scope domain.Scope, r
 }
 
 func (s *Adapters) RemoveTarget(ctx context.Context, actor Actor, scope domain.Scope, targetID string, keepRemote bool) (AdapterTeardownResult, error) {
-	if scope.Project == "" || scope.Env != "" || targetID == "" {
-		return AdapterTeardownResult{}, fmt.Errorf("%w: adapter target removal requires project scope and target id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter target removal requires project scope and target id", targetID); err != nil {
+		return AdapterTeardownResult{}, err
 	}
 	now := store.CanonTime(s.now())
 	var result store.AdapterTeardownResult
 	err := retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterDelete, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterDelete, scope, now)
 			if err != nil {
 				return err
 			}
@@ -1955,18 +1787,14 @@ func (s *Adapters) RemoveTarget(ctx context.Context, actor Actor, scope domain.S
 }
 
 func (s *Adapters) Delete(ctx context.Context, actor Actor, scope domain.Scope, adapterID string, keepRemote bool) (AdapterTeardownResult, error) {
-	if scope.Project == "" || scope.Env != "" || adapterID == "" {
-		return AdapterTeardownResult{}, fmt.Errorf("%w: adapter deletion requires project scope and adapter id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "adapter deletion requires project scope and adapter id", adapterID); err != nil {
+		return AdapterTeardownResult{}, err
 	}
 	now := store.CanonTime(s.now())
 	var batch store.AdapterTeardownBatch
 	err := retryAdapterProviderFence(ctx, func() error {
 		return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, now)
-			if err != nil {
-				return err
-			}
-			proof, err := az.Authorize(ctx, caller, authz.OpAdapterDelete, scope)
+			caller, proof, err := authorize(ctx, az, actor, authz.OpAdapterDelete, scope, now)
 			if err != nil {
 				return err
 			}

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -20,6 +20,45 @@ import (
 	storetx "github.com/Hikyo-Org/hikyo/internal/store/tx"
 )
 
+// adapterScope is the project scope every adapter test operates in.
+var adapterScope = domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+
+// adapterKeyring generates a fresh root key and loads a keyring over db, the
+// setup every adapter test that touches sealed material repeats.
+func adapterKeyring(t *testing.T, db *store.DB) *crypto.Keyring {
+	t.Helper()
+	root, err := crypto.GenerateRootKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return kr
+}
+
+// seedKey inserts a project key row for the adapter scope. The batch fixtures
+// that set up several rows atomically keep their inline SQL; seedKey is the
+// standalone single-key setup.
+func seedKey(t *testing.T, db *store.DB, id, name string) {
+	t.Helper()
+	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES (?,'org_adapter','prj_adapter',?,'','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`, id, name); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// sealAdapterCredential seals value as adp_1's provider credential under the
+// test's project sealer. The AAD matches the adapter fixture every test uses.
+func sealAdapterCredential(t *testing.T, sealer *crypto.ProjectSealer, value string) []byte {
+	t.Helper()
+	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte(value))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed
+}
+
 func adapterCLISession(t *testing.T, db *store.DB) string {
 	t.Helper()
 	value, verifier, err := crypto.NewArtifact(crypto.ArtifactCLISession)
@@ -228,7 +267,7 @@ func TestAdapterCreateAndAddTargetRefuseBeforeCredentialOrProviderWithoutCeremon
 			providerCalls++
 			return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
 		})}
-		_, err := svc.Create(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{
+		_, err := svc.Create(t.Context(), Bearer(bearer), adapterScope, CreateAdapterRequest{
 			Origin: "https://new.example", Credential: []byte("provider-token"),
 			Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", KeyIDs: []string{"key_create"}},
 		})
@@ -248,7 +287,7 @@ func TestAdapterCreateAndAddTargetRefuseBeforeCredentialOrProviderWithoutCeremon
 			providerCalls++
 			return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
 		})}
-		_, err := svc.AddTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{
+		_, err := svc.AddTarget(t.Context(), Bearer(bearer), adapterScope, "adp_1", AdapterTargetInput{
 			EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", KeyIDs: []string{"key_create"},
 		})
 		if !errors.Is(err, ErrReauthRequired) || providerCalls != 0 {
@@ -263,7 +302,7 @@ func TestAdapterCreateRejectsUnknownProviderBeforeCredentialUse(t *testing.T) {
 		factoryCalled = true
 		return adapter.NewModuleLease(fakeAdapterPlanModule{}, nil)
 	}}
-	_, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{
+	_, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, CreateAdapterRequest{
 		Provider: "gitlab", Origin: "https://gitlab.example", Credential: []byte("provider-token"),
 		Target: AdapterTargetInput{EnvironmentID: "env_one", KeyIDs: []string{"key_one"}},
 	})
@@ -303,17 +342,8 @@ func (fakeAdapterConfigureModule) Sync(context.Context, adapter.SyncRequest, ada
 
 func TestAdapterCreateAtomicallyBootstrapsCredentialAndFirstTarget(t *testing.T) {
 	db := adapterServiceDB(t)
-	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_create','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`); err != nil {
-		t.Fatal(err)
-	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	seedKey(t, db, "key_create", "API_TOKEN")
+	kr := adapterKeyring(t, db)
 	gates := 0
 	expires := time.Date(2026, 9, 30, 12, 34, 56, 0, time.UTC)
 	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(origin, credential string) (adapter.Module, func(), error) {
@@ -322,7 +352,7 @@ func TestAdapterCreateAtomicallyBootstrapsCredentialAndFirstTarget(t *testing.T)
 		}
 		return fakeAdapterConfigureModule{gates: &gates, credentialExpiry: expires}, nil, nil
 	})}
-	view, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{Origin: "https://new.example", Credential: []byte("provider-token"), Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", NamePrefix: "PROD_", KeyIDs: []string{"key_create"}}})
+	view, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, CreateAdapterRequest{Origin: "https://new.example", Credential: []byte("provider-token"), Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "new", NamePrefix: "PROD_", KeyIDs: []string{"key_create"}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +377,7 @@ func TestAdapterCreateAtomicallyBootstrapsCredentialAndFirstTarget(t *testing.T)
 	if keys != 1 {
 		t.Fatalf("target keys=%d", keys)
 	}
-	shown, err := svc.Get(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, view.Adapter.ID)
+	shown, err := svc.Get(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, view.Adapter.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,24 +388,15 @@ func TestAdapterCreateAtomicallyBootstrapsCredentialAndFirstTarget(t *testing.T)
 
 func TestEnvironmentCreatePersistsGenerationFenceAndCorrelatedAudit(t *testing.T) {
 	db := adapterServiceDB(t)
-	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_env_create','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`); err != nil {
-		t.Fatal(err)
-	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	seedKey(t, db, "key_env_create", "API_TOKEN")
+	kr := adapterKeyring(t, db)
 	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: testModuleFactory(func(provider adapter.Provider, _, _ string) (adapter.Module, func(), error) {
 		if provider != adapter.GitHubActionsProvider {
 			t.Fatalf("provider = %q, want persisted github-actions", provider)
 		}
 		return fakeEnvironmentConfigureModule{}, nil, nil
 	})}
-	view, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, CreateAdapterRequest{
+	view, err := svc.Create(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, CreateAdapterRequest{
 		Provider: "github-actions", Origin: "https://api.github.com", Credential: []byte("github_pat_fine"),
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "environment", DestinationOwner: "acme", DestinationName: "app", DestinationEnvironment: "production", KeyIDs: []string{"key_env_create"}},
 	})
@@ -419,22 +440,12 @@ func TestOrganizationSelectedRepositoryIDsAreVerifiedBeforeRoutingCommit(t *test
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("github_pat_fine"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "github_pat_fine")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -445,7 +456,7 @@ func TestOrganizationSelectedRepositoryIDsAreVerifiedBeforeRoutingCommit(t *test
 		}
 		return fakeRoutingPreflightModule{seen: &seen}, nil, nil
 	})}
-	updated, err := svc.updateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	updated, err := svc.updateTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "organization", DestinationOwner: "acme", Visibility: "selected", SelectedRepositoryIDs: []int64{11, 22}, NamePrefix: "ONE_", KeyIDs: []string{"key_org_route"}},
 	})
@@ -467,7 +478,7 @@ func TestAdapterRoutingStateRoundTripsFromStore(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	view, err := (&Adapters{DB: db}).Get(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_github")
+	view, err := (&Adapters{DB: db}).Get(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_github")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +524,7 @@ func TestApplyTargetMutationClassifiesUpdateAndMove(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			result, err := (&Adapters{DB: db}).ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+			result, err := (&Adapters{DB: db}).ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 				TargetID: "tgt_one", ExpectedGeneration: 1, Target: tt.target,
 			}, tt.keepRemote)
 			if err != nil {
@@ -563,10 +574,8 @@ func TestApplyTargetMutationKeepsMovePolicyInsideService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := adapterServiceDB(t)
-			if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO keys (id,org_id,project_id,name,folder_path,classification,description,deprecated,deprecation_note,declaration,required_mode,forbidden_mode,created_at) VALUES ('key_policy','org_adapter','prj_adapter','API_TOKEN','','secret','',0,'','optional','none','none','2026-08-17T00:00:00Z')`); err != nil {
-				t.Fatal(err)
-			}
-			_, err := (&Adapters{DB: db}).ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+			seedKey(t, db, "key_policy", "API_TOKEN")
+			_, err := (&Adapters{DB: db}).ApplyTargetMutation(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 				TargetID: "tgt_one", ExpectedGeneration: 1, Target: tt.target,
 			}, tt.keepRemote)
 			if !errors.Is(err, tt.want) {
@@ -616,7 +625,7 @@ func TestApplyTargetMutationRequiresCeremonyForUpdateAndMove(t *testing.T) {
 				}
 			}
 			bearer := adapterCLISession(t, db)
-			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).ApplyTargetMutation(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).ApplyTargetMutation(t.Context(), Bearer(bearer), adapterScope, UpdateAdapterTargetRequest{
 				TargetID: "tgt_one", ExpectedGeneration: 1, Target: tt.target,
 			}, false)
 			if !errors.Is(err, ErrReauthRequired) {
@@ -650,7 +659,7 @@ func TestAdapterCeremonyErrorClassification(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			return svc.requireAdapterCeremony(ctx, az, caller, domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, []string{"env_one"}, authz.OpAdapterSync, time.Now().UTC())
+			return svc.requireAdapterCeremony(ctx, az, caller, adapterScope, []string{"env_one"}, authz.OpAdapterSync, time.Now().UTC())
 		})
 		if !consumerCalled {
 			t.Fatal("requireAdapterCeremony() did not reach reauth consumer")
@@ -677,7 +686,7 @@ func TestAdapterCeremonyErrorClassification(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				return svc.requireAdapterCeremony(ctx, az, caller, domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, []string{"env_one"}, operation, time.Now().UTC())
+				return svc.requireAdapterCeremony(ctx, az, caller, adapterScope, []string{"env_one"}, operation, time.Now().UTC())
 			})
 			if !errors.Is(err, ErrReauthRequired) {
 				t.Fatalf("requireAdapterCeremony(%s) = %v, want reauth required", operation, err)
@@ -699,22 +708,12 @@ func TestApplyTargetMutationConcurrentChangesUseLockedGeneration(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("github_pat_fine"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "github_pat_fine")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -723,7 +722,7 @@ func TestApplyTargetMutationConcurrentChangesUseLockedGeneration(t *testing.T) {
 	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: testModuleFactory(func(adapter.Provider, string, string) (adapter.Module, func(), error) {
 		return blockingRoutingPreflightModule{started: preflightStarted, proceed: preflightProceed}, nil, nil
 	})}
-	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+	scope := adapterScope
 	update := UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "organization", DestinationOwner: "acme", Visibility: "selected", SelectedRepositoryIDs: []int64{11}, NamePrefix: "ONE_", KeyIDs: []string{"key_concurrent_mutation"}},
@@ -767,22 +766,12 @@ func TestAdapterTargetAddAuditsTransactionAuthorityTransition(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "provider-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -790,7 +779,7 @@ func TestAdapterTargetAddAuditsTransactionAuthorityTransition(t *testing.T) {
 	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 		return fakeAdapterConfigureModule{gates: new(int), destinationID: 303, credentialExpiry: expires}, nil, nil
 	})}
-	target, err := svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{
+	target, err := svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", AdapterTargetInput{
 		EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "THREE_", KeyIDs: []string{"key_add_authority"},
 	})
 	if err != nil {
@@ -824,22 +813,12 @@ func TestAdapterTargetAddRefusesDestinationEffectiveNameCollisionAtomically(t *t
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "provider-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -847,7 +826,7 @@ func TestAdapterTargetAddRefusesDestinationEffectiveNameCollisionAtomically(t *t
 	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 		return fakeAdapterConfigureModule{gates: &gates, destinationID: 42}, nil, nil
 	})}
-	_, err = svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_collision"}})
+	_, err = svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", AdapterTargetInput{EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_collision"}})
 	if !errors.Is(err, domain.ErrConflict) {
 		t.Fatalf("AddTarget() error = %v, want conflict", err)
 	}
@@ -876,15 +855,8 @@ func TestTargetedKeyDeleteCascadesMembershipAndQueuesOwnedSlotPrune(t *testing.T
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := (&Keys{DB: db, Keyring: kr}).Delete(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "key_delete"); err != nil {
+	kr := adapterKeyring(t, db)
+	if err := (&Keys{DB: db, Keyring: kr}).Delete(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "key_delete"); err != nil {
 		t.Fatal(err)
 	}
 	var memberships, queued int
@@ -928,22 +900,12 @@ func TestAdapterTargetAddRequiresRevealAcrossEveryAdapterEnvironmentBeforeCreden
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "provider-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -951,7 +913,7 @@ func TestAdapterTargetAddRequiresRevealAcrossEveryAdapterEnvironmentBeforeCreden
 	svc := &Adapters{DB: db, Keyring: kr, ModuleFactory: providerBlindTestModuleFactory(func(string, string) (adapter.Module, func(), error) {
 		return fakeAdapterConfigureModule{gates: &gates, destinationID: 42}, nil, nil
 	})}
-	_, err = svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", AdapterTargetInput{EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "THREE_", KeyIDs: []string{"key_new_target"}})
+	_, err = svc.AddTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", AdapterTargetInput{EnvironmentID: "env_three", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "THREE_", KeyIDs: []string{"key_new_target"}})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("AddTarget() error = %v, want tenant-safe refusal without env_two reveal", err)
 	}
@@ -973,7 +935,7 @@ func TestAdapterTargetDestinationMoveScrubsOldRouteBeforePendingRouteActivation(
 		}
 	}
 	svc := &Adapters{DB: db}
-	result, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	result, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_move"}},
 	}, false)
@@ -1034,7 +996,7 @@ func TestAdapterTargetDestinationMoveKeepRemoteReleasesBeforeActivation(t *testi
 			t.Fatal(err)
 		}
 	}
-	result, err := (&Adapters{DB: db}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	result, err := (&Adapters{DB: db}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_keep_move"}},
 	}, true)
@@ -1081,7 +1043,7 @@ func TestAdapterTargetMoveScrubCompletionQueuesPendingRouteActivation(t *testing
 	}
 	now := time.Date(2026, 8, 17, 1, 0, 0, 0, time.UTC)
 	svc := &Adapters{DB: db, Now: func() time.Time { return now }}
-	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_scrub_move"}},
 	}, false)
@@ -1129,7 +1091,7 @@ func TestAdapterTargetMoveDeadCredentialReleasesOldCustodyThenActivates(t *testi
 		}
 	}
 	now := time.Now().UTC()
-	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_dead_move"}},
 	}, false)
@@ -1183,7 +1145,7 @@ func TestAdapterMoveCredentialFailureRequiresAttentionAndCancelReconvergesOldRou
 	}
 	now := time.Date(2026, 8, 17, 1, 0, 0, 0, time.UTC)
 	svc := &Adapters{DB: db, Now: func() time.Time { return now }}
-	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "ONE_", KeyIDs: []string{"key_attention"}},
 	}, true)
@@ -1198,7 +1160,7 @@ func TestAdapterMoveCredentialFailureRequiresAttentionAndCancelReconvergesOldRou
 	if err := runtime.Fail(t.Context(), job, 0, now.Add(2*time.Second), adapter.ErrProviderAuth); err != nil {
 		t.Fatal(err)
 	}
-	status, err := svc.Move(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, move.MoveID)
+	status, err := svc.Move(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, move.MoveID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1213,7 +1175,7 @@ func TestAdapterMoveCredentialFailureRequiresAttentionAndCancelReconvergesOldRou
 			t.Fatal(err)
 		}
 	}
-	canceled, err := svc.CancelMove(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, move.MoveID)
+	canceled, err := svc.CancelMove(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, move.MoveID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1249,7 +1211,7 @@ func TestAdapterAttentionTargetReplacementResumesActivation(t *testing.T) {
 	}
 	now := time.Date(2026, 8, 17, 1, 0, 0, 0, time.UTC)
 	svc := &Adapters{DB: db, Now: func() time.Time { return now }}
-	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := svc.moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "bad", NamePrefix: "BAD_", KeyIDs: []string{"key_resume"}},
 	}, true)
@@ -1272,7 +1234,7 @@ func TestAdapterAttentionTargetReplacementResumesActivation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	resumed, err := svc.ResumeTargetMove(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, move.MoveID, UpdateAdapterTargetRequest{
+	resumed, err := svc.ResumeTargetMove(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, move.MoveID, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one",
 		Target:   AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "fixed", NamePrefix: "FIXED_", KeyIDs: []string{"key_resume"}},
 	})
@@ -1316,7 +1278,7 @@ func TestAdapterTargetMoveActivationTestsPendingRouteThenEnqueuesConverge(t *tes
 		}
 	}
 	now := time.Now().UTC()
-	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	move, err := (&Adapters{DB: db, Now: func() time.Time { return now }}).moveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "next", NamePrefix: "NEXT_", KeyIDs: []string{"key_activate_move"}},
 	}, true)
@@ -1380,22 +1342,12 @@ func TestAdapterOriginMoveKeepsOldRouteAndCredentialThroughScrubBarrier(t *testi
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldCredential, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("old-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	oldCredential := sealAdapterCredential(t, sealer, "old-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, oldCredential); err != nil {
 		t.Fatal(err)
 	}
@@ -1405,7 +1357,7 @@ func TestAdapterOriginMoveKeepsOldRouteAndCredentialThroughScrubBarrier(t *testi
 		}
 		return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
 	})}
-	move, err := svc.MoveOrigin(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", "https://git.next.example", []byte("new-token"), false)
+	move, err := svc.MoveOrigin(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", "https://git.next.example", []byte("new-token"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1543,14 +1495,7 @@ func TestAdapterPendingOriginReplacementAuditsTransactionAuthorityTransition(t *
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	if _, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter"); err != nil {
 		t.Fatal(err)
 	}
@@ -1560,7 +1505,7 @@ func TestAdapterPendingOriginReplacementAuditsTransactionAuthorityTransition(t *
 		}
 		return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
 	})}
-	resumed, err := svc.ResumeOriginMove(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "move_origin_resume", "https://git.fixed.example", []byte("fixed-token"))
+	resumed, err := svc.ResumeOriginMove(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "move_origin_resume", "https://git.fixed.example", []byte("fixed-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1588,7 +1533,7 @@ func TestAdapterTargetWidenRequiresRevealAcrossEveryAdapterEnvironment(t *testin
 		}
 	}
 	svc := &Adapters{DB: db}
-	_, err := svc.updateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{TargetID: "tgt_one", ExpectedGeneration: 1, Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_existing", "key_widened"}}})
+	_, err := svc.updateTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{TargetID: "tgt_one", ExpectedGeneration: 1, Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_existing", "key_widened"}}})
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("UpdateTarget() error = %v, want tenant-safe refusal without env_two reveal", err)
 	}
@@ -1629,7 +1574,7 @@ func TestAdapterTargetInPlaceClassificationAndReplacementConverge(t *testing.T) 
 			t.Fatal(err)
 		}
 		bearer := adapterCLISession(t, db)
-		out, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).updateTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+		out, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).updateTarget(t.Context(), Bearer(bearer), adapterScope, UpdateAdapterTargetRequest{
 			TargetID: "tgt_one", ExpectedGeneration: 1,
 			Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_update_a"}},
 		})
@@ -1676,7 +1621,7 @@ func TestAdapterTargetInPlaceClassificationAndReplacementConverge(t *testing.T) 
 				t.Fatal(err)
 			}
 			bearer := adapterCLISession(t, db)
-			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).updateTarget(t.Context(), Bearer(bearer), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+			_, err := (&Adapters{DB: db, Auth: &Auth{DB: db}}).updateTarget(t.Context(), Bearer(bearer), adapterScope, UpdateAdapterTargetRequest{
 				TargetID: "tgt_one", ExpectedGeneration: 1,
 				Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: tc.prefix, KeyIDs: tc.keys},
 			})
@@ -1709,7 +1654,7 @@ func TestAdapterFullTargetUpdateAuditsTransactionAuthorityTransition(t *testing.
 			t.Fatal(err)
 		}
 	}
-	out, err := (&Adapters{DB: db}).updateTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, UpdateAdapterTargetRequest{
+	out, err := (&Adapters{DB: db}).updateTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, UpdateAdapterTargetRequest{
 		TargetID: "tgt_one", ExpectedGeneration: 1,
 		Target: AdapterTargetInput{EnvironmentID: "env_one", DestinationKind: "repository", DestinationOwner: "acme", DestinationName: "app", NamePrefix: "ONE_", KeyIDs: []string{"key_update_a", "key_update_b"}},
 	})
@@ -1740,7 +1685,7 @@ func (m fakeAdapterPlanModule) Sync(context.Context, adapter.SyncRequest, adapte
 func recordAdapterPlanArtifact(t *testing.T, db *store.DB, artifactID string) {
 	t.Helper()
 	err := storetx.Write(t.Context(), db, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		p, err := az.Authorize(ctx, authz.Identity{Principal: "usr_adapter"}, authz.OpAdapterPlan, domain.Scope{Org: "org_adapter", Project: "prj_adapter"})
+		p, err := az.Authorize(ctx, authz.Identity{Principal: "usr_adapter"}, authz.OpAdapterPlan, adapterScope)
 		if err != nil {
 			return err
 		}
@@ -1755,7 +1700,7 @@ func TestAdapterAdoptRequiresRevealAcrossEveryAdapterEnvironment(t *testing.T) {
 	db := adapterServiceDB(t)
 	recordAdapterPlanArtifact(t, db, "plan_all_envs")
 	service := &Adapters{DB: db}
-	_, err := service.Adopt(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, AdoptAdapterRequest{
+	_, err := service.Adopt(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, AdoptAdapterRequest{
 		TargetID: "tgt_one", ArtifactID: "plan_all_envs", ExpectedGeneration: 1, ExpectedDestinationID: 42, Entries: []store.AdapterConflictEntry{{Surface: "secret", EffectiveName: "ONE_TOKEN"}},
 	})
 	if !errors.Is(err, domain.ErrNotFound) {
@@ -1764,7 +1709,7 @@ func TestAdapterAdoptRequiresRevealAcrossEveryAdapterEnvironment(t *testing.T) {
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_reveal_two','usr_adapter','reveal','org_adapter','prj_adapter','env_two','2026-08-17T00:00:00Z')`); err != nil {
 		t.Fatal(err)
 	}
-	result, err := service.Adopt(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, AdoptAdapterRequest{
+	result, err := service.Adopt(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, AdoptAdapterRequest{
 		TargetID: "tgt_one", ArtifactID: "plan_all_envs", ExpectedGeneration: 1, ExpectedDestinationID: 42, Entries: []store.AdapterConflictEntry{{Surface: "secret", EffectiveName: "ONE_TOKEN"}},
 	})
 	if err != nil {
@@ -1797,7 +1742,7 @@ func TestAdapterTargetKeepRemoteReleasesAndEnumeratesCustodyWithoutReveal(t *tes
 	// The fixture deliberately grants reveal only in env_one and none in
 	// env_two. Target deletion is the ADR's plain destructive formula, so it
 	// must not consume or require reveal material.
-	result, err := (&Adapters{DB: db}).RemoveTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "tgt_one", true)
+	result, err := (&Adapters{DB: db}).RemoveTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "tgt_one", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1846,7 +1791,7 @@ func TestAdapterDeleteQueuesEveryScrubAndRetainsCredentialUntilLastTerminal(t *t
 			t.Fatal(err)
 		}
 	}
-	result, err := (&Adapters{DB: db}).Delete(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", false)
+	result, err := (&Adapters{DB: db}).Delete(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1898,16 +1843,9 @@ func TestAdapterCredentialReplaceAndRevokeFenceWithoutAutoConverge(t *testing.T)
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	svc := &Adapters{DB: db, Keyring: kr}
-	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+	scope := adapterScope
 	if _, err := svc.ReplaceCredential(t.Context(), LocalPrincipal("usr_adapter"), scope, "adp_1", []byte("provider-token")); !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("ReplaceCredential() without reveal in every target env = %v, want uniform refusal", err)
 	}
@@ -1997,7 +1935,7 @@ func TestAdapterCredentialReplaceAndRevokeFenceWithoutAutoConverge(t *testing.T)
 func TestAdapterManualSyncRequiresTargetRevealAndSupersedesNewest(t *testing.T) {
 	db := adapterServiceDB(t)
 	svc := &Adapters{DB: db}
-	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+	scope := adapterScope
 	if _, err := svc.SyncTarget(t.Context(), LocalPrincipal("usr_adapter"), scope, "tgt_two"); !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("SyncTarget(env_two) = %v, want reveal refusal", err)
 	}
@@ -2032,22 +1970,12 @@ func TestAdapterManualSyncRequiresTargetRevealAndSupersedesNewest(t *testing.T) 
 
 func TestAdapterTargetConnectionReauthorizesEveryProviderRequest(t *testing.T) {
 	db := adapterServiceDB(t)
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "provider-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z',credential_expires_at='2026-08-18T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -2062,7 +1990,7 @@ func TestAdapterTargetConnectionReauthorizesEveryProviderRequest(t *testing.T) {
 		}
 		return fakeAdapterTestModule{gates: &gates, credentialExpiry: expires}, nil, nil
 	})}
-	if _, err := svc.ReplaceCredential(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", []byte("provider-token")); err != nil {
+	if _, err := svc.ReplaceCredential(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", []byte("provider-token")); err != nil {
 		t.Fatal(err)
 	}
 	var clearedExpiry any
@@ -2072,14 +2000,14 @@ func TestAdapterTargetConnectionReauthorizesEveryProviderRequest(t *testing.T) {
 	if clearedExpiry != nil {
 		t.Fatalf("credential replacement retained stale expiry %v", clearedExpiry)
 	}
-	connection, err := svc.TestTarget(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "tgt_one")
+	connection, err := svc.TestTarget(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "tgt_one")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if connection.Version != "1.21.11" || connection.DestinationID != 42 || gates != 2 {
 		t.Fatalf("TestTarget() = %+v gates=%d", connection, gates)
 	}
-	shown, err := svc.Get(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1")
+	shown, err := svc.Get(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2108,22 +2036,12 @@ func TestAdapterPlanPersistsProviderConflictArtifactAndInspectReturnsIt(t *testi
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("provider-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	sealed := sealAdapterCredential(t, sealer, "provider-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, sealed); err != nil {
 		t.Fatal(err)
 	}
@@ -2140,7 +2058,7 @@ func TestAdapterPlanPersistsProviderConflictArtifactAndInspectReturnsIt(t *testi
 			return fakeAdapterPlanModule{plan: adapter.Plan{Changes: []adapter.Change{wantChange}}}, func() {}, nil
 		}),
 	}
-	scope := domain.Scope{Org: "org_adapter", Project: "prj_adapter"}
+	scope := adapterScope
 	result, err := svc.Plan(t.Context(), LocalPrincipal("usr_adapter"), scope, "tgt_one")
 	if err != nil {
 		t.Fatal(err)
@@ -2214,22 +2132,12 @@ func TestAdapterOriginMoveCredentialFailureRequiresAttentionAndCancelReconverges
 			t.Fatal(err)
 		}
 	}
-	root, err := crypto.GenerateRootKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	kr := adapterKeyring(t, db)
 	sealer, err := kr.ForProject(t.Context(), "org_adapter", "prj_adapter")
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldCredential, err := sealer.SealField(adapter.CredentialAAD("org_adapter", "prj_adapter", "adp_1"), []byte("old-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	oldCredential := sealAdapterCredential(t, sealer, "old-token")
 	if _, err := db.SQLiteWrite().ExecContext(t.Context(), `UPDATE adapters SET credential_ciphertext=?,credential_set_at='2026-08-17T00:00:00Z' WHERE id='adp_1'`, oldCredential); err != nil {
 		t.Fatal(err)
 	}
@@ -2239,7 +2147,7 @@ func TestAdapterOriginMoveCredentialFailureRequiresAttentionAndCancelReconverges
 		}
 		return fakeAdapterConfigureModule{gates: new(int)}, nil, nil
 	})}
-	move, err := svc.MoveOrigin(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, "adp_1", "https://git.next.example", []byte("new-token"), false)
+	move, err := svc.MoveOrigin(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, "adp_1", "https://git.next.example", []byte("new-token"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2314,14 +2222,14 @@ func TestAdapterOriginMoveCredentialFailureRequiresAttentionAndCancelReconverges
 	if err := runtime.Fail(t.Context(), firstActivation, 0, now.Add(5*time.Second), adapter.ErrProviderAuth); err != nil {
 		t.Fatal(err)
 	}
-	status, err := svc.Move(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, move.MoveID)
+	status, err := svc.Move(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, move.MoveID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if status.State != "attention_required" {
 		t.Fatalf("attention status = %+v", status)
 	}
-	canceled, err := svc.CancelMove(t.Context(), LocalPrincipal("usr_adapter"), domain.Scope{Org: "org_adapter", Project: "prj_adapter"}, move.MoveID)
+	canceled, err := svc.CancelMove(t.Context(), LocalPrincipal("usr_adapter"), adapterScope, move.MoveID)
 	if err != nil {
 		t.Fatalf("CancelMove() after a refused origin activation: %v", err)
 	}

--- a/internal/service/approvals.go
+++ b/internal/service/approvals.go
@@ -62,10 +62,7 @@ type Approvals struct {
 }
 
 func (s *Approvals) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // ApprovalApproverSpec is one approver-set member as the admin surface states it.
@@ -171,11 +168,7 @@ func (s *Approvals) CreatePolicy(ctx context.Context, actor Actor, scope domain.
 	now := s.now()
 	var view ApprovalPolicyView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalPolicyWrite, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpApprovalPolicyWrite, scope, now)
 		if err != nil {
 			return err
 		}
@@ -214,11 +207,7 @@ func (s *Approvals) UpdatePolicy(ctx context.Context, actor Actor, scope domain.
 	now := s.now()
 	var view ApprovalPolicyView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalPolicyWrite, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpApprovalPolicyWrite, scope, now)
 		if err != nil {
 			return err
 		}
@@ -265,11 +254,7 @@ func (s *Approvals) UpdatePolicy(ctx context.Context, actor Actor, scope domain.
 func (s *Approvals) DeletePolicy(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
 	now := s.now()
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalPolicyWrite, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpApprovalPolicyWrite, scope, now)
 		if err != nil {
 			return err
 		}
@@ -294,11 +279,7 @@ func (s *Approvals) ListPolicies(ctx context.Context, actor Actor, scope domain.
 	now := s.now()
 	var out []ApprovalPolicyView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalPolicyRead, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpApprovalPolicyRead, scope, now)
 		if err != nil {
 			return err
 		}
@@ -329,11 +310,7 @@ func (s *Approvals) ListRequests(ctx context.Context, actor Actor, scope domain.
 	now := s.now()
 	var out []ApprovalRequestView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalRequestRead, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpApprovalRequestRead, scope, now)
 		if err != nil {
 			return err
 		}
@@ -367,11 +344,7 @@ func (s *Approvals) CeremonyBinding(ctx context.Context, actor Actor, scope doma
 	now := s.now()
 	var out ApprovalCeremonyBinding
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalVote, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpApprovalVote, scope, now)
 		if err != nil {
 			return err
 		}
@@ -406,11 +379,7 @@ func (s *Approvals) Vote(ctx context.Context, actor Actor, scope domain.Scope, r
 	var refusal error
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		refusal = nil
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpApprovalVote, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpApprovalVote, scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -165,10 +165,7 @@ type Auth struct {
 }
 
 func (s *Auth) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // verifierAAD binds a sealed verifier to the row that owns it, so a verifier

--- a/internal/service/budget_classification.go
+++ b/internal/service/budget_classification.go
@@ -39,7 +39,9 @@ type budgetClassification struct {
 }
 
 // operationBudgetClass classifies every authz operation. Exported for the
-// conformance totality test via BudgetClassOf; never consulted at runtime.
+// operationBudgetClass is consulted at runtime by chargeDefaultAtEntry
+// (budget.go) to confirm an operation is default-expensive before charging, and
+// enumerated at build time by the conformance totality test via BudgetClassOf.
 var operationBudgetClass = buildBudgetClassification()
 
 // BudgetClassOf reports an operation's classification and whether it is known.

--- a/internal/service/ceremony.go
+++ b/internal/service/ceremony.go
@@ -102,21 +102,12 @@ func requireCeremony(ctx context.Context, auth *Auth, az *authz.TxAuthorizer, ca
 
 type disclosureIntentBuilder func(keyIDs []string) (ReauthIntent, error)
 
-func revealIntentBuilder(environmentID string) disclosureIntentBuilder {
+// disclosureIntent builds the reauth-intent constructor for a single-environment
+// disclosure of the given purpose. It replaces the per-purpose reveal/copy/
+// publish builder closures, which differed only by purpose.
+func disclosureIntent(purpose ReauthPurpose, environmentID string) disclosureIntentBuilder {
 	return func(keyIDs []string) (ReauthIntent, error) {
-		return NewRevealReauthIntent(environmentID, keyIDs)
-	}
-}
-
-func copyIntentBuilder(environmentID string) disclosureIntentBuilder {
-	return func(keyIDs []string) (ReauthIntent, error) {
-		return NewCopyReauthIntent(environmentID, keyIDs)
-	}
-}
-
-func publishIntentBuilder(environmentID string) disclosureIntentBuilder {
-	return func(keyIDs []string) (ReauthIntent, error) {
-		return NewPublishReauthIntent(environmentID, keyIDs)
+		return NewDisclosureReauthIntent(purpose, []string{environmentID}, keyIDs)
 	}
 }
 

--- a/internal/service/definitions.go
+++ b/internal/service/definitions.go
@@ -52,10 +52,7 @@ type Definitions struct {
 }
 
 func (s *Definitions) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // scanSnapshot is the ruleset snapshot version a plan is scanned under, recorded
@@ -169,11 +166,7 @@ func (s *Definitions) Export(ctx context.Context, actor Actor, scope domain.Scop
 	defer release()
 	var out []byte
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsExport, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpDefinitionsExport, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -205,11 +198,7 @@ func (s *Definitions) Check(ctx context.Context, actor Actor, scope domain.Scope
 	defer release()
 	var res CheckResult
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsCheck, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpDefinitionsCheck, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -246,11 +235,7 @@ func (s *Definitions) Check(ctx context.Context, actor Actor, scope domain.Scope
 func (s *Definitions) GetSettings(ctx context.Context, actor Actor, scope domain.Scope) (DefinitionsSettings, error) {
 	var out DefinitionsSettings
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsSettingsGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpDefinitionsSettingsGet, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -280,11 +265,7 @@ func (s *Definitions) SetSettings(ctx context.Context, actor Actor, scope domain
 	}
 	var out DefinitionsSettings
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsSettingsSet, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpDefinitionsSettingsSet, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/definitions_apply.go
+++ b/internal/service/definitions_apply.go
@@ -71,11 +71,7 @@ func sanitizeProvenance(field, s string) (string, error) {
 func (s *Definitions) Plan(ctx context.Context, actor Actor, scope domain.Scope, raw []byte, acks []string) (PlanView, error) {
 	var view PlanView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsPlanCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpDefinitionsPlanCreate, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -354,11 +350,7 @@ func (s *Definitions) envRevisions(ctx context.Context, r store.Repos, p authz.P
 func (s *Definitions) GetPlan(ctx context.Context, actor Actor, scope domain.Scope, planID string) (PlanView, error) {
 	var view PlanView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsPlanGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpDefinitionsPlanGet, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/definitions_apply_exec.go
+++ b/internal/service/definitions_apply_exec.go
@@ -57,11 +57,7 @@ func (s *Definitions) Apply(ctx context.Context, actor Actor, scope domain.Scope
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		now := s.now()
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsApply, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpDefinitionsApply, scope, now)
 		if err != nil {
 			return err
 		}
@@ -206,11 +202,7 @@ func (s *Definitions) scanApplySkew(ctx context.Context, actor Actor, scope doma
 	var compiled *definitions.CompiledBundle
 	var overrides []overrideAck
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDefinitionsApply, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpDefinitionsApply, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/delivery.go
+++ b/internal/service/delivery.go
@@ -177,10 +177,7 @@ type DeliveryConformanceProbe interface {
 }
 
 func (s *Delivery) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // Fetch delivers the authorized projection of the addressed environment, or
@@ -291,16 +288,12 @@ func (s *Delivery) FetchAs(ctx context.Context, actor Actor, scope domain.Scope,
 		// pin-expiry check, and the server-asserted snapshot issuance/expiry all
 		// name the same instant.
 		issuedAt := s.now()
-		caller, err := actor.resolve(ctx, az, issuedAt)
-		if err != nil {
-			return err
-		}
 		// The SAME authorization the delivering path performs, because it IS the
 		// delivering path: a caller who has lost `read` gets
 		// authorize()'s uniform nonexistent answer, never "current". A separate
 		// cheap check on the conditional branch is exactly the shape the ADR
 		// forbids.
-		p, err := az.Authorize(ctx, caller, authz.OpDeliveryFetch, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpDeliveryFetch, scope, issuedAt)
 		if err != nil {
 			return err
 		}
@@ -564,11 +557,7 @@ func (s *Delivery) ReconcileOfflineRecordsAs(ctx context.Context, actor Actor, s
 	var out ReconcileResult
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		out = ReconcileResult{}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpDeliveryReconcileOffline, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpDeliveryReconcileOffline, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/dynamic.go
+++ b/internal/service/dynamic.go
@@ -37,10 +37,7 @@ type Dynamic struct {
 }
 
 func (s *Dynamic) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 var (
@@ -125,8 +122,8 @@ type CreateDynamicProviderRequest struct {
 }
 
 func (s *Dynamic) Configure(ctx context.Context, actor Actor, scope domain.Scope, req CreateDynamicProviderRequest) (DynamicProviderView, error) {
-	if scope.Project == "" || scope.Env != "" {
-		return DynamicProviderView{}, fmt.Errorf("%w: dynamic provider create requires project scope", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "dynamic provider create requires project scope"); err != nil {
+		return DynamicProviderView{}, err
 	}
 	kind, err := dynamic.ParseKind(req.Kind)
 	if err != nil {
@@ -172,11 +169,7 @@ func (s *Dynamic) Configure(ctx context.Context, actor Actor, scope domain.Scope
 	now := store.CanonTime(s.now())
 	var out DynamicProviderView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderConfigure, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderConfigure, scope, now)
 		if err != nil {
 			return err
 		}
@@ -204,17 +197,13 @@ func (s *Dynamic) Configure(ctx context.Context, actor Actor, scope domain.Scope
 }
 
 func (s *Dynamic) List(ctx context.Context, actor Actor, scope domain.Scope) ([]DynamicProviderView, error) {
-	if scope.Project == "" || scope.Env != "" {
-		return nil, fmt.Errorf("%w: dynamic provider list requires project scope", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "dynamic provider list requires project scope"); err != nil {
+		return nil, err
 	}
 	var out []DynamicProviderView
 	now := store.CanonTime(s.now())
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderInspect, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderInspect, scope, now)
 		if err != nil {
 			return err
 		}
@@ -226,7 +215,7 @@ func (s *Dynamic) List(ctx context.Context, actor Actor, scope domain.Scope) ([]
 		for _, row := range rows {
 			out = append(out, DynamicProviderView{DynamicProviderRecord: row})
 		}
-		return insertInspected(ctx, r, proof, caller.Principal, "dynamic-provider-list", int64(len(rows)))
+		return insertInspected(ctx, r, proof, caller.Principal, audit.EventDynamicProviderInspected, audit.Object{Type: "dynamic-provider", ID: "dynamic-provider-list"}, int64(len(rows)))
 	})
 	return out, err
 }
@@ -234,27 +223,14 @@ func (s *Dynamic) List(ctx context.Context, actor Actor, scope domain.Scope) ([]
 // insertInspected records the manage-identities-gated read of provider
 // metadata, mirroring adapter.inspect. A privileged read audits; only a
 // bare-read lease inspect is auditedNone.
-func insertInspected(ctx context.Context, r store.Repos, proof authz.Proof, principal domain.PrincipalID, objectID string, rowCount int64) error {
-	ev, err := domainEvent(ctx, audit.EventDynamicProviderInspected, principal,
-		audit.Object{Type: "dynamic-provider", ID: objectID}, audit.Payload{"row_count": rowCount})
-	if err != nil {
-		return err
-	}
-	return r.Audit().InsertTenant(ctx, proof, ev)
-}
-
 func (s *Dynamic) Get(ctx context.Context, actor Actor, scope domain.Scope, providerID string) (DynamicProviderView, error) {
-	if scope.Project == "" || scope.Env != "" || providerID == "" {
-		return DynamicProviderView{}, fmt.Errorf("%w: dynamic provider show requires project scope and provider id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "dynamic provider show requires project scope and provider id", providerID); err != nil {
+		return DynamicProviderView{}, err
 	}
 	var out DynamicProviderView
 	now := store.CanonTime(s.now())
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderInspect, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderInspect, scope, now)
 		if err != nil {
 			return err
 		}
@@ -263,7 +239,7 @@ func (s *Dynamic) Get(ctx context.Context, actor Actor, scope domain.Scope, prov
 			return err
 		}
 		out = DynamicProviderView{DynamicProviderRecord: record}
-		return insertInspected(ctx, r, proof, caller.Principal, providerID, 1)
+		return insertInspected(ctx, r, proof, caller.Principal, audit.EventDynamicProviderInspected, audit.Object{Type: "dynamic-provider", ID: providerID}, 1)
 	})
 	return out, err
 }
@@ -274,11 +250,7 @@ func (s *Dynamic) Get(ctx context.Context, actor Actor, scope domain.Scope, prov
 func (s *Dynamic) providerMetadata(ctx context.Context, actor Actor, scope domain.Scope, providerID string) (store.DynamicProviderRecord, error) {
 	var out store.DynamicProviderRecord
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderCredentialSet, scope)
+		_, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderCredentialSet, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -321,11 +293,7 @@ func (s *Dynamic) ReplaceCredential(ctx context.Context, actor Actor, scope doma
 	}
 	now := store.CanonTime(s.now())
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderCredentialSet, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderCredentialSet, scope, now)
 		if err != nil {
 			return err
 		}
@@ -347,16 +315,12 @@ func (s *Dynamic) ReplaceCredential(ctx context.Context, actor Actor, scope doma
 }
 
 func (s *Dynamic) RevokeCredential(ctx context.Context, actor Actor, scope domain.Scope, providerID string) error {
-	if scope.Project == "" || scope.Env != "" || providerID == "" {
-		return fmt.Errorf("%w: credential revocation requires project scope and provider id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "credential revocation requires project scope and provider id", providerID); err != nil {
+		return err
 	}
 	now := store.CanonTime(s.now())
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderCredentialRevoke, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderCredentialRevoke, scope, now)
 		if err != nil {
 			return err
 		}
@@ -379,18 +343,14 @@ type DeleteResult struct {
 }
 
 func (s *Dynamic) Delete(ctx context.Context, actor Actor, scope domain.Scope, providerID string, revokeAll bool) (DeleteResult, error) {
-	if scope.Project == "" || scope.Env != "" || providerID == "" {
-		return DeleteResult{}, fmt.Errorf("%w: dynamic provider delete requires project scope and provider id", domain.ErrInvalid)
+	if err := requireProjectScope(scope, "dynamic provider delete requires project scope and provider id", providerID); err != nil {
+		return DeleteResult{}, err
 	}
 	now := store.CanonTime(s.now())
 	var out DeleteResult
 	out.ProviderID = providerID
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpDynamicProviderDelete, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpDynamicProviderDelete, scope, now)
 		if err != nil {
 			return err
 		}
@@ -483,11 +443,7 @@ func (s *Dynamic) MintLease(ctx context.Context, actor Actor, scope domain.Scope
 	)
 	now := store.CanonTime(s.now())
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpLeaseMint, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpLeaseMint, scope, now)
 		if err != nil {
 			return err
 		}
@@ -569,11 +525,7 @@ func (s *Dynamic) MintLease(ctx context.Context, actor Actor, scope domain.Scope
 		disclosed   bool
 	)
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, settleNow)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpLeaseMint, scope)
+		caller, proof, err := authorize(ctx, az, actor, authz.OpLeaseMint, scope, settleNow)
 		if err != nil {
 			return err
 		}
@@ -691,11 +643,7 @@ func (s *Dynamic) ListLeases(ctx context.Context, actor Actor, scope domain.Scop
 	}
 	var out []DynamicLeaseView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpLeaseInspect, scope)
+		_, proof, err := authorize(ctx, az, actor, authz.OpLeaseInspect, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -717,11 +665,7 @@ func (s *Dynamic) GetLease(ctx context.Context, actor Actor, scope domain.Scope,
 	}
 	var out DynamicLeaseView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpLeaseInspect, scope)
+		_, proof, err := authorize(ctx, az, actor, authz.OpLeaseInspect, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -754,11 +698,7 @@ func (s *Dynamic) enqueueLeaseTransition(ctx context.Context, actor Actor, scope
 	now := store.CanonTime(s.now())
 	var out DynamicLeaseView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, op, scope)
+		caller, proof, err := authorize(ctx, az, actor, op, scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -132,10 +132,7 @@ type Federation struct {
 }
 
 func (s *Federation) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // IssuerView is one issuer configuration. The API renders only KeySource.Mode;
@@ -177,11 +174,7 @@ func (s *Federation) CreateIssuer(ctx context.Context, actor Actor, req IssuerRe
 	now := s.now()
 	var out IssuerView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFederationIssuerCreate, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpFederationIssuerCreate, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -216,11 +209,7 @@ func (s *Federation) UpdateIssuer(ctx context.Context, actor Actor, id string, s
 	now := s.now()
 	var out IssuerView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFederationIssuerUpdate, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpFederationIssuerUpdate, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -260,11 +249,7 @@ func (s *Federation) ListIssuers(ctx context.Context, actor Actor) ([]IssuerView
 	now := s.now()
 	var out []IssuerView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFederationIssuerList, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpFederationIssuerList, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -307,11 +292,7 @@ func (s *Federation) ListIssuers(ctx context.Context, actor Actor) ([]IssuerView
 func (s *Federation) DeleteIssuer(ctx context.Context, actor Actor, id string) error {
 	now := s.now()
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFederationIssuerDelete, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpFederationIssuerDelete, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -433,11 +414,7 @@ func (s *Federation) CreateBinding(ctx context.Context, actor Actor, scope domai
 	now := s.now()
 	var out BindingView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpBindingCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpBindingCreate, scope, now)
 		if err != nil {
 			return err
 		}
@@ -521,7 +498,7 @@ func (s *Federation) CreateBinding(ctx context.Context, actor Actor, scope domai
 		if s.Auth == nil {
 			return errors.New("service: the federation surface has no reauthentication seam wired")
 		}
-		current, historical := sortedKeys(reach.Current), sortedKeys(reach.Historical)
+		current, historical := slices.Sorted(maps.Keys(reach.Current)), slices.Sorted(maps.Keys(reach.Historical))
 		if err := s.Auth.RequireDisclosureAuthority(ctx, az, caller, actorGrants, scope, current, historical, now); err != nil {
 			return err
 		}
@@ -619,14 +596,10 @@ func (s *Federation) Reactivate(ctx context.Context, actor Actor, scope domain.S
 	now := s.now()
 	var at time.Time
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
 		// Re-activation NARROWS: it can only refuse tokens the binding would
 		// otherwise have accepted. So it rides the plain capability, like every
 		// other narrowing, with no disclosure gate.
-		p, err := az.Authorize(ctx, caller, authz.OpCredentialRevoke, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpCredentialRevoke, scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/grants.go
+++ b/internal/service/grants.go
@@ -123,10 +123,7 @@ type Grants struct {
 }
 
 func (s *Grants) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // GrantSpec names one grant: who gets what, where.
@@ -197,11 +194,7 @@ func (s *Grants) Create(ctx context.Context, actor Actor, spec GrantSpec) (Grant
 		if err != nil {
 			return err
 		}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, ops.create, spec.Scope)
+		caller, p, err := authorize(ctx, az, actor, ops.create, spec.Scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -849,11 +842,7 @@ func (s *Grants) Revoke(ctx context.Context, actor Actor, spec GrantSpec) error 
 		if err != nil {
 			return err
 		}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, ops.revoke, spec.Scope)
+		caller, p, err := authorize(ctx, az, actor, ops.revoke, spec.Scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -1090,11 +1079,7 @@ func (s *Grants) ApplyTemplate(ctx context.Context, actor Actor, template domain
 		if err != nil {
 			return err
 		}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, ops.template, scope)
+		caller, p, err := authorize(ctx, az, actor, ops.template, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -1213,11 +1198,7 @@ func (s *Grants) List(ctx context.Context, actor Actor, scope domain.Scope) ([]M
 		if ops.list == "" {
 			return fmt.Errorf("%w: the membership surface is listed at org, project or instance scope", domain.ErrInvalid)
 		}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, ops.list, scope)
+		caller, p, err := authorize(ctx, az, actor, ops.list, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/hierarchy.go
+++ b/internal/service/hierarchy.go
@@ -183,11 +183,7 @@ func (s *Orgs) Create(ctx context.Context, actor Actor, name string, active bool
 	// This is a low-rate control-plane operation; sqlite already admits one
 	// writer at a time through BEGIN IMMEDIATE.
 	err = tx.WriteSerialized(ctx, s.DB, "hikyo:org-create", func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgCreate, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpOrgCreate, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -231,11 +227,7 @@ func (s *Orgs) Create(ctx context.Context, actor Actor, name string, active bool
 func (s *Orgs) Get(ctx context.Context, actor Actor, org domain.OrgID) (Org, error) {
 	var out store.Org
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgGet, domain.Scope{Org: org})
+		_, p, err := authorize(ctx, az, actor, authz.OpOrgGet, domain.Scope{Org: org}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -317,11 +309,7 @@ func (s *Orgs) ListMine(ctx context.Context, actor Actor) ([]MyOrg, error) {
 func (s *Orgs) List(ctx context.Context, actor Actor) ([]Org, error) {
 	var out []store.Org
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgList, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpOrgList, domain.Scope{}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -349,11 +337,7 @@ func (s *Orgs) List(ctx context.Context, actor Actor) ([]Org, error) {
 func (s *Orgs) Count(ctx context.Context, actor Actor) (int64, error) {
 	var out int64
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgList, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpOrgList, domain.Scope{}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -380,11 +364,7 @@ func (s *Orgs) Rename(ctx context.Context, actor Actor, org domain.OrgID, name s
 	}
 	var out store.Org
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgRename, domain.Scope{Org: org})
+		caller, p, err := authorize(ctx, az, actor, authz.OpOrgRename, domain.Scope{Org: org}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -421,11 +401,7 @@ func (s *Orgs) Rename(ctx context.Context, actor Actor, org domain.OrgID, name s
 // keeps the ancestry constraint live and the whole transaction rolls back.
 func (s *Orgs) Delete(ctx context.Context, actor Actor, org domain.OrgID) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgDelete, domain.Scope{Org: org})
+		caller, p, err := authorize(ctx, az, actor, authz.OpOrgDelete, domain.Scope{Org: org}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -522,11 +498,7 @@ func (s *Projects) Create(ctx context.Context, actor Actor, org domain.OrgID, na
 	}
 	proj := store.NewProject{ID: id, Name: name, CreatedAt: store.CanonTime(time.Now())}
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectCreate, domain.Scope{Org: org})
+		caller, p, err := authorize(ctx, az, actor, authz.OpProjectCreate, domain.Scope{Org: org}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -550,11 +522,7 @@ func (s *Projects) Create(ctx context.Context, actor Actor, org domain.OrgID, na
 func (s *Projects) Get(ctx context.Context, actor Actor, scope domain.Scope) (Project, error) {
 	var out store.Project
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpProjectGet, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -570,11 +538,7 @@ func (s *Projects) Get(ctx context.Context, actor Actor, scope domain.Scope) (Pr
 func (s *Projects) List(ctx context.Context, actor Actor, org domain.OrgID) ([]Project, error) {
 	var out []store.Project
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectList, domain.Scope{Org: org})
+		_, p, err := authorize(ctx, az, actor, authz.OpProjectList, domain.Scope{Org: org}, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -597,11 +561,7 @@ func (s *Projects) Rename(ctx context.Context, actor Actor, scope domain.Scope, 
 	}
 	var out store.Project
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectRename, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpProjectRename, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -636,11 +596,7 @@ func (s *Projects) Rename(ctx context.Context, actor Actor, scope domain.Scope, 
 // by the ancestry constraints as a conflict.
 func (s *Projects) Delete(ctx context.Context, actor Actor, scope domain.Scope) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectDelete, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpProjectDelete, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -785,11 +741,7 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		clone = CloneResult{}
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpEnvCreate, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -861,7 +813,7 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 			// can be evaluated against the environment being created — which
 			// is what the ADR requires it to be evaluated against.
 			clone, err = cloneInto(ctx, r, az, caller, sealer, s.Keyring, s.Scan, scope, sourceEnvID, created.ID,
-				ceremonyGate(ctx, s.Auth, az, caller, copyIntentBuilder(sourceEnvID)))
+				ceremonyGate(ctx, s.Auth, az, caller, disclosureIntent(PurposeCopy, sourceEnvID)))
 			if err != nil {
 				return err
 			}
@@ -891,11 +843,7 @@ func (s *Environments) create(ctx context.Context, actor Actor, scope domain.Sco
 func (s *Environments) Get(ctx context.Context, actor Actor, scope domain.Scope) (Environment, error) {
 	var out store.Environment
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvRead, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpEnvRead, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -912,11 +860,7 @@ func (s *Environments) Get(ctx context.Context, actor Actor, scope domain.Scope)
 func (s *Environments) List(ctx context.Context, actor Actor, scope domain.Scope) ([]Environment, error) {
 	var out []store.Environment
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvList, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpEnvList, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -940,11 +884,7 @@ func (s *Environments) Rename(ctx context.Context, actor Actor, scope domain.Sco
 	var out store.Environment
 	var rateCharged bool
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvRename, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpEnvRename, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1004,11 +944,7 @@ func (s *Environments) Rename(ctx context.Context, actor Actor, scope domain.Sco
 func (s *Environments) Reorder(ctx context.Context, actor Actor, scope domain.Scope, ordered []string) ([]Environment, error) {
 	var out []store.Environment
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvReorder, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpEnvReorder, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1084,11 +1020,7 @@ func (s *Environments) Reorder(ctx context.Context, actor Actor, scope domain.Sc
 func (s *Environments) Delete(ctx context.Context, actor Actor, scope domain.Scope) error {
 	var rateCharged bool
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvDelete, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpEnvDelete, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1168,11 +1100,7 @@ func (s *Environments) Delete(ctx context.Context, actor Actor, scope domain.Sco
 // `definitions-edit(project)` are enforced as different authorities.
 func (s *Environments) UpdateNote(ctx context.Context, actor Actor, scope domain.Scope, note string, acks []string) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvUpdateNote, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpEnvUpdateNote, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1233,11 +1161,7 @@ func (s *Folders) Create(ctx context.Context, actor Actor, scope domain.Scope, p
 	}
 	folder := store.NewFolder{ID: id, Path: path, CreatedAt: store.CanonTime(time.Now())}
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFolderCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpFolderCreate, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1272,11 +1196,7 @@ func (s *Folders) Create(ctx context.Context, actor Actor, scope domain.Scope, p
 func (s *Folders) Get(ctx context.Context, actor Actor, scope domain.Scope, id string) (Folder, error) {
 	var out store.Folder
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFolderGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpFolderGet, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1292,11 +1212,7 @@ func (s *Folders) Get(ctx context.Context, actor Actor, scope domain.Scope, id s
 func (s *Folders) List(ctx context.Context, actor Actor, scope domain.Scope) ([]Folder, error) {
 	var out []store.Folder
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFolderList, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpFolderList, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1322,11 +1238,7 @@ func (s *Folders) Rename(ctx context.Context, actor Actor, scope domain.Scope, i
 	}
 	var out store.Folder
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFolderRename, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpFolderRename, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1365,11 +1277,7 @@ func (s *Folders) Rename(ctx context.Context, actor Actor, scope domain.Scope, i
 
 func (s *Folders) Delete(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpFolderDelete, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpFolderDelete, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}

--- a/internal/service/identities.go
+++ b/internal/service/identities.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -96,10 +98,7 @@ type Identities struct {
 }
 
 func (s *Identities) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // ServiceAccountView is the metadata surface of one service account.
@@ -216,11 +215,7 @@ func (s *Identities) CreateServiceAccount(ctx context.Context, actor Actor, scop
 	now := s.now()
 	var out ServiceAccountView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpServiceAccountCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpServiceAccountCreate, scope, now)
 		if err != nil {
 			return err
 		}
@@ -259,11 +254,7 @@ func (s *Identities) ListServiceAccounts(ctx context.Context, actor Actor, scope
 	now := s.now()
 	var out []ServiceAccountView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpServiceAccountList, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpServiceAccountList, scope, now)
 		if err != nil {
 			return err
 		}
@@ -310,11 +301,7 @@ func (s *Identities) ListServiceAccounts(ctx context.Context, actor Actor, scope
 func (s *Identities) DeleteServiceAccount(ctx context.Context, actor Actor, scope domain.Scope, id string) error {
 	now := s.now()
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpServiceAccountDelete, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpServiceAccountDelete, scope, now)
 		if err != nil {
 			return err
 		}
@@ -365,11 +352,7 @@ func (s *Identities) MintCredential(ctx context.Context, actor Actor, scope doma
 	now := s.now()
 	var out MintResult
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpCredentialMint, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpCredentialMint, scope, now)
 		if err != nil {
 			return err
 		}
@@ -430,7 +413,7 @@ func (s *Identities) MintCredential(ctx context.Context, actor Actor, scope doma
 		if s.Auth == nil {
 			return errors.New("service: the identity surface has no reauthentication seam wired")
 		}
-		current, historical := sortedKeys(reach.Current), sortedKeys(reach.Historical)
+		current, historical := slices.Sorted(maps.Keys(reach.Current)), slices.Sorted(maps.Keys(reach.Historical))
 		if err := s.Auth.RequireDisclosureAuthority(ctx, az, caller, actorGrants, scope, current, historical, now); err != nil {
 			return err
 		}
@@ -496,11 +479,7 @@ func (s *Identities) ListCredentials(ctx context.Context, actor Actor, scope dom
 	now := s.now()
 	var out []CredentialView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpCredentialList, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpCredentialList, scope, now)
 		if err != nil {
 			return err
 		}
@@ -569,11 +548,7 @@ func (s *Identities) ListCredentials(ctx context.Context, actor Actor, scope dom
 func (s *Identities) RevokeCredential(ctx context.Context, actor Actor, scope domain.Scope, saID, credentialID string) error {
 	now := s.now()
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpCredentialRevoke, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpCredentialRevoke, scope, now)
 		if err != nil {
 			return err
 		}
@@ -630,11 +605,7 @@ type PolicyView struct {
 func (s *Identities) Policy(ctx context.Context, actor Actor) (PolicyView, error) {
 	var out PolicyView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpCredentialPolicyRead, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpCredentialPolicyRead, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -730,11 +701,7 @@ func (s *Identities) SetPolicy(ctx context.Context, actor Actor, change PolicyCh
 	now := s.now()
 	var out PolicyResult
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpCredentialPolicyUpdate, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpCredentialPolicyUpdate, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -935,10 +902,6 @@ func expiringSoon(c CredentialView, now time.Time) bool {
 		return false
 	}
 	return c.ExpiresAt.After(now) && c.ExpiresAt.Before(now.Add(ExpiryWarningWindow))
-}
-
-func sortedKeys(m map[domain.EnvID]bool) []domain.EnvID {
-	return newlyReachable(nil, m)
 }
 
 // credentialKindOf answers which kind a credential is, for the revoke event's

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -156,11 +156,7 @@ func (s *Values) Occurrences(ctx context.Context, actor Actor, scope domain.Scop
 	}
 	var out ImportPresence
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpImportPresence, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpImportPresence, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -335,7 +331,7 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 		}
 	}
 
-	sealer, err := s.sealer(ctx, actor, authz.OpValueImport, scope)
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValueImport, scope)
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -360,11 +356,7 @@ func (s *Values) Import(ctx context.Context, actor Actor, scope domain.Scope, re
 		published = PublishedEnvironment{}
 		advanced = false
 		total := 0
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpValueImport, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpValueImport, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}

--- a/internal/service/invite.go
+++ b/internal/service/invite.go
@@ -103,11 +103,7 @@ func (s *Grants) InviteMember(ctx context.Context, actor Actor, spec InviteSpec)
 	expires := now.Add(ResetLifetime)
 	var out InvitationResult
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, op, spec.Scope)
+		caller, p, err := authorize(ctx, az, actor, op, spec.Scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/keys.go
+++ b/internal/service/keys.go
@@ -571,11 +571,7 @@ func (s *Keys) Create(ctx context.Context, actor Actor, scope domain.Scope, spec
 	}
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyCreate, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -670,11 +666,7 @@ func checkGroupMembership(ctx context.Context, r store.Repos, p authz.Proof, gro
 func (s *Keys) Get(ctx context.Context, actor Actor, scope domain.Scope, id string) (Key, error) {
 	var out Key
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpKeyGet, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -699,11 +691,7 @@ func (s *Keys) List(ctx context.Context, actor Actor, scope domain.Scope) ([]Key
 	var out []Key
 	var revision int64
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyList, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpKeyList, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -753,11 +741,7 @@ func (s *Keys) Rename(ctx context.Context, actor Actor, scope domain.Scope, id, 
 	}
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyRename, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyRename, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -836,11 +820,7 @@ func (s *Keys) UpdateMetadata(ctx context.Context, actor Actor, scope domain.Sco
 	var out Key
 	var rateCharged bool
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyUpdateMetadata, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyUpdateMetadata, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -985,11 +965,7 @@ func (s *Keys) UpdateDeclaration(ctx context.Context, actor Actor, scope domain.
 	}
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyUpdateDeclaration, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyUpdateDeclaration, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1147,11 +1123,7 @@ func (s *Keys) Reclassify(ctx context.Context, actor Actor, scope domain.Scope, 
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		findings = nil
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyReclassify, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyReclassify, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1317,11 +1289,7 @@ func (s *Keys) SetGroup(ctx context.Context, actor Actor, scope domain.Scope, id
 	}
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeySetGroup, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeySetGroup, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1421,11 +1389,7 @@ func (s *Keys) Delete(ctx context.Context, actor Actor, scope domain.Scope, id s
 	}
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyDelete, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyDelete, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1517,11 +1481,7 @@ func (s *KeyGroups) Create(ctx context.Context, actor Actor, scope domain.Scope,
 	created := store.CanonTime(time.Now())
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyGroupCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyGroupCreate, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1574,11 +1534,7 @@ func (s *KeyGroups) Create(ctx context.Context, actor Actor, scope domain.Scope,
 func (s *KeyGroups) Get(ctx context.Context, actor Actor, scope domain.Scope, id string) (KeyGroupView, error) {
 	var out KeyGroupView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyGroupGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpKeyGroupGet, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1599,11 +1555,7 @@ func (s *KeyGroups) Get(ctx context.Context, actor Actor, scope domain.Scope, id
 func (s *KeyGroups) List(ctx context.Context, actor Actor, scope domain.Scope) ([]KeyGroupView, error) {
 	var out []KeyGroupView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyGroupList, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpKeyGroupList, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1653,11 +1605,7 @@ func (s *KeyGroups) Rename(ctx context.Context, actor Actor, scope domain.Scope,
 	var out KeyGroupView
 	var rateCharged bool
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyGroupRename, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyGroupRename, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}
@@ -1717,11 +1665,7 @@ func (s *KeyGroups) Delete(ctx context.Context, actor Actor, scope domain.Scope,
 	}
 	var rateCharged bool
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, time.Now().UTC())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpKeyGroupDelete, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpKeyGroupDelete, scope, time.Now().UTC())
 		if err != nil {
 			return err
 		}

--- a/internal/service/oidc.go
+++ b/internal/service/oidc.go
@@ -229,10 +229,7 @@ type Providers struct {
 }
 
 func (s *Providers) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // ProviderView is a provider as returned to an administrator. The client secret
@@ -280,10 +277,6 @@ func (s *Providers) redirectURI(slug string) string {
 func (s *Providers) Put(ctx context.Context, actor Actor, slug string, in ProviderInput) (ProviderView, error) {
 	var out ProviderView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
 		// Authorize BEFORE discovery closes an SSRF: only an instance-config
 		// holder may make the server fetch an arbitrary issuer URL. Discovery
 		// then validates the issuer (byte-exact) before anything is written.
@@ -293,7 +286,7 @@ func (s *Providers) Put(ctx context.Context, actor Actor, slug string, in Provid
 		// Acceptable here where login is not: provider configuration is a rare
 		// operator action, not a hot path. If provider churn ever matters, split
 		// it read/discover/write like the login path.
-		p, err := az.Authorize(ctx, caller, authz.OpProviderPut, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpProviderPut, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -413,11 +406,7 @@ func (s *Providers) update(ctx context.Context, r store.Repos, az *authz.TxAutho
 func (s *Providers) Get(ctx context.Context, actor Actor, slug string) (ProviderView, error) {
 	var out ProviderView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProviderGet, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpProviderGet, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -438,11 +427,7 @@ func (s *Providers) Get(ctx context.Context, actor Actor, slug string) (Provider
 func (s *Providers) List(ctx context.Context, actor Actor) ([]ProviderView, error) {
 	var out []ProviderView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProviderList, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpProviderList, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -465,11 +450,7 @@ func (s *Providers) List(ctx context.Context, actor Actor) ([]ProviderView, erro
 // can race the delete.
 func (s *Providers) Delete(ctx context.Context, actor Actor, slug string) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProviderDelete, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpProviderDelete, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/pins.go
+++ b/internal/service/pins.go
@@ -39,10 +39,7 @@ type Pins struct {
 }
 
 func (s *Pins) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 type SetPinRequest struct {
@@ -190,11 +187,7 @@ func (s *Pins) Set(ctx context.Context, actor Actor, scope domain.Scope, request
 	var validationRefusal error
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		validationRefusal = nil
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpPinSet, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpPinSet, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -489,11 +482,7 @@ func (s *Pins) List(ctx context.Context, actor Actor, scope domain.Scope) ([]Pin
 	now := s.now()
 	var out []PinView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpPinList, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpPinList, scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/publish.go
+++ b/internal/service/publish.go
@@ -95,10 +95,7 @@ type PublishConformanceProbe interface {
 }
 
 func (s *Revisions) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // PublishedEnvironment is one environment a materialization advanced.
@@ -287,14 +284,10 @@ func (s *Revisions) PublishPlanned(ctx context.Context, actor Actor, scope domai
 		// take real time, and a credential expiring during it must be refused
 		// by the authentication this publish actually rides.
 		now := s.now()
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
 		// The addressed environment is authorized FIRST: a caller who may not
 		// publish here learns nothing from the selection read, and the uniform
 		// nonexistent answer is the only thing they see.
-		p, err := az.Authorize(ctx, caller, authz.OpValuePublish, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpValuePublish, scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/reauth_intent.go
+++ b/internal/service/reauth_intent.go
@@ -112,10 +112,6 @@ func NewRevealReauthIntent(environmentID string, keyIDs []string) (ReauthIntent,
 	return NewDisclosureReauthIntent(PurposeReveal, []string{environmentID}, keyIDs)
 }
 
-func NewCopyReauthIntent(environmentID string, keyIDs []string) (ReauthIntent, error) {
-	return NewDisclosureReauthIntent(PurposeCopy, []string{environmentID}, keyIDs)
-}
-
 func NewPublishReauthIntent(environmentID string, keyIDs []string) (ReauthIntent, error) {
 	return NewDisclosureReauthIntent(PurposePublish, []string{environmentID}, keyIDs)
 }
@@ -164,9 +160,14 @@ func newReauthIntentForOperation(operation authz.Operation, environmentID string
 	return newDisclosureReauthIntent(descriptor.variant, []string{environmentID}, keyIDs)
 }
 
+// canonicalSet returns ids sorted with adjacent duplicates removed, without
+// mutating the caller's slice.
+func canonicalSet(ids []string) []string {
+	return slices.Compact(slices.Sorted(slices.Values(ids)))
+}
+
 func newDisclosureReauthIntent(variant reauthIntentVariant, environmentIDs, keyIDs []string) (ReauthIntent, error) {
-	canonicalEnvironments := slices.Sorted(slices.Values(environmentIDs))
-	canonicalEnvironments = slices.Compact(canonicalEnvironments)
+	canonicalEnvironments := canonicalSet(environmentIDs)
 	if len(canonicalEnvironments) == 0 {
 		return ReauthIntent{}, fmt.Errorf("%w: reauthentication intent requires an environment", domain.ErrInvalid)
 	}
@@ -224,8 +225,7 @@ func newReauthIntentFromBinding(purpose ReauthPurpose, operation authz.Operation
 }
 
 func newAdapterReauthIntent(variant reauthIntentVariant, environmentIDs []string) (ReauthIntent, error) {
-	canonical := slices.Sorted(slices.Values(environmentIDs))
-	canonical = slices.Compact(canonical)
+	canonical := canonicalSet(environmentIDs)
 	if len(canonical) == 0 {
 		return ReauthIntent{}, fmt.Errorf("%w: adapter reauthentication intent requires environments", domain.ErrInvalid)
 	}

--- a/internal/service/reauth_intent_test.go
+++ b/internal/service/reauth_intent_test.go
@@ -72,7 +72,7 @@ func TestReauthIntentDerivesCanonicalBinding(t *testing.T) {
 		{
 			name: "copy",
 			make: func(t *testing.T) ReauthIntent {
-				intent, err := NewCopyReauthIntent("env_prod", []string{"key_b", "key_a"})
+				intent, err := NewDisclosureReauthIntent(PurposeCopy, []string{"env_prod"}, []string{"key_b", "key_a"})
 				return mustReauthIntent(t, intent, err)
 			},
 			wantPurpose:          PurposeCopy,

--- a/internal/service/reencrypt.go
+++ b/internal/service/reencrypt.go
@@ -78,10 +78,7 @@ func (s *Reencrypt) chunkPause() time.Duration {
 }
 
 func (s *Reencrypt) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // ReencryptResult reports one reencrypt run: the scope and how many rows moved.
@@ -487,11 +484,7 @@ func (s *Reencrypt) pause(ctx context.Context) error {
 
 func (s *Reencrypt) retireInstance(ctx context.Context, actor Actor, moved int, active uint32, tables []instanceTable) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpReencryptInstance, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpReencryptInstance, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -645,11 +638,7 @@ func (s *Reencrypt) walkTable(
 // scope.
 func (s *Reencrypt) retireProject(ctx context.Context, actor Actor, scope domain.Scope, moved int, active uint32, tables []projectTable) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpReencryptProject, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpReencryptProject, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/remotes.go
+++ b/internal/service/remotes.go
@@ -64,10 +64,7 @@ func (s *Remotes) fetchGate() *fetchGate {
 }
 
 func (s *Remotes) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // RemoteView is one directory card entry: the stored configuration plus the
@@ -171,11 +168,7 @@ func (s *Remotes) AddRemote(ctx context.Context, actor Actor, name, rawURL, pin,
 		known        map[string]string // remote identity -> entry name
 	)
 	if err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteAdd, domain.Scope{})
+		_, p, err := authorize(ctx, az, actor, authz.OpRemoteAdd, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -221,11 +214,7 @@ func (s *Remotes) AddRemote(ctx context.Context, actor Actor, name, rawURL, pin,
 	}
 	var out RemoteView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteAdd, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteAdd, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -360,11 +349,7 @@ func (s *Remotes) loadForFetch(ctx context.Context, actor Actor, now time.Time, 
 		snaps   = map[string]store.RemoteSnapshot{}
 	)
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, op, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, op, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -500,11 +485,7 @@ func (s *Remotes) settle(
 	// inferring it would put the wrong operation name on the audit trail.
 	var views []RemoteView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, op, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, op, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -611,11 +592,7 @@ func (s *Remotes) RenameRemote(ctx context.Context, actor Actor, name, newName s
 	now := s.now()
 	var out RemoteView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteRename, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteRename, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -656,11 +633,7 @@ func (s *Remotes) RenameRemote(ctx context.Context, actor Actor, name, newName s
 func (s *Remotes) RemoveRemote(ctx context.Context, actor Actor, name string) error {
 	now := s.now()
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteRemove, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteRemove, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/retention.go
+++ b/internal/service/retention.go
@@ -98,10 +98,7 @@ type Retention struct {
 }
 
 func (s *Retention) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 func storePolicy(policy RetentionPolicy) store.RetentionPolicy {
@@ -162,11 +159,7 @@ func formatRetentionPolicy(policy RetentionPolicy) string {
 func (s *Retention) GetOrg(ctx context.Context, actor Actor, orgID domain.OrgID) (RetentionPolicy, error) {
 	var out RetentionPolicy
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgRetentionRead, domain.Scope{Org: orgID})
+		_, p, err := authorize(ctx, az, actor, authz.OpOrgRetentionRead, domain.Scope{Org: orgID}, s.now())
 		if err != nil {
 			return err
 		}
@@ -189,11 +182,7 @@ func (s *Retention) SetOrg(ctx context.Context, actor Actor, orgID domain.OrgID,
 	}
 	var out RetentionPolicy
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpOrgRetentionUpdate, domain.Scope{Org: orgID})
+		caller, p, err := authorize(ctx, az, actor, authz.OpOrgRetentionUpdate, domain.Scope{Org: orgID}, s.now())
 		if err != nil {
 			return err
 		}
@@ -249,11 +238,7 @@ func (s *Retention) SetOrg(ctx context.Context, actor Actor, orgID domain.OrgID,
 func (s *Retention) GetProject(ctx context.Context, actor Actor, scope domain.Scope) (ProjectRetention, error) {
 	var out ProjectRetention
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectRetentionRead, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpProjectRetentionRead, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -279,11 +264,7 @@ func (s *Retention) GetProject(ctx context.Context, actor Actor, scope domain.Sc
 func (s *Retention) SetProject(ctx context.Context, actor Actor, scope domain.Scope, want *RetentionPolicy) (ProjectRetention, error) {
 	var out ProjectRetention
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectRetentionUpdate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpProjectRetentionUpdate, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -577,11 +558,7 @@ func (s *Retention) GetHealth(ctx context.Context, actor Actor) (PruneHealth, er
 	var out PruneHealth
 	now := s.now()
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpRetentionHealthRead, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpRetentionHealthRead, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/revisions.go
+++ b/internal/service/revisions.go
@@ -114,11 +114,7 @@ func (s *Revisions) History(ctx context.Context, actor Actor, scope domain.Scope
 	var out []RevisionView
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		out = nil
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRevisionList, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpRevisionList, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -159,11 +155,7 @@ func (s *Revisions) Show(ctx context.Context, actor Actor, scope domain.Scope, r
 	var out RevisionDetail
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		out = RevisionDetail{}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRevisionShow, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpRevisionShow, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -261,11 +253,7 @@ func (s *Revisions) Signals(ctx context.Context, actor Actor, scope domain.Scope
 	var out EnvironmentSignals
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		out = EnvironmentSignals{EnvironmentID: string(scope.Env)}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRevisionSignals, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpRevisionSignals, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -340,11 +328,7 @@ func (s *Revisions) PendingDrafts(ctx context.Context, actor Actor, scope domain
 	var out []PendingDraft
 	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
 		out = nil
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpValuePendingList, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpValuePendingList, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -500,7 +484,7 @@ func (s *Revisions) Export(ctx context.Context, actor Actor, scope domain.Scope,
 					unit = append(unit, entry.KeyID)
 				}
 			}
-			gate := ceremonyGate(ctx, s.Auth, az, caller, revealIntentBuilder(string(scope.Env)))
+			gate := ceremonyGate(ctx, s.Auth, az, caller, disclosureIntent(PurposeReveal, string(scope.Env)))
 			if err := gate(unit); err != nil {
 				return revisionExportResult{}, err
 			}
@@ -588,11 +572,7 @@ func (s *Revisions) RotateTokenKey(ctx context.Context, actor Actor) (TokenKeyRo
 	defer abort()
 	next.CreatedAt = store.CanonTime(s.now())
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRotateTokenKey, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRotateTokenKey, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/rollback.go
+++ b/internal/service/rollback.go
@@ -47,11 +47,7 @@ func (s *Revisions) Restore(ctx context.Context, actor Actor, scope domain.Scope
 		out.Preview = ImpactPreview{}
 		announced = nil
 		now := s.now()
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRevisionRestore, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpRevisionRestore, scope, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/rotation.go
+++ b/internal/service/rotation.go
@@ -49,10 +49,7 @@ type RootKeySource interface {
 }
 
 func (s *Rotation) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // DEKScope selects what rotate-dek / reencrypt operate on: one project's DEK,
@@ -123,11 +120,7 @@ func (s *Rotation) RotateDEK(ctx context.Context, actor Actor, scope DEKScope) (
 	next.CreatedAt = store.CanonTime(s.now())
 
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRotateDEK, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRotateDEK, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -225,11 +218,7 @@ func (s *Rotation) RotateMasterKey(ctx context.Context, actor Actor) (MasterKeyR
 	}()
 
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRotateMasterKey, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRotateMasterKey, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -375,11 +364,7 @@ func (s *Rotation) rootRotateFinalize(ctx context.Context, actor Actor) (RootKey
 
 	var newEpoch uint32
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRotateRootKey, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRotateRootKey, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -412,11 +397,7 @@ func (s *Rotation) rootRotateFinalize(ctx context.Context, actor Actor) (RootKey
 // inside its own transaction and does not.
 func (s *Rotation) rootRotationTx(ctx context.Context, actor Actor, event audit.EventType, epoch uint32, mutate func(context.Context, store.Repos, authz.Proof) error) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRotateRootKey, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRotateRootKey, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/saml_providers.go
+++ b/internal/service/saml_providers.go
@@ -62,10 +62,7 @@ func NewSAMLProviders(db *store.DB, keyring *wencrypto.Keyring, externalOrigin s
 }
 
 func (s *SAMLProviders) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 type SAMLProviderInput struct {
@@ -215,11 +212,7 @@ func (s *SAMLProviders) Put(ctx context.Context, actor Actor, slug string, input
 
 	var output SAMLProviderView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLProviderPut, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLProviderPut, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -332,11 +325,7 @@ func (s *SAMLProviders) authorize(ctx context.Context, actor Actor, operation au
 func (s *SAMLProviders) Patch(ctx context.Context, actor Actor, slug string, patch SAMLProviderPatch) (SAMLProviderView, error) {
 	var output SAMLProviderView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLProviderPatch, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLProviderPatch, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -408,11 +397,7 @@ func (s *SAMLProviders) Patch(ctx context.Context, actor Actor, slug string, pat
 func (s *SAMLProviders) Get(ctx context.Context, actor Actor, slug string) (SAMLProviderView, error) {
 	var output SAMLProviderView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLProviderGet, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLProviderGet, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -438,11 +423,7 @@ func (s *SAMLProviders) Get(ctx context.Context, actor Actor, slug string) (SAML
 func (s *SAMLProviders) List(ctx context.Context, actor Actor) ([]SAMLProviderView, error) {
 	var output []SAMLProviderView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLProviderList, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLProviderList, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -468,11 +449,7 @@ func (s *SAMLProviders) List(ctx context.Context, actor Actor) ([]SAMLProviderVi
 
 func (s *SAMLProviders) Delete(ctx context.Context, actor Actor, slug string) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLProviderDelete, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLProviderDelete, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -543,11 +520,7 @@ func (s *SAMLProviders) RefreshMetadata(ctx context.Context, actor Actor, slug s
 	}
 	var output SAMLProviderView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLProviderRefreshMetadata, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLProviderRefreshMetadata, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -1255,11 +1228,7 @@ func (s *SAMLProviders) recordProviderFailure(ctx context.Context, actor Actor, 
 	confirmedCopy := slices.Clone(confirmed)
 	slices.Sort(confirmedCopy)
 	auditErr := tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, operation, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, operation, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/saml_sp_keys.go
+++ b/internal/service/saml_sp_keys.go
@@ -43,11 +43,7 @@ func generatedSPKeyInput(key generatedSAMLSPKey) authz.NewSAMLSPKey {
 func (s *SAMLProviders) ListSPKeys(ctx context.Context, actor Actor) ([]SAMLSPKeyView, error) {
 	var output []SAMLSPKeyView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLSPKeyList, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLSPKeyList, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -97,11 +93,7 @@ func (s *SAMLProviders) RotateSPKey(ctx context.Context, actor Actor) (SAMLSPKey
 	}
 	var output SAMLSPKeyView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLSPKeyRotate, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLSPKeyRotate, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -130,11 +122,7 @@ func (s *SAMLProviders) RotateSPKey(ctx context.Context, actor Actor) (SAMLSPKey
 
 func (s *SAMLProviders) RetireSPKey(ctx context.Context, actor Actor, fingerprint string) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLSPKeyRetire, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLSPKeyRetire, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}
@@ -166,11 +154,7 @@ func (s *SAMLProviders) CompromiseRetireSPKey(ctx context.Context, actor Actor, 
 	}
 	var output SAMLSPKeyView
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpSAMLSPKeyCompromiseRetire, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpSAMLSPKeyCompromiseRetire, domain.Scope{}, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/scim.go
+++ b/internal/service/scim.go
@@ -59,10 +59,7 @@ type SCIM struct {
 }
 
 func (s *SCIM) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 func (s *SCIM) staleness() time.Duration {
@@ -824,11 +821,7 @@ func (s *SCIM) adminTx(
 	body func(context.Context, *scimAdminContext) error,
 ) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, op, domain.Scope{Org: org})
+		caller, p, err := authorize(ctx, az, actor, op, domain.Scope{Org: org}, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/scim_admin.go
+++ b/internal/service/scim_admin.go
@@ -79,11 +79,7 @@ func (s *SCIM) CreateBinding(ctx context.Context, actor Actor, org domain.OrgID,
 	var out SCIMBindingView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMBindingCreate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpSCIMBindingCreate, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -264,11 +260,7 @@ func (s *SCIM) ListBindings(ctx context.Context, actor Actor, org domain.OrgID) 
 	var out []SCIMBindingView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMBindingList, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpSCIMBindingList, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -304,11 +296,7 @@ func (s *SCIM) GetBinding(ctx context.Context, actor Actor, org domain.OrgID, id
 	var out SCIMBindingView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		scope := domain.Scope{Org: org}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpSCIMBindingGet, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpSCIMBindingGet, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/scim_wire.go
+++ b/internal/service/scim_wire.go
@@ -105,11 +105,7 @@ func (s *SCIM) wireTxOnce(
 ) error {
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		now := s.now()
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, op, domain.Scope{Org: org})
+		caller, p, err := authorize(ctx, az, actor, op, domain.Scope{Org: org}, now)
 		if err != nil {
 			return err
 		}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -193,6 +193,46 @@ func (a Actor) resolve(ctx context.Context, az *authz.TxAuthorizer, now time.Tim
 	return identity, nil
 }
 
+// insertInspected records a read/inspect audit event carrying a row_count
+// payload and inserts it under the caller's proof. It is the shared tail of the
+// adapter and dynamic-provider read methods.
+func insertInspected(ctx context.Context, r store.Repos, proof authz.Proof, principal domain.PrincipalID, typ audit.EventType, obj audit.Object, rowCount int64) error {
+	ev, err := domainEvent(ctx, typ, principal, obj, audit.Payload{"row_count": rowCount})
+	if err != nil {
+		return err
+	}
+	return r.Audit().InsertTenant(ctx, proof, ev)
+}
+
+// nowOr returns fn().UTC(), or time.Now().UTC() when fn is nil. It is the shared
+// body of every service's now() clock accessor: an injected clock in tests, the
+// real UTC wall clock in production.
+func nowOr(fn func() time.Time) time.Time {
+	if fn == nil {
+		return time.Now().UTC()
+	}
+	return fn().UTC()
+}
+
+// authorize is the resolve->Authorize prelude every tenant operation runs at
+// the top of its transaction: resolve the caller's live Identity, then mint an
+// operation-bound Proof for the addressed scope. It is a pure extraction of the
+// copy-pasted prelude and preserves the chokepoint exactly — it runs inside the
+// caller's transaction (via the passed authorizer), holds no state, and caches
+// nothing, so "no authorization cache" and "re-authorize before every step"
+// stay mechanical.
+// Named results + bare returns keep any nil out of the authz.Proof position:
+// the proof-forgery analyzer bans a nil literal there, and a bare return yields
+// the zero interface without writing one.
+func authorize(ctx context.Context, az *authz.TxAuthorizer, actor Actor, op authz.Operation, scope domain.Scope, now time.Time) (caller authz.Identity, proof authz.Proof, err error) {
+	caller, err = actor.resolve(ctx, az, now)
+	if err != nil {
+		return
+	}
+	proof, err = az.Authorize(ctx, caller, op, scope)
+	return
+}
+
 // resolveSelf is resolve for the SELF-SCOPED surface (the caller's own session
 // listing and revoke). AuthenticateSelfSurface resolves every HTTP bearer class
 // and applies the request's OpenAPI artifact declaration before narrowing the

--- a/internal/service/settings.go
+++ b/internal/service/settings.go
@@ -75,10 +75,7 @@ type ProjectSettings struct {
 }
 
 func (s *ProjectSettings) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // GetEnvironment reads one environment's protection state and window. It is
@@ -88,11 +85,7 @@ func (s *ProjectSettings) now() time.Time {
 func (s *ProjectSettings) GetEnvironment(ctx context.Context, actor Actor, scope domain.Scope) (EnvironmentSettings, error) {
 	var out EnvironmentSettings
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvSettingsRead, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpEnvSettingsRead, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -116,11 +109,7 @@ func (s *ProjectSettings) SetEnvironment(ctx context.Context, actor Actor, scope
 		if want.HasWindow && want.Window < 0 {
 			return ErrNegativeWindow
 		}
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpEnvSettingsUpdate, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpEnvSettingsUpdate, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -261,11 +250,7 @@ type MachineRevealSettings struct {
 func (s *ProjectSettings) GetMachineReveal(ctx context.Context, actor Actor, scope domain.Scope) (MachineRevealSettings, error) {
 	var out MachineRevealSettings
 	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectMachineRevealGet, scope)
+		_, p, err := authorize(ctx, az, actor, authz.OpProjectMachineRevealGet, scope, s.now())
 		if err != nil {
 			return err
 		}
@@ -289,11 +274,7 @@ func (s *ProjectSettings) GetMachineReveal(ctx context.Context, actor Actor, sco
 func (s *ProjectSettings) SetMachineReveal(ctx context.Context, actor Actor, scope domain.Scope, enabled bool) (MachineRevealSettings, error) {
 	var out MachineRevealSettings
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, s.now())
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpProjectMachineRevealSet, scope)
+		caller, p, err := authorize(ctx, az, actor, authz.OpProjectMachineRevealSet, scope, s.now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/updates.go
+++ b/internal/service/updates.go
@@ -33,10 +33,6 @@ type Updates struct {
 	outcomeMu sync.Mutex
 }
 
-type pendingOutcomeControl interface {
-	PendingOutcomes(context.Context) ([]updater.Job, error)
-}
-
 // Run reconciles helper-owned terminal outcomes independently of any browser.
 // The helper journal is durable, so startup catches outcomes completed while
 // the server was stopped; the short poll records ordinary completions promptly.
@@ -66,6 +62,10 @@ func (s *Updates) Run(ctx context.Context) {
 // closed system authority, then acknowledges it. Browser departure, session
 // expiry, and grant changes after the committed intent cannot erase outcome
 // evidence for an already-authorized privileged action.
+type pendingOutcomeControl interface {
+	PendingOutcomes(context.Context) ([]updater.Job, error)
+}
+
 func (s *Updates) ReconcileOutcomes(ctx context.Context) error {
 	control, ok := s.Control.(pendingOutcomeControl)
 	if !ok {
@@ -128,11 +128,7 @@ func (s *Updates) GetStatus(ctx context.Context, actor Actor) (updatecheck.Statu
 	}
 
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpUpdateStatusRead, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpUpdateStatusRead, domain.Scope{}, now())
 		if err != nil {
 			return err
 		}
@@ -303,11 +299,7 @@ func (s *Updates) recordOutcome(ctx context.Context, actor Actor, job updater.Jo
 		now = s.Now
 	}
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, repos store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now())
-		if err != nil {
-			return err
-		}
-		proof, err := az.Authorize(ctx, caller, authz.OpUpdateJobRead, domain.Scope{})
+		caller, proof, err := authorize(ctx, az, actor, authz.OpUpdateJobRead, domain.Scope{}, now())
 		if err != nil {
 			return err
 		}

--- a/internal/service/values.go
+++ b/internal/service/values.go
@@ -291,10 +291,6 @@ func sealerFor(ctx context.Context, db *store.DB, kr *crypto.Keyring, actor Acto
 }
 
 // sealer is sealerFor bound to this service's datastore and keyring.
-func (s *Values) sealer(ctx context.Context, actor Actor, op authz.Operation, scope domain.Scope) (*crypto.ProjectSealer, error) {
-	return sealerFor(ctx, s.DB, s.Keyring, actor, op, scope)
-}
-
 // valueAAD binds a ciphertext to exactly one row: org, project, environment,
 // key, THIS row id, and the column. Every component is a column on the row
 // being decrypted, so a ciphertext lifted anywhere else stops opening.
@@ -484,7 +480,7 @@ func (s *Values) stage(ctx context.Context, actor Actor, scope domain.Scope, key
 	if scope.Env == "" {
 		return StagedChange{}, fmt.Errorf("%w: a value addresses an environment", domain.ErrInvalid)
 	}
-	sealer, err := s.sealer(ctx, actor, authz.OpValueStage, scope)
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValueStage, scope)
 	if err != nil {
 		return StagedChange{}, err
 	}
@@ -644,7 +640,7 @@ func (s *Values) declare(ctx context.Context, actor Actor, scope domain.Scope, e
 	// Gated on the FIRST destination: a caller who cannot write there cannot
 	// write anywhere in this call, because the whole declare is all-or-nothing.
 	first := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(envIDs[0])}
-	sealer, err := s.sealer(ctx, actor, authz.OpValueSet, first)
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValueSet, first)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -767,7 +763,7 @@ func (s *Values) read(ctx context.Context, actor Actor, scope domain.Scope, keyN
 	case keyName != "":
 		op = authz.OpValueRead
 	}
-	sealer, err := s.sealer(ctx, actor, op, scope)
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, op, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -783,7 +779,7 @@ func (s *Values) read(ctx context.Context, actor Actor, scope domain.Scope, keyN
 				return nil, err
 			}
 			cells, err := readCells(ctx, r.Catalogue(), r.Values(), p, sealer, keyName, true,
-				ceremonyGate(ctx, s.Auth, az, caller, revealIntentBuilder(string(scope.Env))))
+				ceremonyGate(ctx, s.Auth, az, caller, disclosureIntent(PurposeReveal, string(scope.Env))))
 			if err != nil {
 				return nil, err
 			}
@@ -794,11 +790,7 @@ func (s *Values) read(ctx context.Context, actor Actor, scope domain.Scope, keyN
 		})
 	} else {
 		err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
-			caller, err := actor.resolve(ctx, az, time.Now().UTC())
-			if err != nil {
-				return err
-			}
-			p, err := az.Authorize(ctx, caller, op, scope)
+			_, p, err := authorize(ctx, az, actor, op, scope, time.Now().UTC())
 			if err != nil {
 				return err
 			}
@@ -951,7 +943,7 @@ func (s *Values) Diff(ctx context.Context, actor Actor, scope domain.Scope, left
 	if reveal {
 		gate = authz.OpValueReveal
 	}
-	sealer, err := s.sealer(ctx, actor, gate, leftScope)
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, gate, leftScope)
 	if err != nil {
 		return nil, err
 	}
@@ -979,7 +971,7 @@ func (s *Values) Diff(ctx context.Context, actor Actor, scope domain.Scope, left
 			// per-environment: a window open on staging authorizes nothing in
 			// production, which is the whole point of capping production at 0.
 			cells, err := readCells(ctx, cat, vals, p, sealer, "", reveal,
-				ceremonyGate(ctx, s.Auth, az, caller, revealIntentBuilder(envID)))
+				ceremonyGate(ctx, s.Auth, az, caller, disclosureIntent(PurposeReveal, envID)))
 			if err != nil {
 				return nil, err
 			}
@@ -1098,7 +1090,7 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 	}
 	// Gated on the source read, which every copy needs whatever it carries.
 	sourceScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(req.SourceEnvironmentID)}
-	sealer, err := s.sealer(ctx, actor, authz.OpValueList, sourceScope)
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValueList, sourceScope)
 	if err != nil {
 		return CopyResult{}, err
 	}
@@ -1136,7 +1128,7 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 			destScope := domain.Scope{Org: scope.Org, Project: scope.Project, Env: domain.EnvID(destID)}
 			if err := authorizeDestination(ctx, r, az, caller, destScope,
 				req.ConfirmProtected, plan.hasConfig, len(plan.secretKeyIDs) > 0, plan.keyIDs,
-				ceremonyGate(ctx, s.Auth, az, caller, publishIntentBuilder(destID))); err != nil {
+				ceremonyGate(ctx, s.Auth, az, caller, disclosureIntent(PurposePublish, destID))); err != nil {
 				return copyWriteResult{}, err
 			}
 		}
@@ -1145,7 +1137,7 @@ func (s *Values) Copy(ctx context.Context, actor Actor, scope domain.Scope, req 
 		// does — including copy-without-display, which discloses to a
 		// destination rather than to a screen and is a disclosure either way.
 		material, err := openCopySourcePlan(ctx, r, az, caller, sealer, sourceScope, plan, copyOpCopy,
-			ceremonyGate(ctx, s.Auth, az, caller, copyIntentBuilder(req.SourceEnvironmentID)))
+			ceremonyGate(ctx, s.Auth, az, caller, disclosureIntent(PurposeCopy, req.SourceEnvironmentID)))
 		if err != nil {
 			return copyWriteResult{}, err
 		}

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -78,10 +78,7 @@ type Workspace struct {
 }
 
 func (s *Workspace) now() time.Time {
-	if s.Now == nil {
-		return time.Now().UTC()
-	}
-	return s.Now().UTC()
+	return nowOr(s.Now)
 }
 
 // ---------------------------------------------------------------------------
@@ -104,11 +101,7 @@ func (s *Workspace) Serve(ctx context.Context, actor Actor) (remotefetch.Listing
 	now := s.now()
 	var out remotefetch.Listing
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteDirectoryServe, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteDirectoryServe, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -238,11 +231,7 @@ func (s *Workspace) MintConnection(ctx context.Context, actor Actor, label strin
 	now := s.now()
 	var out MintConnectionResult
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteCredentialCreate, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteCredentialCreate, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -324,11 +313,7 @@ func (s *Workspace) ListConnections(ctx context.Context, actor Actor) ([]Connect
 	now := s.now()
 	var out []ConnectionView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteCredentialList, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteCredentialList, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -359,11 +344,7 @@ func (s *Workspace) ShowConnection(ctx context.Context, actor Actor, id string) 
 	now := s.now()
 	var out ConnectionView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteCredentialShow, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteCredentialShow, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -393,11 +374,7 @@ func (s *Workspace) ShowConnection(ctx context.Context, actor Actor, id string) 
 func (s *Workspace) RevokeConnection(ctx context.Context, actor Actor, id string) error {
 	now := s.now()
 	return tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpRemoteCredentialRevoke, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpRemoteCredentialRevoke, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -464,11 +441,7 @@ func (s *Workspace) ListOrigins(ctx context.Context, actor Actor) ([]OriginView,
 	now := s.now()
 	var out []OriginView
 	err := tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpWorkspaceOriginList, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpWorkspaceOriginList, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -534,11 +507,7 @@ func (s *Workspace) AddOrigin(ctx context.Context, actor Actor, origin string) (
 	s.originAllowlistMu.Lock()
 	defer s.originAllowlistMu.Unlock()
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpWorkspaceOriginAdd, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpWorkspaceOriginAdd, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}
@@ -581,11 +550,7 @@ func (s *Workspace) RemoveOrigin(ctx context.Context, actor Actor, origin string
 	s.originAllowlistMu.Lock()
 	defer s.originAllowlistMu.Unlock()
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
-		caller, err := actor.resolve(ctx, az, now)
-		if err != nil {
-			return err
-		}
-		p, err := az.Authorize(ctx, caller, authz.OpWorkspaceOriginRemove, domain.Scope{})
+		caller, p, err := authorize(ctx, az, actor, authz.OpWorkspaceOriginRemove, domain.Scope{}, now)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Part of #619. PR C-service: duplicate helpers in internal/service. Behaviour-preserving pure extractions.

## What
- One `authorize` helper for the resolve->Authorize prelude (178 of 206 sites; the 28 left genuinely differ). Uses named results + bare returns so no `nil` literal sits in the proof position (the proof-forgery analyzer rejects that).
- `nowOr` for 20 of 21 `s.Now` nil-checks; `requireProjectScope` for 20 of 28 scope guards (messages verbatim); `auditSuperseded` for 7 of 8 blocks; `insertInspected` reuse; `s.gate` for the two inline providerGate closures; `providerFor` for providerForAdapter/Move; `disclosureIntent` for the three reveal/copy/publish closures; `canonicalSet` for the sort+compact id sites.
- Test fixtures: `adapterScope`, `adapterKeyring`, `seedKey`, `sealAdapterCredential` replace copy-pasted literals.
- hierarchy.go DTO copies left as-is (a deliberate policy-field boundary, not slop).
- Net -900 LOC.

## Verification
- build, vet, gofmt clean; service/conformance/server/lint/boundary green; sqlite isolation e2e green (710s). Postgres isolation legs on CI's per-job databases. deadcode no new unreachable.
- Cross-model (Codex) review before merge.