### PR TITLE
feat(server): add stateless MCP transport (#628)

### DIFF
--- a/api/match_test.go
+++ b/api/match_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/routers"
+
+	"github.com/Hikyo-Org/hikyo/internal/operation"
 )
 
 // countingRouter counts contract route lookups. The admission path's cost is
@@ -83,6 +85,13 @@ func TestMatchRequestResolvesTheContractRouteExactlyOnce(t *testing.T) {
 	}
 	if attached.ID != op.ID {
 		t.Fatalf("attached operation = %q, want %q", attached.ID, op.ID)
+	}
+	shared, ok := operation.FromContext(admitted.Context())
+	if !ok {
+		t.Fatal("transport-independent operation contract was not attached")
+	}
+	if shared.ID != op.ID || shared.AuthorizationOperation != op.AuthzOp {
+		t.Fatalf("shared contract = %#v, want %q/%q", shared, op.ID, op.AuthzOp)
 	}
 
 	if counting.calls != 1 {

--- a/api/spec.go
+++ b/api/spec.go
@@ -29,6 +29,8 @@ import (
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers"
 	"github.com/getkin/kin-openapi/routers/gorillamux"
+
+	"github.com/Hikyo-Org/hikyo/internal/operation"
 )
 
 // SpecYAML is the contract as authored. Exported so tooling (the oasdiff
@@ -187,12 +189,12 @@ type Operation struct {
 }
 
 const (
-	ArtifactNone               = "none"
-	ArtifactHumanSession       = "human-session"
-	ArtifactMachineCredential  = "machine-credential"
-	ArtifactSCIMCredential     = "scim-credential"
-	ArtifactInstanceCredential = "instance-credential"
-	ArtifactLocal              = "local"
+	ArtifactNone               = operation.ArtifactNone
+	ArtifactHumanSession       = operation.ArtifactHumanSession
+	ArtifactMachineCredential  = operation.ArtifactMachineCredential
+	ArtifactSCIMCredential     = operation.ArtifactSCIMCredential
+	ArtifactInstanceCredential = operation.ArtifactInstanceCredential
+	ArtifactLocal              = operation.ArtifactLocal
 )
 
 // AdmitsArtifact reports whether the operation's OpenAPI declaration admits
@@ -253,7 +255,19 @@ func withOperation(ctx context.Context, op Operation) context.Context {
 	if op.ID == "" {
 		return ctx
 	}
-	return context.WithValue(ctx, operationContextKey{}, op)
+	ctx = context.WithValue(ctx, operationContextKey{}, op)
+	ctx = operation.WithNetwork(ctx)
+	var contract operation.Contract
+	var err error
+	if op.AuthzOp == "" {
+		contract, err = operation.NewArtifactContract(op.ID, op.artifacts)
+	} else {
+		contract, err = operation.NewContract(op.ID, op.AuthzOp, op.formula, op.artifacts)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return operation.WithContract(ctx, contract)
 }
 
 // Operations returns every operation in the contract, keyed by operationId.

--- a/docs/handoff/628-mcp-transport.md
+++ b/docs/handoff/628-mcp-transport.md
@@ -1,0 +1,62 @@
+# Issue 628 handoff: stateless MCP transport
+
+## Delivered
+
+- Added the feature-gated `POST /mcp` endpoint using the official Go MCP SDK
+  pinned at `v1.7.0`, with stateless JSON responses and protocol `2026-07-28`.
+- Added a deterministic closed registry whose typed rows bind tool name,
+  input and output schemas, service operation, authorization operation,
+  formula, audit disposition, machine-only artifact policy, read-only
+  annotations, result bound, and secret policy. Registration verifies the
+  formula and audit disposition against the authorization registry.
+- Added a transport-independent operation contract consumed by the existing
+  in-transaction artifact-admission chokepoint. Raw service-account bearers
+  stay redacted and are available only to registered adapter callbacks.
+- Added exact Host, trusted-proxy authority, Origin, protocol mirror header,
+  content type, Accept, request size, bearer size, deadline, concurrency,
+  cancellation, admission, authenticated rate-limit signaling, and safe-error
+  enforcement.
+- Added `mcp` to the audit origin vocabulary with forward and rollback
+  migrations for SQLite and PostgreSQL. The static discovery and catalogue
+  methods are explicitly classified and audit-exempted.
+
+## Boundary held
+
+- The production registry is intentionally empty in this ticket. Issue #629
+  owns the five datastore-bounded read tools and their service mappings.
+- `internal/mcpserver` imports no store, generated SQL, or crypto packages.
+  It has no generic operation proxy, REST loopback, session state, or outbound
+  bearer forwarding.
+- Browser CORS remains disabled for `/mcp`, even when an Origin is approved for
+  the separate cross-instance workspace API.
+
+## Validation anchors
+
+- Conformance tests pin discovery capabilities, mirror headers, explicit
+  legacy refusal, validated static notifications, JSON responses, deterministic
+  catalogues, unknown-tool refusal, and the exact SDK version.
+- Security tests cover body and result bounds, Host and Origin rejection,
+  trusted proxies, bearer multiplicity and redaction, safe errors, deadlines,
+  cancellation, discovery admission, and instance concurrency.
+- Two independent handlers with separate registries accept alternating
+  requests without a session id.
+  An import-boundary test prevents store, generated SQL, or crypto imports.
+- The existing cross-engine upgrade test now proves that an `mcp` audit origin
+  is accepted after migration while pre-migration data survives.
+
+## Next ticket
+
+Issue #629 should register only the five ADR-pinned read tools through this
+registry, call existing services with the callback's raw bearer, and add the
+dual-engine authorization, pagination, cursor, denial, rate, and secret-canary
+evidence that depends on those concrete operations.
+
+## Verification
+
+- `go test ./... -count=1`: 4,545 tests passed across 74 packages.
+- `go test ./internal/isolation -count=1 -timeout 30m`: 1,419 tests passed.
+- `go test -race ./internal/mcpserver -count=1`: 30 tests passed.
+- `go build ./...`, `go vet ./...`, and the complete docs/PWA verification
+  passed.
+- Independent spec and standards review rounds returned clean after their
+  findings were fixed.

--- a/docs/site/src/content/docs/docs/configuration.mdx
+++ b/docs/site/src/content/docs/docs/configuration.mdx
@@ -47,6 +47,29 @@ Proxy mode requires trusted CIDRs when the plaintext public listener is not
 loopback. The list names proxies, not browser client networks. Operational
 routes never exist on the public router; keep the operational bind private.
 
+## MCP endpoint
+
+The MCP endpoint is disabled by default. These settings control its exact
+public exposure:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `HIKYO_MCP_ENABLED` | `false` | Enables the stateless JSON `POST /mcp` endpoint. |
+| `HIKYO_MCP_ALLOWED_ORIGINS` | empty | Comma-separated, exact browser origins admitted at `/mcp`. Wildcards, `null`, paths, queries, fragments, and credentials are rejected. |
+
+Production requires an HTTPS `HIKYO_EXTERNAL_ORIGIN`. Development permits
+plain HTTP only on a loopback origin. Requests without an `Origin` header are
+accepted for non-browser MCP clients. An allowed browser origin does not enable
+CORS response headers, so it is an additional request check rather than a
+cross-origin browser API grant.
+
+Treat every configured MCP client and its model provider as a recipient of MCP
+tool results. When the read tools are installed by the next MCP release, results
+may include non-secret configuration plaintext and caller-owned non-secret
+draft plaintext. Secret values and secret draft material are never returned.
+Enabling the endpoint in this release exposes only the empty, tenant-free tool
+catalog until those tools are installed.
+
 ## Security response headers
 
 Every public response carries the same set, refusals and API errors included:

--- a/go.mod
+++ b/go.mod
@@ -15,11 +15,13 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/gofrs/flock v0.13.0
+	github.com/google/jsonschema-go v0.4.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.19.1
 	github.com/mattermost/xml-roundtrip-validator v0.1.0
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oapi-codegen/runtime v1.7.0
 	github.com/oasdiff/oasdiff v1.29.1
 	github.com/openbao/openbao/api/v2 v2.6.0
@@ -201,6 +203,8 @@ require (
 	github.com/riza-io/grpc-go v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/segmentio/asm v1.2.1 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sethvargo/go-retry v0.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.3 // indirect
@@ -226,6 +230,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yargevad/filepathx v1.0.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver v1.17.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:E
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -437,6 +439,8 @@ github.com/moby/sys/user v0.4.1 h1:RgjRlaDKi/Xmyrz4t8lyzXT6v2ooFeO/7xtchmhVWE0=
 github.com/moby/sys/user v0.4.1/go.mod h1:E9QsW5WRe1kUAf7kW8hXKwu1uhsZEAdPLYHYSDudF4Y=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -549,6 +553,10 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57Hu
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sassoftware/go-rpmutils v0.4.0 h1:ojND82NYBxgwrV+mX1CWsd5QJvvEZTKddtCdFLPWhpg=
 github.com/sassoftware/go-rpmutils v0.4.0/go.mod h1:3goNWi7PGAT3/dlql2lv3+MSN5jNYPjT5mVcQcIsYzI=
+github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
+github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sethvargo/go-retry v0.4.0 h1:9qy1OoIAxBL+gBYnkTnTnWle5wlfsXQlwRzIbbpdqPw=
@@ -634,6 +642,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yargevad/filepathx v1.0.0 h1:SYcT+N3tYGi+NvazubCNlvgIPbzAk7i7y2dwg3I5FYc=
 github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -269,7 +269,10 @@ func (l *Limiter) allowShared(bucket, subject string, allowance int) bool {
 	window := l.now().UTC().Truncate(time.Minute)
 	count, err := l.shared.BumpWindow(ctx, bucket, subject, window)
 	if err != nil {
-		l.logger().Error("admission: shared counter unreachable, refusing", "bucket", bucket, "err", err)
+		// A backend error may echo subject, which is derived from an untrusted
+		// request header on proxy-aware discovery paths. Keep the failure visible
+		// without copying attacker-controlled or credential material into logs.
+		l.logger().Error("admission: shared counter unreachable, refusing", "bucket", bucket)
 		return false
 	}
 	return count <= int64(allowance)

--- a/internal/admission/admission_shared_test.go
+++ b/internal/admission/admission_shared_test.go
@@ -1,10 +1,12 @@
 package admission
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -154,13 +156,18 @@ func TestSharedCounterErrorsFailClosed(t *testing.T) {
 	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	store := newFakeShared()
 	l := sharedLimiter(t, store, &now)
-	store.setErr(errors.New("datastore unreachable"))
+	var logs bytes.Buffer
+	l.UseShared(store, slog.New(slog.NewTextHandler(&logs, nil)))
+	store.setErr(errors.New("datastore unreachable with CANARY-HEADER-VALUE"))
 
 	if l.allowIP("1.2.3.4") {
 		t.Fatal("allowIP admitted while the shared counter was unreachable (must fail closed)")
 	}
 	if l.AllowDiscovery("1.2.3.4") {
 		t.Fatal("AllowDiscovery admitted while the shared counter was unreachable")
+	}
+	if strings.Contains(logs.String(), "CANARY-HEADER-VALUE") {
+		t.Fatalf("shared counter error leaked request-derived data: %q", logs.String())
 	}
 	if l.AllowIssuerRefresh("https://issuer.example") {
 		t.Fatal("AllowIssuerRefresh admitted while the shared counter was unreachable")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/mcpserver"
 	"github.com/Hikyo-Org/hikyo/internal/oidcfed"
 	"github.com/Hikyo-Org/hikyo/internal/remotefetch"
 	"github.com/Hikyo-Org/hikyo/internal/scanning"
@@ -575,9 +576,24 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		TrustedProxies: proxies,
 	}
 
+	var mcpHandler http.Handler
+	if cfg.MCPEnabled {
+		mcpHandler, err = mcpserver.New(mcpserver.Options{
+			Registry:       mcpserver.NewRegistry(),
+			ExternalOrigin: cfg.ExternalOrigin,
+			AllowedOrigins: cfg.MCPAllowedOrigins,
+			TrustedProxies: proxies,
+			Admission:      limiter,
+			Version:        Version,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("boot: refusing to serve: MCP transport: %w", err)
+		}
+	}
+
 	log.Info("boot complete", "version", Version, "engine", sc.Engine, "external_origin", cfg.ExternalOrigin,
 		"addr", ln.Addr().String(), "operational_addr", operationalLn.Addr().String(), "dev", cfg.Dev, "update_channel", cfg.UpdateChannel,
-		"argon2_memory_kib", cfg.Argon2MemoryKiB, "auth_concurrency", limiter.Concurrency())
+		"argon2_memory_kib", cfg.Argon2MemoryKiB, "auth_concurrency", limiter.Concurrency(), "mcp_enabled", cfg.MCPEnabled)
 	// The operational readiness check is the datastore-and-schema probe, plus
 	// an optional HA lease-datastore probe attached below when HA is enabled so
 	// /readyz fails closed if the lease table becomes unreachable.
@@ -594,6 +610,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		publicHandler: server.NewPublic(&service.System{DB: db, Store: sc}, api, webui.Assets(), server.PublicOptions{
 			HSTS:           config.EmitHSTS(cfg.ExternalOrigin),
 			ExternalOrigin: cfg.ExternalOrigin,
+			MCP:            mcpHandler,
 		}),
 		operationalHandler: server.NewOperational(readyChk, operationalHealth{retention: retentionSvc, tls: tlsReloader}, metrics),
 		tlsReloader:        tlsReloader,

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -82,6 +82,7 @@ const (
 	OriginWeb           Origin = "web"
 	OriginCLI           Origin = "cli"
 	OriginAPI           Origin = "api"
+	OriginMCP           Origin = "mcp"
 	OriginOperatorFetch Origin = "operator-fetch"
 	OriginAdapterJob    Origin = "adapter-job"
 	OriginOfflineRecon  Origin = "offline-reconciled"
@@ -185,7 +186,7 @@ func Validate(e Event, trail Trail, scope domain.Scope) error {
 		return fmt.Errorf("audit: %s: unknown actor class %q", e.Type, e.Actor.Class)
 	}
 	switch e.Origin {
-	case OriginWeb, OriginCLI, OriginAPI, OriginOperatorFetch, OriginAdapterJob, OriginOfflineRecon, OriginSystem:
+	case OriginWeb, OriginCLI, OriginAPI, OriginMCP, OriginOperatorFetch, OriginAdapterJob, OriginOfflineRecon, OriginSystem:
 	default:
 		return fmt.Errorf("audit: %s: unknown origin %q", e.Type, e.Origin)
 	}

--- a/internal/authz/artifact_admission.go
+++ b/internal/authz/artifact_admission.go
@@ -5,22 +5,25 @@ import (
 	"errors"
 	"time"
 
-	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
 )
 
-// AdmitOperation enforces the artifact classes declared by the exact OpenAPI
-// operation attached to an HTTP request. Authentication still resolves the
+// AdmitOperation enforces the artifact classes declared by the exact network
+// operation attached to a request. Authentication still resolves the
 // live identity inside this transaction; this check then refuses a resolved
 // bearer whose class the contract excludes before handler logic can use it.
 //
-// An absent operation means an in-process caller. HTTP validation attaches an
-// operation to every contract route before dispatch, so there is no HTTP
-// fallback table and a new declaration takes effect without a second edit.
+// An absent operation means an in-process caller. Each network adapter attaches
+// a compiled contract before dispatch, so there is no request-derived fallback
+// table and a new declaration takes effect without a second edit.
 func (a *TxAuthorizer) AdmitOperation(ctx context.Context, caller Identity) error {
-	op, ok := api.OperationFromContext(ctx)
+	op, ok := operation.FromContext(ctx)
 	if !ok {
+		if operation.IsNetwork(ctx) {
+			return domain.ErrNotFound
+		}
 		return nil
 	}
 	class := ContractArtifactClass(caller)

--- a/internal/authz/artifact_admission_test.go
+++ b/internal/authz/artifact_admission_test.go
@@ -1,0 +1,48 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
+)
+
+func TestAdmitOperationConsumesTransportIndependentContract(t *testing.T) {
+	contract, err := operation.NewContract(
+		"mcp:echo", "key.list", []string{"read@project"}, []string{operation.ArtifactMachineCredential},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := operation.WithContract(context.Background(), contract)
+
+	allowed := Identity{
+		Principal: "svc_a", Class: domain.ClassWorkload,
+		CredentialID: "cred_a", Artifact: operation.ArtifactMachineCredential,
+	}
+	authorizer := &TxAuthorizer{}
+	if err := authorizer.AdmitOperation(ctx, allowed); err != nil {
+		t.Fatalf("machine credential refused: %v", err)
+	}
+
+	human := Identity{
+		Principal: "usr_a", Class: domain.ClassHuman,
+		SessionID: "ses_a", Artifact: operation.ArtifactHumanSession,
+	}
+	if err := authorizer.AdmitOperation(ctx, human); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("human session error = %v", err)
+	}
+	denials := authorizer.PendingDenials()
+	if len(denials) != 1 || denials[0].Event.Object.Type != "api-operation" || denials[0].Event.Object.ID != "mcp:echo" {
+		t.Fatalf("artifact denial = %#v", denials)
+	}
+
+	if err := (&TxAuthorizer{}).AdmitOperation(context.Background(), human); err != nil {
+		t.Fatalf("in-process caller without network contract refused: %v", err)
+	}
+	if err := (&TxAuthorizer{}).AdmitOperation(operation.WithNetwork(context.Background()), human); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("network caller without a contract error = %v", err)
+	}
+}

--- a/internal/authz/authorize.go
+++ b/internal/authz/authorize.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
 	"github.com/Hikyo-Org/hikyo/internal/store/authn"
 )
 
@@ -72,7 +73,7 @@ func (a *TxAuthorizer) Authorize(ctx context.Context, caller Identity, op Operat
 	// through a view derived from the same embedded OpenAPI registry. Other
 	// in-process actors intentionally retain service-level semantics that may be
 	// broader than today's public wire declarations (for example machine reveal).
-	if _, exactWireOperation := api.OperationFromContext(ctx); !exactWireOperation && caller.Class == domain.ClassInstanceConn {
+	if !operation.IsNetwork(ctx) && caller.Class == domain.ClassInstanceConn {
 		artifact := api.ArtifactInstanceCredential
 		admitted, described := api.AuthorizationOperationAdmitsArtifact(string(op), artifact)
 		if !described || !admitted {
@@ -102,15 +103,15 @@ func (a *TxAuthorizer) Authorize(ctx context.Context, caller Identity, op Operat
 func ContractArtifactClass(caller Identity) string {
 	switch {
 	case caller.Class == "":
-		return api.ArtifactLocal
+		return operation.ArtifactLocal
 	case caller.Class == domain.ClassHuman:
-		return api.ArtifactHumanSession
+		return operation.ArtifactHumanSession
 	case caller.Class == domain.ClassInstanceConn:
-		return api.ArtifactInstanceCredential
+		return operation.ArtifactInstanceCredential
 	case caller.Class == domain.ClassProvisioning:
-		return api.ArtifactSCIMCredential
+		return operation.ArtifactSCIMCredential
 	case domain.IsServiceAccountKind(caller.Class):
-		return api.ArtifactMachineCredential
+		return operation.ArtifactMachineCredential
 	default:
 		return ""
 	}

--- a/internal/authz/classify.go
+++ b/internal/authz/classify.go
@@ -92,9 +92,11 @@ func mustNewWireRegistry(table map[string]wireEntry) map[string]wireEntry {
 }
 
 var wireRegistry = mustNewWireRegistry(map[string]wireEntry{
-	"http:GET /healthz": {Class: ClassUnauthenticated},
-	"http:GET /metrics": {Class: ClassUnauthenticated},
-	"http:GET /readyz":  {Class: ClassUnauthenticated},
+	"http:GET /healthz":   {Class: ClassUnauthenticated},
+	"http:GET /metrics":   {Class: ClassUnauthenticated},
+	"http:GET /readyz":    {Class: ClassUnauthenticated},
+	"mcp:server/discover": {Class: ClassUnauthenticated},
+	"mcp:tools/list":      {Class: ClassUnauthenticated},
 
 	// The contract surface (#47). Every entry below exists in
 	// api/openapi.yaml and carries the same class there under

--- a/internal/authz/registry.go
+++ b/internal/authz/registry.go
@@ -4215,6 +4215,34 @@ var systemSiteEvents = map[SystemSite][]audit.EventType{
 // exposing mutation. Production code has no business calling these.
 type RegistryFacts struct{}
 
+// NetworkOperationPolicy is the narrow immutable projection used by network
+// adapters to prove that their compiled contract matches the authorization
+// registry. It contains no handler or datastore authority.
+type NetworkOperationPolicy struct {
+	Formula     []string
+	AuditedNone bool
+	ReadOnly    bool
+}
+
+// LookupNetworkOperationPolicy returns the registered formula and successful
+// audit disposition for one authorization operation.
+func LookupNetworkOperationPolicy(name string) (NetworkOperationPolicy, bool) {
+	spec, ok := registry.ops[Operation(name)]
+	if !ok {
+		return NetworkOperationPolicy{}, false
+	}
+	policy := NetworkOperationPolicy{AuditedNone: spec.auditedNone, ReadOnly: true}
+	for _, atom := range spec.formula {
+		policy.Formula = append(policy.Formula, string(atom.Cap)+"@"+levelNames[atom.At])
+	}
+	for storeOp := range spec.storeOps {
+		if !readOnlyStoreOps[storeOp] {
+			policy.ReadOnly = false
+		}
+	}
+	return policy, true
+}
+
 // Operations lists every registered operation and its class.
 func (RegistryFacts) Operations() map[Operation]Class {
 	out := make(map[Operation]Class, len(registry.ops))

--- a/internal/authz/session.go
+++ b/internal/authz/session.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"time"
 
-	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
 	"github.com/Hikyo-Org/hikyo/internal/store/authn"
 )
 
@@ -235,7 +235,7 @@ func (a *TxAuthorizer) AuthenticateCaller(ctx context.Context, presented string,
 	if crypto.ParseArtifact(presented, crypto.ArtifactWorkload) == nil ||
 		crypto.ParseArtifact(presented, crypto.ArtifactAutomation) == nil {
 		identity, err = a.authenticateMachine(ctx, presented, now)
-	} else if _, wire := api.OperationFromContext(ctx); wire && crypto.ParseArtifact(presented, crypto.ArtifactSCIM) == nil {
+	} else if operation.IsNetwork(ctx) && crypto.ParseArtifact(presented, crypto.ArtifactSCIM) == nil {
 		identity, _, err = a.AuthenticateSCIMCaller(ctx, presented, now)
 	} else if crypto.ParseArtifact(presented, crypto.ArtifactInstanceConn) == nil {
 		// The instance-connection credential (#71). It is a machine artifact with
@@ -319,7 +319,7 @@ func (a *TxAuthorizer) authenticateSessionSurface(
 	admitsWorkspace bool,
 	inProcessArtifacts ...crypto.ArtifactType,
 ) (Identity, error) {
-	if _, wire := api.OperationFromContext(ctx); wire {
+	if operation.IsNetwork(ctx) {
 		identity, err := a.AuthenticateCaller(ctx, presented, now)
 		if err != nil {
 			return Identity{}, err

--- a/internal/authz/wire_registry_test.go
+++ b/internal/authz/wire_registry_test.go
@@ -19,9 +19,10 @@ func rejectsWireRegistry(t *testing.T, name string, entry wireEntry) {
 func TestWireRegistrySnapshot(t *testing.T) {
 	facts := RegistryFacts{}
 	// #568 added member invitations, #147 added dynamic providers and leases,
-	// #151 added change approvals, and #157 added adapter pause and resume.
-	if got := len(facts.Wire()); got != 315 {
-		t.Fatalf("wire entries = %d, want 315", got)
+	// #151 added change approvals, #157 added adapter pause and resume, and
+	// #628 added the two unauthenticated MCP metadata methods.
+	if got := len(facts.Wire()); got != 317 {
+		t.Fatalf("wire entries = %d, want 317", got)
 	}
 	if got := len(facts.WireRoutes()); got != 225 {
 		t.Fatalf("operation-linked entries = %d, want 225", got)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,13 @@ type Config struct {
 	// header. Defaults to http://<Listen> when unset.
 	ExternalOrigin string
 
+	// MCPEnabled gates the separately versioned MCP protocol endpoint. It is
+	// off unless the operator explicitly enables it. MCPAllowedOrigins is the
+	// exact allowlist for requests that carry a browser Origin header; an empty
+	// list still permits non-browser clients that omit Origin.
+	MCPEnabled        bool
+	MCPAllowedOrigins []string
+
 	// Root-key source descriptor — never the key material itself; the crypto
 	// package reads and validates it at boot. Only `hikyo server` consults it.
 	RootKeyFile    string // --root-key-file (also covers systemd LoadCredential paths)
@@ -175,6 +182,8 @@ var knownEnv = map[string]bool{
 	"HIKYO_TLS_CERT_FILE":              true,
 	"HIKYO_TLS_KEY_FILE":               true,
 	"HIKYO_EXTERNAL_ORIGIN":            true,
+	"HIKYO_MCP_ENABLED":                true,
+	"HIKYO_MCP_ALLOWED_ORIGINS":        true,
 	"HIKYO_TRUSTED_PROXY_CIDRS":        true,
 	"HIKYO_ROOT_KEY":                   true,
 	"HIKYO_NEW_ROOT_KEY_FILE":          true,
@@ -440,6 +449,29 @@ func Load(subcommand string, args []string, getenv func(string) string, environ 
 		cfg.ExternalOrigin != origin.Scheme+"://"+origin.Host {
 		return nil, nil, fmt.Errorf("HIKYO_EXTERNAL_ORIGIN must be an exact canonical HTTP(S) origin without credentials, path, query, or fragment")
 	}
+	if subcommand == "server" {
+		rawEnabled := strings.TrimSpace(getenv("HIKYO_MCP_ENABLED"))
+		if rawEnabled != "" {
+			enabled, err := strconv.ParseBool(rawEnabled)
+			if err != nil {
+				return nil, nil, fmt.Errorf("HIKYO_MCP_ENABLED: %q is not a boolean", rawEnabled)
+			}
+			cfg.MCPEnabled = enabled
+		}
+		rawOrigins := strings.TrimSpace(getenv("HIKYO_MCP_ALLOWED_ORIGINS"))
+		if rawOrigins != "" && !cfg.MCPEnabled {
+			return nil, nil, errors.New("HIKYO_MCP_ALLOWED_ORIGINS requires HIKYO_MCP_ENABLED=true")
+		}
+		if cfg.MCPEnabled {
+			if origin.Scheme != "https" && (!cfg.Dev || !isLoopbackHost(origin.Hostname())) {
+				return nil, nil, errors.New("MCP requires an https HIKYO_EXTERNAL_ORIGIN; plaintext is allowed only for a loopback origin in development mode")
+			}
+			cfg.MCPAllowedOrigins, err = parseMCPAllowedOrigins(rawOrigins)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
 
 	if err := loadBackupPolicy(cfg, getenv); err != nil {
 		return nil, nil, err
@@ -474,6 +506,30 @@ func Load(subcommand string, args []string, getenv func(string) string, environ 
 		}
 	}
 	return cfg, warnings, nil
+}
+
+func parseMCPAllowedOrigins(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	seen := make(map[string]bool)
+	var origins []string
+	for _, part := range strings.Split(raw, ",") {
+		candidate := strings.TrimSpace(part)
+		parsed, err := url.Parse(candidate)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") ||
+			parsed.Host == "" || parsed.User != nil || parsed.Path != "" ||
+			parsed.RawQuery != "" || parsed.Fragment != "" ||
+			candidate != parsed.Scheme+"://"+parsed.Host {
+			return nil, fmt.Errorf("HIKYO_MCP_ALLOWED_ORIGINS: %q is not an exact HTTP(S) origin", candidate)
+		}
+		if candidate == "null" || candidate == "*" || seen[candidate] {
+			return nil, fmt.Errorf("HIKYO_MCP_ALLOWED_ORIGINS: %q is not a unique exact origin", candidate)
+		}
+		seen[candidate] = true
+		origins = append(origins, candidate)
+	}
+	return origins, nil
 }
 
 // loadHAConfig parses and validates the multi-node HA switch. Every

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -144,9 +145,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
-		"postgres:///hikyo", // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
+		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {
@@ -319,6 +320,102 @@ func TestExternalOriginMustBeCanonicalAndCannotContainCredentials(t *testing.T) 
 				t.Fatalf("Load() error = %v, want HIKYO_EXTERNAL_ORIGIN refusal", err)
 			}
 		})
+	}
+}
+
+func TestMCPIsFeatureGatedAndRequiresItsPinnedPublicOriginProfile(t *testing.T) {
+	base := []string{"HIKYO_DB", "sqlite:/data/hikyo.db"}
+
+	disabled, warnings, err := Load("server", nil, env(base...), environFrom(base...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if disabled.MCPEnabled {
+		t.Fatal("MCP enabled without HIKYO_MCP_ENABLED")
+	}
+
+	enabled, warnings, err := Load("server", nil, env(append(base,
+		"HIKYO_EXTERNAL_ORIGIN", "https://hikyo.example.com",
+		"HIKYO_MCP_ENABLED", "true",
+		"HIKYO_MCP_ALLOWED_ORIGINS", "https://assistant.example.com,http://localhost:4310",
+	)...), environFrom(
+		"HIKYO_MCP_ENABLED", "true",
+		"HIKYO_MCP_ALLOWED_ORIGINS", "https://assistant.example.com,http://localhost:4310",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("MCP settings must be recognized, got warnings %v", warnings)
+	}
+	if !enabled.MCPEnabled {
+		t.Fatal("HIKYO_MCP_ENABLED=true did not enable MCP")
+	}
+	wantOrigins := []string{"https://assistant.example.com", "http://localhost:4310"}
+	if !slices.Equal(enabled.MCPAllowedOrigins, wantOrigins) {
+		t.Fatalf("MCPAllowedOrigins = %v, want %v", enabled.MCPAllowedOrigins, wantOrigins)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		env  []string
+		want string
+	}{
+		{
+			name: "malformed enable",
+			env:  append(base, "HIKYO_MCP_ENABLED", "sometimes"),
+			want: "HIKYO_MCP_ENABLED",
+		},
+		{
+			name: "production plaintext",
+			env: append(base,
+				"HIKYO_EXTERNAL_ORIGIN", "http://localhost:8080",
+				"HIKYO_MCP_ENABLED", "true"),
+			want: "requires an https HIKYO_EXTERNAL_ORIGIN",
+		},
+		{
+			name: "development public plaintext",
+			args: []string{"--dev"},
+			env: []string{
+				"HIKYO_EXTERNAL_ORIGIN", "http://hikyo.example.com",
+				"HIKYO_MCP_ENABLED", "true",
+			},
+			want: "loopback",
+		},
+		{
+			name: "wildcard origin",
+			env: append(base,
+				"HIKYO_EXTERNAL_ORIGIN", "https://hikyo.example.com",
+				"HIKYO_MCP_ENABLED", "true",
+				"HIKYO_MCP_ALLOWED_ORIGINS", "*"),
+			want: "HIKYO_MCP_ALLOWED_ORIGINS",
+		},
+		{
+			name: "unused allowlist",
+			env: append(base,
+				"HIKYO_EXTERNAL_ORIGIN", "https://hikyo.example.com",
+				"HIKYO_MCP_ALLOWED_ORIGINS", "https://assistant.example.com"),
+			want: "HIKYO_MCP_ENABLED",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Load("server", tc.args, env(tc.env...), environFrom(tc.env...))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	dev, _, err := Load("server", []string{"--dev"}, env("HIKYO_MCP_ENABLED", "true"), nil)
+	if err != nil {
+		t.Fatalf("development loopback MCP was refused: %v", err)
+	}
+	if !dev.MCPEnabled {
+		t.Fatal("development loopback MCP was not enabled")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,9 +145,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
-		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
+		"postgres:///hikyo", // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {

--- a/internal/isolation/testdata/audited_exemptions.json
+++ b/internal/isolation/testdata/audited_exemptions.json
@@ -55,7 +55,9 @@
     "http:GET /readyz": "unauthenticated readiness probe: same contract as /healthz",
     "http:POST /api/v1/auth/webauthn/login/start": "opens a discoverable-credential ceremony and returns opaque options; no proof is validated, no credential or account is resolved, and no state a probe could distinguish is created \u2014 the login lands at login/finish, which carries the events",
     "http:POST /api/v1/auth/webauthn/reauth/start": "opens a ceremony bound to the operation unit and returns opaque options; validates no proof and changes no state \u2014 the window opens at reauth/finish, which carries the events",
-    "http:POST /api/v1/auth/webauthn/step-up/start": "opens a ceremony scoped to the acting account's credentials and returns opaque options; validates no proof and changes no state \u2014 the elevation lands at step-up/finish, which carries the events"
+    "http:POST /api/v1/auth/webauthn/step-up/start": "opens a ceremony scoped to the acting account's credentials and returns opaque options; validates no proof and changes no state \u2014 the elevation lands at step-up/finish, which carries the events",
+    "mcp:server/discover": "unauthenticated static MCP protocol metadata: no principal, tenant data, or state change",
+    "mcp:tools/list": "unauthenticated static MCP tool metadata: one compiled tenant-free catalogue, no principal, tenant data, or state change"
   },
   "operations": {
     "definitions.plan.get": "reads an immutable definitions plan under definitions-edit authority and changes no state; plan creation and apply carry the auditable acts, so polling the plan would only duplicate those records",

--- a/internal/mcpserver/handler.go
+++ b/internal/mcpserver/handler.go
@@ -1,0 +1,479 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Hikyo-Org/hikyo/internal/audit"
+)
+
+const (
+	Path                       = "/mcp"
+	ProtocolVersion            = "2026-07-28"
+	MaxRequestBytes            = 256 << 10
+	MaxStaticResponseBytes     = 64 << 10
+	MaxBearerBytes             = 4096
+	ToolExecutionTimeout       = 30 * time.Second
+	DefaultInstanceConcurrency = 64
+)
+
+type discoveryAdmission interface {
+	AllowDiscovery(string) bool
+}
+
+// Options fixes the transport policy at process boot.
+type Options struct {
+	Registry       *Registry
+	ExternalOrigin string
+	AllowedOrigins []string
+	TrustedProxies []*net.IPNet
+	Admission      discoveryAdmission
+	Version        string
+	MaxConcurrent  int
+}
+
+type handler struct {
+	sdk            http.Handler
+	externalScheme string
+	externalHost   string
+	allowedOrigins []string
+	trustedProxies []*net.IPNet
+	admission      discoveryAdmission
+	slots          chan struct{}
+}
+
+type bearerContextKey struct{}
+type callStateContextKey struct{}
+
+type callState struct {
+	rateLimited atomic.Bool
+}
+
+func markRateLimited(ctx context.Context) {
+	if state, ok := ctx.Value(callStateContextKey{}).(*callState); ok {
+		state.rateLimited.Store(true)
+	}
+}
+
+// New constructs the feature-gated endpoint handler around the pinned SDK.
+func New(options Options) (http.Handler, error) {
+	concurrency := options.MaxConcurrent
+	if concurrency == 0 {
+		concurrency = DefaultInstanceConcurrency
+	}
+	if concurrency < 1 || concurrency > DefaultInstanceConcurrency {
+		return nil, errors.New("mcpserver: instance concurrency must be between 1 and 64")
+	}
+	origin, err := url.Parse(options.ExternalOrigin)
+	if err != nil || (origin.Scheme != "http" && origin.Scheme != "https") ||
+		origin.Host == "" || origin.User != nil || origin.Path != "" || origin.RawQuery != "" || origin.Fragment != "" ||
+		options.ExternalOrigin != origin.Scheme+"://"+origin.Host {
+		return nil, errors.New("mcpserver: external origin must be canonical")
+	}
+	for _, candidate := range options.AllowedOrigins {
+		allowed, parseErr := url.Parse(candidate)
+		if parseErr != nil || (allowed.Scheme != "http" && allowed.Scheme != "https") ||
+			allowed.Host == "" || allowed.User != nil || allowed.Path != "" || allowed.RawQuery != "" || allowed.Fragment != "" ||
+			candidate != allowed.Scheme+"://"+allowed.Host || candidate == "null" || candidate == "*" {
+			return nil, errors.New("mcpserver: allowed origins must be canonical")
+		}
+	}
+	registrations := options.Registry.freeze()
+	server := mcp.NewServer(&mcp.Implementation{
+		Name: "hikyo", Title: "Hikyo", Description: "Read-only Hikyo configuration tools.", Version: options.Version,
+	}, &mcp.ServerOptions{
+		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
+	})
+	for _, item := range registrations {
+		item.install(server)
+	}
+	sdk := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, &mcp.StreamableHTTPOptions{
+		Stateless: true, JSONResponse: true, MaxRequestBodyBytes: MaxRequestBytes,
+		PropagateRequestCancellation: true,
+	})
+	return &handler{
+		sdk: sdk, externalScheme: origin.Scheme, externalHost: origin.Host,
+		allowedOrigins: slices.Clone(options.AllowedOrigins),
+		trustedProxies: slices.Clone(options.TrustedProxies),
+		admission:      options.Admission, slots: make(chan struct{}, concurrency),
+	}, nil
+}
+
+type rpcEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type requestMeta struct {
+	Meta map[string]any `json:"_meta"`
+	Name string         `json:"name"`
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.validHost(r) || !h.validOrigin(r) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+	if r.Method != http.MethodPost {
+		h.sdk.ServeHTTP(w, r)
+		return
+	}
+	if baseMediaType(r.Header.Get("Content-Type")) != "application/json" || !acceptsMCP(r.Header.Values("Accept")) {
+		h.sdk.ServeHTTP(w, r)
+		return
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(r.Body, MaxRequestBytes+1))
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	if len(raw) > MaxRequestBytes {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(raw))
+	var envelope rpcEnvelope
+	if err := decodeOne(raw, &envelope); err != nil {
+		h.sdk.ServeHTTP(w, r)
+		return
+	}
+	if envelope.JSONRPC != "2.0" {
+		h.serveSDK(w, r, envelope.Method, envelope.ID, MaxStaticResponseBytes, nil)
+		return
+	}
+
+	requestedVersion, requestedName := metadataFrom(envelope.Params)
+	headerVersions := r.Header.Values("Mcp-Protocol-Version")
+	if len(headerVersions) != 1 || requestedVersion == "" || headerVersions[0] != requestedVersion {
+		writeRPCError(w, http.StatusBadRequest, envelope.ID, -32020, "protocol mirror headers do not match request", nil)
+		return
+	}
+	methodHeaders := r.Header.Values("Mcp-Method")
+	nameHeaders := r.Header.Values("Mcp-Name")
+	if len(methodHeaders) != 1 || methodHeaders[0] != envelope.Method ||
+		(envelope.Method == "tools/call" && (len(nameHeaders) != 1 || nameHeaders[0] != requestedName)) ||
+		(envelope.Method != "tools/call" && len(nameHeaders) != 0) {
+		writeRPCError(w, http.StatusBadRequest, envelope.ID, -32020, "protocol mirror headers do not match request", nil)
+		return
+	}
+	if requestedVersion != "" && requestedVersion != ProtocolVersion {
+		writeRPCError(w, http.StatusBadRequest, envelope.ID, -32022, "unsupported protocol version; upgrade the MCP client", map[string]any{
+			"supported": []string{ProtocolVersion}, "requested": requestedVersion,
+		})
+		return
+	}
+	if len(headerVersions) == 1 && headerVersions[0] != ProtocolVersion {
+		writeRPCError(w, http.StatusBadRequest, envelope.ID, -32022, "unsupported protocol version; upgrade the MCP client", map[string]any{
+			"supported": []string{ProtocolVersion}, "requested": headerVersions[0],
+		})
+		return
+	}
+	if envelope.Method != "server/discover" && envelope.Method != "tools/list" && envelope.Method != "tools/call" {
+		writeRPCError(w, http.StatusNotFound, envelope.ID, -32601, "method not registered", nil)
+		return
+	}
+	if len(r.Header.Values("Mcp-Session-Id")) != 0 {
+		writeRPCError(w, http.StatusBadRequest, envelope.ID, -32020, "stateless transport does not accept a session id", nil)
+		return
+	}
+
+	sourceIP := h.sourceIP(r)
+	ctx := audit.WithContext(r.Context(), audit.Context{
+		SourceIP: sourceIP, UserAgent: r.UserAgent(), Origin: audit.OriginMCP, RequestOrigin: r.Header.Get("Origin"),
+	})
+	if envelope.Method == "server/discover" || envelope.Method == "tools/list" {
+		if h.admission != nil && !h.admission.AllowDiscovery(sourceIP) {
+			w.Header().Set("Retry-After", "60")
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+		r = r.WithContext(ctx)
+		if len(envelope.ID) == 0 {
+			h.serveValidatedStaticNotification(w, r, raw)
+			return
+		}
+		h.serveStatic(w, r, envelope.Method, envelope.ID)
+		return
+	}
+
+	select {
+	case h.slots <- struct{}{}:
+		defer func() { <-h.slots }()
+	default:
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+		return
+	}
+	bearer, ok := parseBearer(r.Header.Values("Authorization"))
+	if !ok {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, ToolExecutionTimeout)
+	defer cancel()
+	state := &callState{}
+	ctx = context.WithValue(ctx, callStateContextKey{}, state)
+	ctx = context.WithValue(ctx, bearerContextKey{}, newBearer(bearer))
+	h.serveSDK(w, r.WithContext(ctx), envelope.Method, envelope.ID, 0, state)
+}
+
+func (h *handler) serveValidatedStaticNotification(w http.ResponseWriter, r *http.Request, raw []byte) {
+	objectStart := bytes.IndexByte(raw, '{')
+	if objectStart < 0 {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	withID := make([]byte, 0, len(raw)+7)
+	withID = append(withID, raw[:objectStart+1]...)
+	withID = append(withID, `"id":0,`...)
+	withID = append(withID, raw[objectStart+1:]...)
+	r.Body = io.NopCloser(bytes.NewReader(withID))
+
+	capture := newCapturedResponse()
+	h.sdk.ServeHTTP(capture, r)
+	if capture.status >= http.StatusOK && capture.status < http.StatusMultipleChoices &&
+		capture.body.Len() <= MaxStaticResponseBytes {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	if capture.body.Len() > MaxStaticResponseBytes {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	body := capture.body.Bytes()
+	if baseMediaType(capture.header.Get("Content-Type")) == "application/json" {
+		var response map[string]json.RawMessage
+		if json.Unmarshal(body, &response) == nil {
+			if _, hasID := response["id"]; hasID {
+				response["id"] = json.RawMessage("null")
+				body, _ = json.Marshal(response)
+			}
+		}
+	}
+	copyHeaders(w.Header(), capture.header)
+	w.Header().Del("Content-Length")
+	w.WriteHeader(capture.status)
+	_, _ = w.Write(body)
+}
+
+func (h *handler) serveStatic(w http.ResponseWriter, r *http.Request, method string, requestID json.RawMessage) {
+	h.serveSDK(w, r, method, requestID, MaxStaticResponseBytes, nil)
+}
+
+func (h *handler) serveSDK(w http.ResponseWriter, r *http.Request, method string, requestID json.RawMessage, maxBytes int, state *callState) {
+	capture := newCapturedResponse()
+	h.sdk.ServeHTTP(capture, r)
+	if state != nil && state.rateLimited.Load() {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+		return
+	}
+	body := capture.body.Bytes()
+	if len(body) > 0 && baseMediaType(capture.header.Get("Content-Type")) == "application/json" {
+		var response map[string]json.RawMessage
+		if json.Unmarshal(body, &response) == nil {
+			if _, hasID := response["id"]; hasID && len(requestID) > 0 {
+				response["id"] = slices.Clone(requestID)
+			}
+			if method == "server/discover" {
+				var result map[string]json.RawMessage
+				if json.Unmarshal(response["result"], &result) == nil {
+					result["supportedVersions"], _ = json.Marshal([]string{ProtocolVersion})
+					response["result"], _ = json.Marshal(result)
+				}
+			}
+			body, _ = json.Marshal(response)
+		}
+	}
+	if maxBytes > 0 && len(body) > maxBytes {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	copyHeaders(w.Header(), capture.header)
+	w.Header().Del("Content-Length")
+	w.WriteHeader(capture.status)
+	_, _ = w.Write(body)
+}
+
+func parseBearer(values []string) (string, bool) {
+	if len(values) != 1 || len(values[0]) > len("Bearer ")+MaxBearerBytes {
+		return "", false
+	}
+	value, ok := strings.CutPrefix(values[0], "Bearer ")
+	if !ok || value == "" || strings.TrimSpace(value) != value || strings.ContainsAny(value, " \t\r\n,") {
+		return "", false
+	}
+	return value, true
+}
+
+func metadataFrom(params json.RawMessage) (version, name string) {
+	var decoded requestMeta
+	if json.Unmarshal(params, &decoded) != nil || decoded.Meta == nil {
+		return "", ""
+	}
+	version, _ = decoded.Meta["io.modelcontextprotocol/protocolVersion"].(string)
+	return version, decoded.Name
+}
+
+func decodeOne(raw []byte, out any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) {
+		return errors.New("trailing JSON value")
+	}
+	return nil
+}
+
+func writeRPCError(w http.ResponseWriter, status int, id json.RawMessage, code int, message string, data any) {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	payload := struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    any    `json:"data,omitempty"`
+		} `json:"error"`
+	}{JSONRPC: "2.0", ID: id}
+	payload.Error.Code = code
+	payload.Error.Message = message
+	payload.Error.Data = data
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (h *handler) validHost(r *http.Request) bool {
+	host := r.Host
+	if h.trusted(r.RemoteAddr) {
+		forwarded := r.Header.Values("X-Forwarded-Host")
+		if len(forwarded) != 1 || forwarded[0] == "" || strings.Contains(forwarded[0], ",") {
+			return false
+		}
+		host = forwarded[0]
+		forwardedProto := r.Header.Values("X-Forwarded-Proto")
+		if len(forwardedProto) != 1 || forwardedProto[0] == "" || strings.Contains(forwardedProto[0], ",") || forwardedProto[0] != h.externalScheme {
+			return false
+		}
+	}
+	return host != "" && !strings.Contains(host, ",") && strings.EqualFold(host, h.externalHost)
+}
+
+func (h *handler) validOrigin(r *http.Request) bool {
+	values := r.Header.Values("Origin")
+	if len(values) == 0 {
+		return true
+	}
+	return len(values) == 1 && values[0] != "null" && !strings.Contains(values[0], ",") && slices.Contains(h.allowedOrigins, values[0])
+}
+
+func (h *handler) trusted(remote string) bool {
+	host, _, err := net.SplitHostPort(remote)
+	if err != nil {
+		host = remote
+	}
+	ip := net.ParseIP(host)
+	for _, network := range h.trustedProxies {
+		if ip != nil && network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *handler) sourceIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if !h.trusted(r.RemoteAddr) {
+		return host
+	}
+	values := r.Header.Values("X-Forwarded-For")
+	if len(values) != 1 {
+		return host
+	}
+	entries := strings.Split(values[0], ",")
+	for i := len(entries) - 1; i >= 0; i-- {
+		candidate := strings.TrimSpace(entries[i])
+		if net.ParseIP(candidate) == nil {
+			return host
+		}
+		if !h.trusted(candidate) {
+			return candidate
+		}
+	}
+	return host
+}
+
+func baseMediaType(value string) string {
+	if before, _, ok := strings.Cut(value, ";"); ok {
+		value = before
+	}
+	return strings.TrimSpace(value)
+}
+
+func acceptsMCP(values []string) bool {
+	jsonOK, streamOK := false, false
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			switch baseMediaType(part) {
+			case "application/json", "*/*":
+				jsonOK = true
+			case "text/event-stream":
+				streamOK = true
+			}
+		}
+	}
+	return jsonOK && streamOK
+}
+
+type capturedResponse struct {
+	header http.Header
+	status int
+	body   bytes.Buffer
+	wrote  bool
+}
+
+func newCapturedResponse() *capturedResponse {
+	return &capturedResponse{header: make(http.Header), status: http.StatusOK}
+}
+func (r *capturedResponse) Header() http.Header { return r.header }
+func (r *capturedResponse) WriteHeader(status int) {
+	if !r.wrote {
+		r.status = status
+		r.wrote = true
+	}
+}
+func (r *capturedResponse) Write(p []byte) (int, error) {
+	if !r.wrote {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.body.Write(p)
+}
+
+func copyHeaders(dst, src http.Header) {
+	for key, values := range src {
+		dst[key] = slices.Clone(values)
+	}
+}

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -1,0 +1,655 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/operation"
+)
+
+type echoInput struct {
+	Value string `json:"value" jsonschema:"required"`
+}
+
+type echoOutput struct {
+	Value string `json:"value"`
+}
+
+type fixedAdmission bool
+
+func (a fixedAdmission) AllowDiscovery(string) bool { return bool(a) }
+
+func testContract(t *testing.T, name string) operation.Contract {
+	t.Helper()
+	contract, err := operation.NewContract("mcp:"+name, "key.list", []string{"read@project"}, []string{operation.ArtifactMachineCredential})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return contract
+}
+
+func testRegistry(t *testing.T, names ...string) (*Registry, <-chan string) {
+	t.Helper()
+	registry := NewRegistry()
+	seen := make(chan string, 10)
+	for _, name := range names {
+		name := name
+		err := Register(registry, ToolSpec{
+			Name: name, Description: "Read one test value.",
+			ServiceOperation: "service.Keys.List", Contract: testContract(t, name),
+			AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+		}, func(ctx context.Context, bearer Bearer, input echoInput) (echoOutput, error) {
+			contract, ok := operation.FromContext(ctx)
+			if !ok || contract.ID != "mcp:"+name {
+				return echoOutput{}, errors.New("operation contract missing")
+			}
+			seen <- bearer.raw()
+			return echoOutput{Value: input.Value}, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return registry, seen
+}
+
+func modernBody(id int, method, name, arguments string) []byte {
+	params := `{"_meta":{"io.modelcontextprotocol/protocolVersion":"` + ProtocolVersion + `","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1"}}}`
+	if method == "tools/call" {
+		params = `{"name":` + strconvQuote(name) + `,"arguments":` + arguments + `,"_meta":{"io.modelcontextprotocol/protocolVersion":"` + ProtocolVersion + `","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"test","version":"1"}}}`
+	}
+	return []byte(`{"jsonrpc":"2.0","id":` + strconvItoa(id) + `,"method":` + strconvQuote(method) + `,"params":` + params + `}`)
+}
+
+func strconvQuote(value string) string {
+	b, _ := json.Marshal(value)
+	return string(b)
+}
+
+func strconvItoa(value int) string { return strconv.FormatInt(int64(value), 10) }
+
+func request(method, target, rpcMethod, name string, body []byte) *http.Request {
+	req := httptest.NewRequest(method, target, bytes.NewReader(body))
+	req.Host = "hikyo.example.com"
+	if method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("Mcp-Protocol-Version", ProtocolVersion)
+		req.Header.Set("Mcp-Method", rpcMethod)
+		if name != "" {
+			req.Header.Set("Mcp-Name", name)
+		}
+	}
+	return req
+}
+
+func testHandler(t *testing.T, registry *Registry) http.Handler {
+	t.Helper()
+	h, err := New(Options{
+		Registry:       registry,
+		ExternalOrigin: "https://hikyo.example.com",
+		AllowedOrigins: []string{"https://assistant.example.com"},
+		Version:        "v-test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func serve(t *testing.T, h http.Handler, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v: %q", err, rec.Body.String())
+	}
+	return body
+}
+
+func TestStatelessDiscoveryUsesOnlyPinnedProtocolAndCapabilities(t *testing.T) {
+	registry, _ := testRegistry(t, "zeta", "alpha")
+	h := testHandler(t, registry)
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", modernBody(1, "server/discover", "", ""))
+	// Static metadata never resolves or validates a presented bearer.
+	req.Header.Add("Authorization", "Bearer ignored-one")
+	req.Header.Add("Authorization", "Bearer ignored-two")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Mcp-Session-Id") != "" {
+		t.Fatal("stateless discovery emitted a session id")
+	}
+	body := decodeResponse(t, rec)
+	result := body["result"].(map[string]any)
+	versions := result["supportedVersions"].([]any)
+	if len(versions) != 1 || versions[0] != ProtocolVersion {
+		t.Fatalf("supportedVersions = %v", versions)
+	}
+	capabilities := result["capabilities"].(map[string]any)
+	if len(capabilities) != 1 || capabilities["tools"] == nil {
+		t.Fatalf("capabilities = %v", capabilities)
+	}
+}
+
+func TestAdapterPreservesOpaqueJSONRPCID(t *testing.T) {
+	registry, seen := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	body := bytes.Replace(modernBody(1, "server/discover", "", ""), []byte(`"id":1`), []byte(`"id":9007199254740993`), 1)
+	rec := serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"id":9007199254740993`) {
+		t.Fatalf("discovery id = %d %q", rec.Code, rec.Body.String())
+	}
+
+	body = bytes.Replace(modernBody(1, "tools/call", "echo", `{"value":"ok"}`), []byte(`"id":1`), []byte(`"id":9007199254740993`), 1)
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "echo", body)
+	req.Header.Set("Authorization", "Bearer token")
+	rec = serve(t, h, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"id":9007199254740993`) {
+		t.Fatalf("tool id = %d %q", rec.Code, rec.Body.String())
+	}
+	<-seen
+}
+
+func TestClosedToolCatalogIsDeterministicAndCallable(t *testing.T) {
+	registry, seen := testRegistry(t, "zeta", "alpha")
+	h := testHandler(t, registry)
+
+	list := serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/list", "", modernBody(1, "tools/list", "", "")))
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d: %q", list.Code, list.Body.String())
+	}
+	result := decodeResponse(t, list)["result"].(map[string]any)
+	tools := result["tools"].([]any)
+	var names []string
+	for _, item := range tools {
+		names = append(names, item.(map[string]any)["name"].(string))
+	}
+	if !slices.Equal(names, []string{"alpha", "zeta"}) {
+		t.Fatalf("catalog order = %v", names)
+	}
+
+	call := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "alpha", modernBody(2, "tools/call", "alpha", `{"value":"ok"}`))
+	call.Header.Set("Authorization", "Bearer raw-service-account-token")
+	rec := serve(t, h, call)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("call status = %d: %q", rec.Code, rec.Body.String())
+	}
+	select {
+	case got := <-seen:
+		if got != "raw-service-account-token" {
+			t.Fatalf("bearer = %q", got)
+		}
+	default:
+		t.Fatal("registered operation was not called")
+	}
+	if strings.Contains(rec.Body.String(), "raw-service-account-token") {
+		t.Fatal("bearer leaked into response")
+	}
+	structured := decodeResponse(t, rec)["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if structured["value"] != "ok" {
+		t.Fatalf("structuredContent = %v", structured)
+	}
+
+	unknown := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "missing", modernBody(3, "tools/call", "missing", `{}`))
+	unknown.Header.Set("Authorization", "Bearer raw-service-account-token")
+	unknownRec := serve(t, h, unknown)
+	if unknownRec.Code != http.StatusBadRequest || !strings.Contains(unknownRec.Body.String(), `"code":-32602`) || !strings.Contains(unknownRec.Body.String(), "unknown tool") {
+		t.Fatalf("unknown tool = %d %q", unknownRec.Code, unknownRec.Body.String())
+	}
+}
+
+func TestTransportSecurityAndBounds(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	validBody := modernBody(1, "server/discover", "", "")
+
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		rec := serve(t, h, request(method, "https://hikyo.example.com/mcp", "", "", nil))
+		if rec.Code != http.StatusMethodNotAllowed || rec.Header().Get("Allow") != http.MethodPost {
+			t.Errorf("%s = %d Allow %q", method, rec.Code, rec.Header().Get("Allow"))
+		}
+	}
+
+	badHost := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", validBody)
+	badHost.Host = "attacker.example.com"
+	if rec := serve(t, h, badHost); rec.Code != http.StatusForbidden {
+		t.Errorf("bad Host status = %d", rec.Code)
+	}
+	badOrigin := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", validBody)
+	badOrigin.Header.Set("Origin", "https://attacker.example.com")
+	if rec := serve(t, h, badOrigin); rec.Code != http.StatusForbidden || rec.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("bad Origin = %d CORS %q", rec.Code, rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+	allowedOrigin := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", validBody)
+	allowedOrigin.Header.Set("Origin", "https://assistant.example.com")
+	if rec := serve(t, h, allowedOrigin); rec.Code != http.StatusOK || rec.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Errorf("allowed Origin = %d CORS %q", rec.Code, rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+
+	badType := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", validBody)
+	badType.Header.Set("Content-Type", "text/plain")
+	if rec := serve(t, h, badType); rec.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("content type status = %d", rec.Code)
+	}
+	badAccept := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", validBody)
+	badAccept.Header.Set("Accept", "application/json")
+	if rec := serve(t, h, badAccept); rec.Code != http.StatusBadRequest {
+		t.Errorf("Accept status = %d", rec.Code)
+	}
+	over := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", bytes.Repeat([]byte("x"), MaxRequestBytes+1))
+	if rec := serve(t, h, over); rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversize status = %d", rec.Code)
+	}
+}
+
+func TestTrustedProxyAuthorityIsExact(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	_, proxyNet, err := net.ParseCIDR("10.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := New(Options{
+		Registry: registry, ExternalOrigin: "https://hikyo.example.com",
+		TrustedProxies: []*net.IPNet{proxyNet}, Version: "v-test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := request(http.MethodPost, "https://internal/mcp", "server/discover", "", modernBody(1, "server/discover", "", ""))
+	valid.Host = "internal:8080"
+	valid.RemoteAddr = "10.0.0.2:1234"
+	valid.Header.Set("X-Forwarded-Host", "hikyo.example.com")
+	valid.Header.Set("X-Forwarded-Proto", "https")
+	if rec := serve(t, h, valid); rec.Code != http.StatusOK {
+		t.Fatalf("trusted authority = %d %q", rec.Code, rec.Body.String())
+	}
+
+	for _, mutate := range []func(*http.Request){
+		func(r *http.Request) { r.Header.Set("X-Forwarded-Host", "attacker.example.com") },
+		func(r *http.Request) { r.Header.Add("X-Forwarded-Host", "hikyo.example.com") },
+		func(r *http.Request) { r.Header.Del("X-Forwarded-Host") },
+		func(r *http.Request) { r.Header.Set("X-Forwarded-Proto", "http") },
+		func(r *http.Request) { r.Header.Set("X-Forwarded-Proto", "https,http") },
+		func(r *http.Request) { r.Header.Del("X-Forwarded-Proto") },
+	} {
+		req := valid.Clone(valid.Context())
+		req.Body = io.NopCloser(bytes.NewReader(modernBody(1, "server/discover", "", "")))
+		mutate(req)
+		if rec := serve(t, h, req); rec.Code != http.StatusForbidden {
+			t.Fatalf("ambiguous forwarded authority = %d %q", rec.Code, rec.Body.String())
+		}
+	}
+
+	untrusted := valid.Clone(valid.Context())
+	untrusted.Body = io.NopCloser(bytes.NewReader(modernBody(1, "server/discover", "", "")))
+	untrusted.RemoteAddr = "192.0.2.1:1234"
+	if rec := serve(t, h, untrusted); rec.Code != http.StatusForbidden {
+		t.Fatalf("untrusted forwarded authority = %d", rec.Code)
+	}
+}
+
+func TestHandlerConfigurationRejectsNonCanonicalOrigins(t *testing.T) {
+	for _, options := range []Options{
+		{ExternalOrigin: "https://user@hikyo.example.com"},
+		{ExternalOrigin: "ftp://hikyo.example.com"},
+		{ExternalOrigin: "https://hikyo.example.com/path"},
+		{ExternalOrigin: "https://hikyo.example.com", AllowedOrigins: []string{"*"}},
+		{ExternalOrigin: "https://hikyo.example.com", AllowedOrigins: []string{"https://assistant.example.com/path"}},
+	} {
+		if _, err := New(options); err == nil {
+			t.Fatalf("invalid options accepted: %#v", options)
+		}
+	}
+}
+
+func TestProtocolMirrorHeadersAreRequiredAndExact(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	base := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", modernBody(1, "server/discover", "", ""))
+
+	cases := []struct {
+		name   string
+		mutate func(*http.Request)
+	}{
+		{name: "missing version", mutate: func(r *http.Request) { r.Header.Del("Mcp-Protocol-Version") }},
+		{name: "missing method", mutate: func(r *http.Request) { r.Header.Del("Mcp-Method") }},
+		{name: "mismatched method", mutate: func(r *http.Request) { r.Header.Set("Mcp-Method", "tools/list") }},
+		{name: "ambiguous method", mutate: func(r *http.Request) { r.Header.Add("Mcp-Method", "server/discover") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := base.Clone(base.Context())
+			req.Body = io.NopCloser(bytes.NewReader(modernBody(1, "server/discover", "", "")))
+			tc.mutate(req)
+			rec := serve(t, h, req)
+			if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), `"code":-32020`) {
+				t.Fatalf("response = %d %q", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	call := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "wrong", modernBody(2, "tools/call", "echo", `{"value":"ok"}`))
+	call.Header.Set("Authorization", "Bearer token")
+	if rec := serve(t, h, call); rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), `"code":-32020`) {
+		t.Fatalf("mismatched name = %d %q", rec.Code, rec.Body.String())
+	}
+
+	session := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", modernBody(3, "server/discover", "", ""))
+	session.Header.Set("Mcp-Session-Id", "attacker-state")
+	if rec := serve(t, h, session); rec.Code != http.StatusBadRequest || rec.Header().Get("Mcp-Session-Id") != "" {
+		t.Fatalf("session header = %d response session %q", rec.Code, rec.Header().Get("Mcp-Session-Id"))
+	}
+}
+
+func TestDiscoveryAdmissionAndToolConcurrencyAreBounded(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	h, err := New(Options{
+		Registry: registry, ExternalOrigin: "https://hikyo.example.com",
+		Admission: fixedAdmission(false), Version: "v-test", MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, method := range []string{"server/discover", "tools/list"} {
+		rec := serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", method, "", modernBody(1, method, "", "")))
+		if rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") == "" {
+			t.Fatalf("%s admission = %d Retry-After %q", method, rec.Code, rec.Header().Get("Retry-After"))
+		}
+	}
+
+	blocking := NewRegistry()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	if err := Register(blocking, ToolSpec{
+		Name: "wait", Description: "Wait for release.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "wait"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(context.Context, Bearer, echoInput) (echoOutput, error) {
+		close(started)
+		<-release
+		return echoOutput{Value: "ok"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h, err = New(Options{Registry: blocking, ExternalOrigin: "https://hikyo.example.com", Version: "v-test", MaxConcurrent: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "wait", modernBody(2, "tools/call", "wait", `{"value":"x"}`))
+	first.Header.Set("Authorization", "Bearer token")
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, first)
+		firstDone <- rec
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first operation did not start")
+	}
+	second := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "wait", modernBody(3, "tools/call", "wait", `{"value":"x"}`))
+	second.Header.Set("Authorization", "Bearer token")
+	if rec := serve(t, h, second); rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") == "" {
+		t.Fatalf("concurrent call = %d Retry-After %q", rec.Code, rec.Header().Get("Retry-After"))
+	}
+	close(release)
+	select {
+	case rec := <-firstDone:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("first response = %d %q", rec.Code, rec.Body.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first operation did not return")
+	}
+}
+
+func TestToolDeadlineAndAuthorizationHeaderAreBounded(t *testing.T) {
+	registry := NewRegistry()
+	remaining := make(chan time.Duration, 1)
+	called := make(chan struct{}, 1)
+	if err := Register(registry, ToolSpec{
+		Name: "deadline", Description: "Report deadline.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "deadline"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(ctx context.Context, _ Bearer, _ echoInput) (echoOutput, error) {
+		called <- struct{}{}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return echoOutput{}, errors.New("missing deadline")
+		}
+		remaining <- time.Until(deadline)
+		return echoOutput{Value: "ok"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h := testHandler(t, registry)
+
+	missing := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "deadline", modernBody(1, "tools/call", "deadline", `{"value":"x"}`))
+	if rec := serve(t, h, missing); rec.Code != http.StatusUnauthorized || rec.Header().Get("WWW-Authenticate") != "Bearer" {
+		t.Fatalf("missing bearer = %d challenge %q", rec.Code, rec.Header().Get("WWW-Authenticate"))
+	}
+	select {
+	case <-called:
+		t.Fatal("missing bearer reached operation")
+	default:
+	}
+
+	duplicate := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "deadline", modernBody(2, "tools/call", "deadline", `{"value":"x"}`))
+	duplicate.Header.Add("Authorization", "Bearer one")
+	duplicate.Header.Add("Authorization", "Bearer two")
+	if rec := serve(t, h, duplicate); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("duplicate bearer = %d", rec.Code)
+	}
+
+	valid := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "deadline", modernBody(3, "tools/call", "deadline", `{"value":"x"}`))
+	valid.Header.Set("Authorization", "Bearer token")
+	if rec := serve(t, h, valid); rec.Code != http.StatusOK {
+		t.Fatalf("valid call = %d %q", rec.Code, rec.Body.String())
+	}
+	select {
+	case got := <-remaining:
+		if got <= 29*time.Second || got > ToolExecutionTimeout {
+			t.Fatalf("deadline remaining = %s", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("operation did not report deadline")
+	}
+}
+
+func TestValidatedStaticNotificationReturns202WithoutBody(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	for _, method := range []string{"server/discover", "tools/list"} {
+		body := bytes.Replace(modernBody(1, method, "", ""), []byte(`"id":1,`), nil, 1)
+		rec := serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", method, "", body))
+		if rec.Code != http.StatusAccepted || rec.Body.Len() != 0 {
+			t.Fatalf("%s notification = %d %q", method, rec.Code, rec.Body.String())
+		}
+	}
+
+	malformed := bytes.Replace(modernBody(1, "tools/list", "", ""), []byte(`"id":1,`), nil, 1)
+	malformed = bytes.Replace(malformed, []byte(`"params":{`), []byte(`"params":{"cursor":123,`), 1)
+	rec := serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/list", "", malformed))
+	if rec.Code == http.StatusAccepted || strings.Contains(rec.Body.String(), `"id":0`) {
+		t.Fatalf("notification = %d %q", rec.Code, rec.Body.String())
+	}
+
+	largeRegistry := NewRegistry()
+	if err := Register(largeRegistry, ToolSpec{
+		Name: "large", Description: strings.Repeat("x", MaxStaticResponseBytes), ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "large"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(context.Context, Bearer, echoInput) (echoOutput, error) { return echoOutput{}, nil }); err != nil {
+		t.Fatal(err)
+	}
+	largeHandler := testHandler(t, largeRegistry)
+	largeBody := bytes.Replace(modernBody(1, "tools/list", "", ""), []byte(`"id":1,`), nil, 1)
+	rec = serve(t, largeHandler, request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/list", "", largeBody))
+	if rec.Code != http.StatusInternalServerError || rec.Body.Len() > 256 {
+		t.Fatalf("oversized notification = %d bytes=%d", rec.Code, rec.Body.Len())
+	}
+}
+
+func TestLegacyAndUnregisteredMethodsAreExplicitlyRefused(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+
+	legacy := modernBody(1, "server/discover", "", "")
+	legacy = bytes.ReplaceAll(legacy, []byte(ProtocolVersion), []byte("2025-11-25"))
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "server/discover", "", legacy)
+	req.Header.Set("Mcp-Protocol-Version", "2025-11-25")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), `"code":-32022`) || !strings.Contains(rec.Body.String(), ProtocolVersion) {
+		t.Fatalf("legacy response = %d %q", rec.Code, rec.Body.String())
+	}
+
+	unknownBody := modernBody(2, "resources/list", "", "")
+	unknown := request(http.MethodPost, "https://hikyo.example.com/mcp", "resources/list", "", unknownBody)
+	unknownRec := serve(t, h, unknown)
+	if unknownRec.Code != http.StatusNotFound || !strings.Contains(unknownRec.Body.String(), `"code":-32601`) {
+		t.Fatalf("unregistered method = %d %q", unknownRec.Code, unknownRec.Body.String())
+	}
+}
+
+func TestMalformedJSONRPCPrecedesUnknownMethodPolicy(t *testing.T) {
+	registry, _ := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	validUnknown := modernBody(1, "resources/list", "", "")
+	for _, body := range [][]byte{
+		bytes.Replace(validUnknown, []byte(`"jsonrpc":"2.0"`), []byte(`"jsonrpc":"1.0"`), 1),
+		bytes.Replace(validUnknown, []byte(`"jsonrpc":"2.0",`), nil, 1),
+	} {
+		req := request(http.MethodPost, "https://hikyo.example.com/mcp", "resources/list", "", body)
+		rec := serve(t, h, req)
+		if rec.Code != http.StatusBadRequest || strings.Contains(rec.Body.String(), `"code":-32601`) {
+			t.Fatalf("malformed unknown method = %d %q", rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestToolErrorsAreSafeAndExecutionIsBounded(t *testing.T) {
+	registry := NewRegistry()
+	err := Register(registry, ToolSpec{
+		Name: "failure", Description: "Fail safely.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "failure"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(context.Context, Bearer, echoInput) (echoOutput, error) {
+		return echoOutput{}, errors.New("database row contains CANARY-SECRET")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := testHandler(t, registry)
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "failure", modernBody(1, "tools/call", "failure", `{"value":"x"}`))
+	req.Header.Set("Authorization", "Bearer token")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), SafeOperationError) || strings.Contains(rec.Body.String(), "CANARY-SECRET") {
+		t.Fatalf("safe error response = %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthenticatedRateLimitUsesUniformHTTPResponse(t *testing.T) {
+	registry := NewRegistry()
+	err := Register(registry, ToolSpec{
+		Name: "limited", Description: "Refuse a limited call.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "limited"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(context.Context, Bearer, echoInput) (echoOutput, error) {
+		return echoOutput{}, fmt.Errorf("CANARY-RATE-DETAIL: %w", ErrRateLimited)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := testHandler(t, registry)
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "limited", modernBody(1, "tools/call", "limited", `{"value":"x"}`))
+	req.Header.Set("Authorization", "Bearer token")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") != "60" ||
+		strings.Contains(rec.Body.String(), "CANARY-RATE-DETAIL") {
+		t.Fatalf("rate response = %d Retry-After %q body %q", rec.Code, rec.Header().Get("Retry-After"), rec.Body.String())
+	}
+}
+
+func TestCancellationReachesRegisteredOperation(t *testing.T) {
+	registry := NewRegistry()
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	err := Register(registry, ToolSpec{
+		Name: "wait", Description: "Wait for cancellation.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "wait"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(ctx context.Context, _ Bearer, _ echoInput) (echoOutput, error) {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return echoOutput{}, ctx.Err()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := testHandler(t, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "wait", modernBody(1, "tools/call", "wait", `{"value":"x"}`)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer token")
+	done := make(chan struct{})
+	go func() {
+		serve(t, h, req)
+		close(done)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("operation did not start")
+	}
+	cancel()
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("request cancellation did not reach operation")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled request did not return")
+	}
+}
+
+func TestSuccessiveRequestsCanAlternateReplicas(t *testing.T) {
+	registryA, seenA := testRegistry(t, "echo")
+	registryB, seenB := testRegistry(t, "echo")
+	replicas := []http.Handler{testHandler(t, registryA), testHandler(t, registryB)}
+	seen := []<-chan string{seenA, seenB}
+	for i, replica := range replicas {
+		req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "echo", modernBody(i+1, "tools/call", "echo", `{"value":"ok"}`))
+		req.Header.Set("Authorization", "Bearer token")
+		rec := serve(t, replica, req)
+		if rec.Code != http.StatusOK || rec.Header().Get("Mcp-Session-Id") != "" {
+			t.Fatalf("replica %d = %d session %q", i, rec.Code, rec.Header().Get("Mcp-Session-Id"))
+		}
+		<-seen[i]
+	}
+}
+
+func TestBearerFormattingAlwaysRedacts(t *testing.T) {
+	b := newBearer("CANARY-TOKEN")
+	for _, formatted := range []string{b.String(), fmt.Sprintf("%v", b), fmt.Sprintf("%#v", b)} {
+		if strings.Contains(formatted, "CANARY-TOKEN") {
+			t.Fatalf("bearer formatting leaked: %q", formatted)
+		}
+	}
+}

--- a/internal/mcpserver/registry.go
+++ b/internal/mcpserver/registry.go
@@ -1,0 +1,239 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
+)
+
+const (
+	// MaxStructuredContentBytes is the phase-1 encoded tool-result bound.
+	MaxStructuredContentBytes = 256 << 10
+	// MaxCompatibilityTextBytes is the phase-1 compatibility-summary bound.
+	MaxCompatibilityTextBytes = 4 << 10
+	// SafeOperationError is the only fallback text emitted for an unexpected
+	// service error. Domain-specific safe errors can join this closed policy in
+	// the tool ticket; raw errors never cross the transport.
+	SafeOperationError = "Hikyo operation refused"
+)
+
+// ErrRateLimited lets an authenticated service callback request the transport's
+// uniform HTTP 429 response without exposing internal error details.
+var ErrRateLimited = errors.New("mcpserver: rate limited")
+
+type AuditDisposition string
+
+const AuditDispositionNone AuditDisposition = "audited:none"
+
+type SecretPolicy string
+
+const SecretPolicyNoSecretMaterial SecretPolicy = "no-secret-material"
+
+const compatibilitySummary = "Hikyo returned structured data."
+
+// Bearer wraps the raw presented service-account artifact. Formatting is
+// always redacted; only this adapter package can unwrap it for a service call.
+type Bearer struct{ value string }
+
+func newBearer(value string) Bearer { return Bearer{value: value} }
+func (b Bearer) raw() string        { return b.value }
+func (Bearer) String() string       { return "[REDACTED]" }
+func (Bearer) GoString() string     { return "mcpserver.Bearer([REDACTED])" }
+
+// ToolSpec is the security and wire policy for one explicitly registered
+// operation. Input and output schemas are inferred once from the generic
+// Register types and pinned into the immutable registry row.
+type ToolSpec struct {
+	Name             string
+	Title            string
+	Description      string
+	ServiceOperation string
+	Contract         operation.Contract
+	AuditDisposition AuditDisposition
+	SecretPolicy     SecretPolicy
+}
+
+// RegistryRow is the immutable, reviewable projection used by closure tests.
+type RegistryRow struct {
+	Name                   string
+	InputSchema            json.RawMessage
+	OutputSchema           json.RawMessage
+	ServiceOperation       string
+	AuthorizationOperation string
+	Formula                []string
+	Artifacts              []string
+	AuditDisposition       AuditDisposition
+	ReadOnly               bool
+	ResultBytes            int
+	SecretPolicy           SecretPolicy
+}
+
+type registration struct {
+	row     RegistryRow
+	install func(*mcp.Server)
+}
+
+// Registry is a closed tool set. New freezes it before serving.
+type Registry struct {
+	mu            sync.Mutex
+	registrations map[string]registration
+	frozen        bool
+}
+
+func NewRegistry() *Registry {
+	return &Registry{registrations: make(map[string]registration)}
+}
+
+var toolNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
+
+// Register adds one typed service-operation mapping to the closed registry.
+func Register[In, Out any](registry *Registry, spec ToolSpec, handler func(context.Context, Bearer, In) (Out, error)) error {
+	if registry == nil {
+		return errors.New("mcpserver: nil registry")
+	}
+	if handler == nil {
+		return errors.New("mcpserver: nil tool handler")
+	}
+	if !toolNamePattern.MatchString(spec.Name) {
+		return fmt.Errorf("mcpserver: invalid tool name %q", spec.Name)
+	}
+	if spec.Description == "" {
+		return fmt.Errorf("mcpserver: tool %q has no description", spec.Name)
+	}
+	if spec.ServiceOperation == "" {
+		return fmt.Errorf("mcpserver: tool %q has no service operation", spec.Name)
+	}
+	if spec.AuditDisposition != AuditDispositionNone {
+		return fmt.Errorf("mcpserver: tool %q has an unsupported audit disposition", spec.Name)
+	}
+	if spec.SecretPolicy != SecretPolicyNoSecretMaterial {
+		return fmt.Errorf("mcpserver: tool %q has an unsupported secret policy", spec.Name)
+	}
+	if spec.Contract.ID != "mcp:"+spec.Name || spec.Contract.AuthorizationOperation == "" ||
+		len(spec.Contract.Formula()) == 0 || len(spec.Contract.Artifacts()) == 0 {
+		return fmt.Errorf("mcpserver: tool %q has an incomplete or mismatched operation contract", spec.Name)
+	}
+	if !spec.Contract.AdmitsArtifact(operation.ArtifactMachineCredential) || len(spec.Contract.Artifacts()) != 1 {
+		return fmt.Errorf("mcpserver: tool %q must admit only machine credentials", spec.Name)
+	}
+	policy, ok := authz.LookupNetworkOperationPolicy(spec.Contract.AuthorizationOperation)
+	if !ok || !slices.Equal(policy.Formula, spec.Contract.Formula()) {
+		return fmt.Errorf("mcpserver: tool %q authorization formula does not match the registry", spec.Name)
+	}
+	if !policy.ReadOnly || !policy.AuditedNone {
+		return fmt.Errorf("mcpserver: tool %q authorization operation is not an audited-none read", spec.Name)
+	}
+	inputSchema, err := jsonschema.For[In](nil)
+	if err != nil {
+		return fmt.Errorf("mcpserver: tool %q input schema: %w", spec.Name, err)
+	}
+	outputSchema, err := jsonschema.For[Out](nil)
+	if err != nil {
+		return fmt.Errorf("mcpserver: tool %q output schema: %w", spec.Name, err)
+	}
+	inputSchemaJSON, err := json.Marshal(inputSchema)
+	if err != nil {
+		return fmt.Errorf("mcpserver: tool %q input schema encoding: %w", spec.Name, err)
+	}
+	outputSchemaJSON, err := json.Marshal(outputSchema)
+	if err != nil {
+		return fmt.Errorf("mcpserver: tool %q output schema encoding: %w", spec.Name, err)
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if registry.frozen {
+		return errors.New("mcpserver: registry is frozen")
+	}
+	if _, exists := registry.registrations[spec.Name]; exists {
+		return fmt.Errorf("mcpserver: duplicate tool %q", spec.Name)
+	}
+
+	row := RegistryRow{
+		Name: spec.Name, InputSchema: inputSchemaJSON, OutputSchema: outputSchemaJSON,
+		ServiceOperation: spec.ServiceOperation, AuthorizationOperation: spec.Contract.AuthorizationOperation,
+		Formula: spec.Contract.Formula(), Artifacts: spec.Contract.Artifacts(),
+		AuditDisposition: spec.AuditDisposition, ReadOnly: true,
+		ResultBytes: MaxStructuredContentBytes, SecretPolicy: spec.SecretPolicy,
+	}
+	registry.registrations[spec.Name] = registration{
+		row: row,
+		install: func(server *mcp.Server) {
+			closedWorld := false
+			nondestructive := false
+			mcp.AddTool(server, &mcp.Tool{
+				Name: spec.Name, Title: spec.Title, Description: spec.Description,
+				InputSchema: json.RawMessage(inputSchemaJSON), OutputSchema: json.RawMessage(outputSchemaJSON),
+				Annotations: &mcp.ToolAnnotations{
+					ReadOnlyHint: true, IdempotentHint: true,
+					DestructiveHint: &nondestructive, OpenWorldHint: &closedWorld,
+				},
+			}, func(ctx context.Context, _ *mcp.CallToolRequest, input In) (*mcp.CallToolResult, Out, error) {
+				ctx = operation.WithContract(ctx, spec.Contract)
+				bearer, _ := ctx.Value(bearerContextKey{}).(Bearer)
+				output, err := handler(ctx, bearer, input)
+				if err != nil {
+					var zero Out
+					if errors.Is(err, ErrRateLimited) {
+						markRateLimited(ctx)
+					}
+					return nil, zero, errors.New(SafeOperationError)
+				}
+				encoded, err := json.Marshal(output)
+				if err != nil || len(encoded) > MaxStructuredContentBytes {
+					var zero Out
+					return nil, zero, errors.New(SafeOperationError)
+				}
+				return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: compatibilitySummary}}}, output, nil
+			})
+		},
+	}
+	return nil
+}
+
+func (r *Registry) freeze() []registration {
+	return r.snapshot(true)
+}
+
+func (r *Registry) snapshot(freeze bool) []registration {
+	if r == nil {
+		r = NewRegistry()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if freeze {
+		r.frozen = true
+	}
+	out := make([]registration, 0, len(r.registrations))
+	for _, item := range r.registrations {
+		out = append(out, item)
+	}
+	slices.SortFunc(out, func(a, b registration) int { return strings.Compare(a.row.Name, b.row.Name) })
+	return out
+}
+
+// Rows returns the deterministic policy projection.
+func (r *Registry) Rows() []RegistryRow {
+	items := r.snapshot(false)
+	rows := make([]RegistryRow, 0, len(items))
+	for _, item := range items {
+		row := item.row
+		row.Formula = slices.Clone(row.Formula)
+		row.Artifacts = slices.Clone(row.Artifacts)
+		row.InputSchema = slices.Clone(row.InputSchema)
+		row.OutputSchema = slices.Clone(row.OutputSchema)
+		rows = append(rows, row)
+	}
+	return rows
+}

--- a/internal/mcpserver/registry_test.go
+++ b/internal/mcpserver/registry_test.go
@@ -1,0 +1,151 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/operation"
+)
+
+func TestRegistryRefusesInvalidDuplicateAndLateRows(t *testing.T) {
+	registry := NewRegistry()
+	valid := ToolSpec{
+		Name: "echo", Description: "Echo one value.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "echo"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}
+	handler := func(context.Context, Bearer, echoInput) (echoOutput, error) { return echoOutput{}, nil }
+	if err := Register(registry, valid, handler); err != nil {
+		t.Fatal(err)
+	}
+	if err := Register(registry, valid, handler); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate registration error = %v", err)
+	}
+	if _, err := New(Options{Registry: registry, ExternalOrigin: "https://hikyo.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	late := valid
+	late.Name = "late"
+	late.Contract = testContract(t, "late")
+	if err := Register(registry, late, handler); err == nil || !strings.Contains(err.Error(), "frozen") {
+		t.Fatalf("late registration error = %v", err)
+	}
+
+	humanContract, err := operation.NewContract("mcp:human", "key.list", []string{"read@project"}, []string{operation.ArtifactHumanSession})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Register(NewRegistry(), ToolSpec{
+		Name: "human", Description: "Invalid human tool.", ServiceOperation: "service.Keys.List",
+		Contract: humanContract, AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, handler); err == nil || !strings.Contains(err.Error(), "only machine credentials") {
+		t.Fatalf("human registration error = %v", err)
+	}
+
+	drifted, err := operation.NewContract("mcp:echo", "key.list", []string{"edit@project"}, []string{operation.ArtifactMachineCredential})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		edit func(*ToolSpec)
+	}{
+		{name: "missing service operation", edit: func(spec *ToolSpec) { spec.ServiceOperation = "" }},
+		{name: "formula drift", edit: func(spec *ToolSpec) { spec.Contract = drifted }},
+		{name: "audit drift", edit: func(spec *ToolSpec) { spec.AuditDisposition = "audited:write" }},
+		{name: "secret policy drift", edit: func(spec *ToolSpec) { spec.SecretPolicy = "may-return-secrets" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := valid
+			tc.edit(&spec)
+			if err := Register(NewRegistry(), spec, handler); err == nil {
+				t.Fatal("incomplete or drifted registry row accepted")
+			}
+		})
+	}
+}
+
+func TestRegistryRowsAreDeterministicAndImmutable(t *testing.T) {
+	registry, _ := testRegistry(t, "zeta", "alpha")
+	rows := registry.Rows()
+	if len(rows) != 2 || rows[0].Name != "alpha" || rows[1].Name != "zeta" {
+		t.Fatalf("rows = %#v", rows)
+	}
+	if rows[0].ServiceOperation != "service.Keys.List" || rows[0].AuthorizationOperation != "key.list" ||
+		rows[0].AuditDisposition != AuditDispositionNone || !rows[0].ReadOnly ||
+		rows[0].ResultBytes != MaxStructuredContentBytes || rows[0].SecretPolicy != SecretPolicyNoSecretMaterial ||
+		!json.Valid(rows[0].InputSchema) || !json.Valid(rows[0].OutputSchema) {
+		t.Fatalf("incomplete registry projection: %#v", rows[0])
+	}
+	rows[0].Formula[0] = "mutated"
+	rows[0].Artifacts[0] = operation.ArtifactHumanSession
+	rows[0].InputSchema[0] = 'x'
+	rows[0].OutputSchema[0] = 'x'
+	again := registry.Rows()
+	if slices.Contains(again[0].Formula, "mutated") || slices.Contains(again[0].Artifacts, operation.ArtifactHumanSession) ||
+		again[0].InputSchema[0] == 'x' || again[0].OutputSchema[0] == 'x' {
+		t.Fatalf("registry projection was mutable: %#v", again[0])
+	}
+}
+
+func TestEncodedToolResultBoundFailsClosed(t *testing.T) {
+	registry := NewRegistry()
+	if err := Register(registry, ToolSpec{
+		Name: "large", Description: "Return an oversized result.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "large"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(context.Context, Bearer, echoInput) (echoOutput, error) {
+		return echoOutput{Value: strings.Repeat("x", MaxStructuredContentBytes)}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h := testHandler(t, registry)
+	req := request("POST", "https://hikyo.example.com/mcp", "tools/call", "large", modernBody(1, "tools/call", "large", `{"value":"x"}`))
+	req.Header.Set("Authorization", "Bearer token")
+	rec := serve(t, h, req)
+	if rec.Code != 200 || !strings.Contains(rec.Body.String(), SafeOperationError) {
+		t.Fatalf("oversized result = %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdapterHasNoStoreSQLOrCryptoImports(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Clean(entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, forbidden := range []string{"internal/store", "internal/crypto", "api/apigen"} {
+			if strings.Contains(string(raw), `"github.com/Hikyo-Org/hikyo/`+forbidden) {
+				t.Errorf("%s imports forbidden boundary %s", entry.Name(), forbidden)
+			}
+		}
+	}
+}
+
+func TestOfficialSDKIsPinnedExactly(t *testing.T) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		t.Fatal("build information unavailable")
+	}
+	for _, dependency := range info.Deps {
+		if dependency.Path == "github.com/modelcontextprotocol/go-sdk" {
+			if dependency.Version != "v1.7.0" || dependency.Replace != nil {
+				t.Fatalf("SDK dependency = %s replacement %#v", dependency.Version, dependency.Replace)
+			}
+			return
+		}
+	}
+	t.Fatal(errors.New("official MCP SDK dependency missing"))
+}

--- a/internal/operation/contract.go
+++ b/internal/operation/contract.go
@@ -1,0 +1,99 @@
+// Package operation carries the transport-independent authorization contract
+// attached by every network adapter before it invokes a service operation.
+package operation
+
+import (
+	"context"
+	"errors"
+	"slices"
+)
+
+const (
+	ArtifactNone               = "none"
+	ArtifactHumanSession       = "human-session"
+	ArtifactMachineCredential  = "machine-credential"
+	ArtifactSCIMCredential     = "scim-credential"
+	ArtifactInstanceCredential = "instance-credential"
+	ArtifactLocal              = "local"
+)
+
+// Contract is one immutable network-operation admission row. It is built from
+// trusted compiled registry data, never request input.
+type Contract struct {
+	ID                     string
+	AuthorizationOperation string
+	formula                []string
+	artifacts              []string
+}
+
+// NewContract constructs a complete immutable operation contract.
+func NewContract(id, authorizationOperation string, formula, artifacts []string) (Contract, error) {
+	switch {
+	case id == "":
+		return Contract{}, errors.New("operation: contract id is required")
+	case authorizationOperation == "":
+		return Contract{}, errors.New("operation: authorization operation is required")
+	case len(formula) == 0:
+		return Contract{}, errors.New("operation: authorization formula is required")
+	case len(artifacts) == 0:
+		return Contract{}, errors.New("operation: artifact allowlist is required")
+	}
+	return Contract{
+		ID:                     id,
+		AuthorizationOperation: authorizationOperation,
+		formula:                slices.Clone(formula),
+		artifacts:              slices.Clone(artifacts),
+	}, nil
+}
+
+// NewArtifactContract constructs an immutable admission row for a network
+// operation that has an artifact policy but no domain authorization formula.
+func NewArtifactContract(id string, artifacts []string) (Contract, error) {
+	if id == "" {
+		return Contract{}, errors.New("operation: contract id is required")
+	}
+	if len(artifacts) == 0 {
+		return Contract{}, errors.New("operation: artifact allowlist is required")
+	}
+	return Contract{ID: id, artifacts: slices.Clone(artifacts)}, nil
+}
+
+// Formula returns a copy of the authorization formula.
+func (c Contract) Formula() []string { return slices.Clone(c.formula) }
+
+// Artifacts returns a copy of the artifact allowlist.
+func (c Contract) Artifacts() []string { return slices.Clone(c.artifacts) }
+
+// AdmitsArtifact reports whether class is explicitly admitted.
+func (c Contract) AdmitsArtifact(class string) bool {
+	return slices.Contains(c.artifacts, class)
+}
+
+type contextKey struct{}
+type networkContextKey struct{}
+
+// WithNetwork marks work entered through a network adapter, including public
+// metadata operations that have no authorization contract.
+func WithNetwork(ctx context.Context) context.Context {
+	return context.WithValue(ctx, networkContextKey{}, true)
+}
+
+// IsNetwork reports whether a trusted adapter attached network provenance.
+func IsNetwork(ctx context.Context) bool {
+	network, _ := ctx.Value(networkContextKey{}).(bool)
+	return network
+}
+
+// WithContract attaches a trusted operation contract to a network request.
+func WithContract(ctx context.Context, contract Contract) context.Context {
+	if contract.ID == "" {
+		panic("operation: cannot attach an empty contract")
+	}
+	return context.WithValue(WithNetwork(ctx), contextKey{}, contract)
+}
+
+// FromContext returns the network operation contract, when one was attached.
+func FromContext(ctx context.Context) (Contract, bool) {
+	contract, ok := ctx.Value(contextKey{}).(Contract)
+	return contract, ok && contract.ID != ""
+}

--- a/internal/operation/contract_test.go
+++ b/internal/operation/contract_test.go
@@ -1,0 +1,92 @@
+package operation
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestContractIsImmutableAndMovesThroughContext(t *testing.T) {
+	formula := []string{"read@project"}
+	artifacts := []string{ArtifactMachineCredential}
+	contract, err := NewContract("mcp:hikyo_list_definitions", "key.list", formula, artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	formula[0] = "edit@instance"
+	artifacts[0] = ArtifactHumanSession
+
+	ctx := WithContract(context.Background(), contract)
+	if !IsNetwork(ctx) {
+		t.Fatal("contract did not carry network provenance")
+	}
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("contract was not attached")
+	}
+	if got.ID != "mcp:hikyo_list_definitions" || got.AuthorizationOperation != "key.list" {
+		t.Fatalf("contract = %#v", got)
+	}
+	if !slices.Equal(got.Formula(), []string{"read@project"}) {
+		t.Fatalf("formula = %v", got.Formula())
+	}
+	if !got.AdmitsArtifact(ArtifactMachineCredential) || got.AdmitsArtifact(ArtifactHumanSession) {
+		t.Fatalf("artifact allowlist = %v", got.Artifacts())
+	}
+
+	returned := got.Artifacts()
+	returned[0] = ArtifactHumanSession
+	if got.AdmitsArtifact(ArtifactHumanSession) {
+		t.Fatal("artifact accessor exposed mutable policy")
+	}
+}
+
+func TestNetworkProvenanceDoesNotInventAContract(t *testing.T) {
+	ctx := WithNetwork(context.Background())
+	if !IsNetwork(ctx) {
+		t.Fatal("network provenance was not attached")
+	}
+	if _, ok := FromContext(ctx); ok {
+		t.Fatal("network provenance invented an authorization contract")
+	}
+}
+
+func TestContractRejectsIncompletePolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		id        string
+		operation string
+		formula   []string
+		artifacts []string
+	}{
+		{"missing id", "", "key.list", []string{"read@project"}, []string{ArtifactMachineCredential}},
+		{"missing operation", "mcp:x", "", []string{"read@project"}, []string{ArtifactMachineCredential}},
+		{"missing formula", "mcp:x", "key.list", nil, []string{ArtifactMachineCredential}},
+		{"missing artifacts", "mcp:x", "key.list", []string{"read@project"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewContract(tc.id, tc.operation, tc.formula, tc.artifacts); err == nil {
+				t.Fatal("incomplete contract accepted")
+			}
+		})
+	}
+}
+
+func TestArtifactContractAllowsTransportOnlyOperation(t *testing.T) {
+	contract, err := NewArtifactContract("getMeta", []string{ArtifactNone})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contract.AuthorizationOperation != "" || len(contract.Formula()) != 0 || !contract.AdmitsArtifact(ArtifactNone) {
+		t.Fatalf("transport-only contract = %#v", contract)
+	}
+}
+
+func TestWithContractRefusesEmptyContract(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("empty contract did not panic")
+		}
+	}()
+	_ = WithContract(context.Background(), Contract{})
+}

--- a/internal/server/cors.go
+++ b/internal/server/cors.go
@@ -62,6 +62,13 @@ const corsMaxAge = "600"
 func workspaceCORS(allowed func(context.Context, string) bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// MCP has its own exact Origin admission and deliberately emits no
+			// browser CORS grant. Keep the workspace tier off that surface even
+			// when the same origin is allowed to read /api/v1.
+			if r.URL.Path == "/mcp" {
+				next.ServeHTTP(w, r)
+				return
+			}
 			// VARY IS SET ON EVERY BRANCH, BEFORE THE DECISION. It is a
 			// cache-control statement, not an allowlist grant: it says "this
 			// response depends on the Origin header", which is true whether the

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestMCPRouteIsExactAndFeatureGated(t *testing.T) {
+	marker := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-MCP-Test", "reached")
+		w.WriteHeader(http.StatusAccepted)
+	})
+	enabled := NewPublic(nil, nil, nil, PublicOptions{MCP: marker})
+	rec := httptest.NewRecorder()
+	enabled.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	if rec.Code != http.StatusAccepted || rec.Header().Get("X-MCP-Test") != "reached" {
+		t.Fatalf("enabled /mcp = %d marker %q", rec.Code, rec.Header().Get("X-MCP-Test"))
+	}
+
+	for _, target := range []string{"/mcp/", "/mcp/anything"} {
+		rec = httptest.NewRecorder()
+		enabled.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, target, nil))
+		if rec.Code != http.StatusNotFound || rec.Header().Get("X-MCP-Test") != "" {
+			t.Fatalf("%s = %d marker %q", target, rec.Code, rec.Header().Get("X-MCP-Test"))
+		}
+	}
+
+	disabled := NewPublic(nil, nil, fstest.MapFS{"index.html": {Data: []byte("SPA")}}, PublicOptions{})
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Accept", "text/html")
+	disabled.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound || rec.Body.String() == "SPA" {
+		t.Fatalf("disabled /mcp = %d %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWorkspaceCORSNeverDecoratesMCP(t *testing.T) {
+	h := workspaceCORS(func(context.Context, string) bool { return true })(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Origin", "https://workspace.example.com")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("MCP CORS = %d origin %q", rec.Code, rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,8 @@ type PublicOptions struct {
 	// ExternalOrigin is the config-validated canonical public origin. CORS uses
 	// it to identify same-origin requests without trusting the Host header.
 	ExternalOrigin string
+	// MCP is nil while the independently gated MCP surface is disabled.
+	MCP http.Handler
 }
 
 // TLSMetrics reports the label-free native TLS gauges served operationally.
@@ -114,6 +116,10 @@ func NewPublic(ready ReadyChecker, a *API, ui fs.FS, publicOptions PublicOptions
 	// before anything tries to resolve one. Requests without an `Origin` header
 	// pass through untouched, so nothing else on the router changes.
 	r.Use(workspaceCORS(workspaceOriginCheck(a, publicOptions.ExternalOrigin)))
+
+	if publicOptions.MCP != nil {
+		r.Handle("/mcp", publicOptions.MCP)
+	}
 
 	if a != nil {
 		r.Group(func(g chi.Router) {

--- a/internal/server/spa.go
+++ b/internal/server/spa.go
@@ -184,7 +184,7 @@ func cspOrigin(raw string) (string, bool) {
 // reservedRoots are the surfaces that own their own vocabulary. Each covers
 // itself and everything beneath it. `/api` subsumes ContractPrefix, so the
 // version prefix needs no entry of its own.
-var reservedRoots = []string{"/api", "/metrics", "/healthz", "/readyz",
+var reservedRoots = []string{"/api", "/mcp", "/metrics", "/healthz", "/readyz",
 	strings.TrimSuffix(assetPrefix, "/")}
 
 // reservedFromFallback reports whether a path is withheld from the SPA

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/internal/audit"
 	"github.com/Hikyo-Org/hikyo/internal/authz"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
 	"github.com/Hikyo-Org/hikyo/internal/store"
 	"github.com/Hikyo-Org/hikyo/internal/store/migrate"
 )
@@ -172,7 +172,7 @@ func (a Actor) resolve(ctx context.Context, az *authz.TxAuthorizer, now time.Tim
 	} else if a.scimToken != "" {
 		if crypto.ParseArtifact(a.scimToken, crypto.ArtifactSCIM) == nil {
 			identity, err = resolveSCIMCredential(ctx, az, a, now)
-		} else if _, wire := api.OperationFromContext(ctx); wire {
+		} else if operation.IsNetwork(ctx) {
 			// A valid bearer of another class must reach the exact SCIM
 			// operation's admission row, not fail early on SCIM grammar.
 			identity, err = az.AuthenticateCaller(ctx, a.scimToken, now)

--- a/internal/store/migrate/upgrade_test.go
+++ b/internal/store/migrate/upgrade_test.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pressly/goose/v3"
 
 	"github.com/Hikyo-Org/hikyo/internal/store"
 )
@@ -28,6 +31,37 @@ func TestUpgradeOldToNewPostgres(t *testing.T) {
 	// A dedicated scratch database so the partial-schema (N-1) state never
 	// collides with other postgres legs sharing the server.
 	runUpgradeOldToNew(t, postgresTestConfig(t, "upgrade"))
+}
+
+func TestMCPAuditOriginMigrationRollsBackSQLite(t *testing.T) {
+	runMCPAuditOriginRollback(t, store.Config{Engine: store.EngineSQLite, Path: filepath.Join(t.TempDir(), "rollback.db")})
+}
+
+func TestMCPAuditOriginMigrationRollsBackPostgres(t *testing.T) {
+	runMCPAuditOriginRollback(t, postgresTestConfig(t, "mcp_origin_rollback"))
+}
+
+func runMCPAuditOriginRollback(t *testing.T, cfg store.Config) {
+	t.Helper()
+	ctx := t.Context()
+	if err := Run(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := withProvider(ctx, cfg, func(provider *goose.Provider, _ *sql.DB) error {
+		_, err := provider.Down(ctx)
+		return err
+	}); err != nil {
+		t.Fatalf("rollback MCP audit origin migration: %v", err)
+	}
+	if err := insertMCPAuditOrigin(t, cfg, "evt_mcp_rollback_refused"); err == nil {
+		t.Fatal("rolled-back schema still accepted the mcp audit origin")
+	}
+	if err := Run(ctx, cfg); err != nil {
+		t.Fatalf("reapply MCP audit origin migration: %v", err)
+	}
+	if err := insertMCPAuditOrigin(t, cfg, "evt_mcp_rollback_reapplied"); err != nil {
+		t.Fatalf("reapplied schema refused the mcp audit origin: %v", err)
+	}
 }
 
 // postgresTestConfig provisions a throwaway postgres database for a migration
@@ -99,6 +133,12 @@ func runUpgradeOldToNew(t *testing.T, cfg store.Config) {
 	if err := Check(ctx, cfg); err != nil {
 		t.Fatalf("after the upgrade the schema check must pass: %v", err)
 	}
+	// The new closed origin member is accepted on both audit trails' shared
+	// envelope shape. This catches a Go-only vocabulary change with no matching
+	// engine migration.
+	execUpgrade(t, cfg, "INSERT INTO audit_instance_events "+
+		"(id, type, schema_version, occurred_at, occurred_asserted, recorded_at, actor_class, outcome, origin, payload) "+
+		"VALUES ('evt_mcp_upgrade', 'grant.denied', 1, '2026-01-01T00:00:00Z', FALSE, '2026-01-01T00:00:00Z', 'unauthenticated', 'denied', 'mcp', '{}')")
 	// Data survived old→new.
 	if n := countUpgrade(t, cfg, "SELECT COUNT(*) FROM orgs WHERE id = '"+seed+"'"); n != 1 {
 		t.Fatalf("the org seeded on the old schema did not survive the upgrade: count=%d", n)
@@ -141,4 +181,22 @@ func countUpgrade(t *testing.T, cfg store.Config, query string) int {
 		t.Fatalf("count query: %v", err)
 	}
 	return n
+}
+
+func insertMCPAuditOrigin(t *testing.T, cfg store.Config, id string) error {
+	t.Helper()
+	db, err := store.Open(t.Context(), cfg)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	query := "INSERT INTO audit_instance_events " +
+		"(id, type, schema_version, occurred_at, occurred_asserted, recorded_at, actor_class, outcome, origin, payload) " +
+		"VALUES ('" + id + "', 'grant.denied', 1, '2026-01-01T00:00:00Z', FALSE, '2026-01-01T00:00:00Z', 'unauthenticated', 'denied', 'mcp', '{}')"
+	if db.Engine() == store.EnginePostgres {
+		_, err = db.PG().Exec(t.Context(), query)
+		return err
+	}
+	_, err = db.SQLiteWrite().ExecContext(t.Context(), query)
+	return err
 }

--- a/internal/store/migrations/postgres/00042_mcp_audit_origin.sql
+++ b/internal/store/migrations/postgres/00042_mcp_audit_origin.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- MCP emits through the existing append-only audit trails. Widen only the
+-- closed origin vocabulary; every other audit invariant remains unchanged.
+ALTER TABLE audit_tenant_events DROP CONSTRAINT audit_tenant_events_origin_check;
+ALTER TABLE audit_tenant_events ADD CONSTRAINT audit_tenant_events_origin_check CHECK (
+    origin IN ('web', 'cli', 'api', 'mcp', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')
+);
+ALTER TABLE audit_instance_events DROP CONSTRAINT audit_instance_events_origin_check;
+ALTER TABLE audit_instance_events ADD CONSTRAINT audit_instance_events_origin_check CHECK (
+    origin IN ('web', 'cli', 'api', 'mcp', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')
+);
+
+-- +goose Down
+-- Existing mcp rows intentionally make this rollback fail closed rather than
+-- silently relabeling or deleting forensic records.
+ALTER TABLE audit_tenant_events DROP CONSTRAINT audit_tenant_events_origin_check;
+ALTER TABLE audit_tenant_events ADD CONSTRAINT audit_tenant_events_origin_check CHECK (
+    origin IN ('web', 'cli', 'api', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')
+);
+ALTER TABLE audit_instance_events DROP CONSTRAINT audit_instance_events_origin_check;
+ALTER TABLE audit_instance_events ADD CONSTRAINT audit_instance_events_origin_check CHECK (
+    origin IN ('web', 'cli', 'api', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')
+);

--- a/internal/store/migrations/sqlite/00042_mcp_audit_origin.sql
+++ b/internal/store/migrations/sqlite/00042_mcp_audit_origin.sql
@@ -1,0 +1,124 @@
+-- +goose Up
+-- SQLite cannot alter a CHECK constraint. Rebuild both append-only audit
+-- tables in one migration transaction and preserve every row and sequence.
+CREATE TABLE audit_tenant_events_mcp (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    occurred_at TEXT NOT NULL,
+    occurred_asserted INTEGER NOT NULL CHECK (occurred_asserted IN (0, 1)),
+    recorded_at TEXT NOT NULL,
+    actor_id TEXT,
+    actor_class TEXT NOT NULL CHECK (actor_class IN ('human', 'machine', 'system', 'break-glass', 'unauthenticated')),
+    actor_credential_id TEXT,
+    authority_id TEXT,
+    scope_class TEXT NOT NULL CHECK (scope_class IN ('org', 'project', 'env')),
+    org_id TEXT NOT NULL,
+    project_id TEXT,
+    env_id TEXT,
+    object_type TEXT,
+    object_id TEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN ('intent', 'success', 'denied', 'failure', 'unknown', 'disconnected')),
+    correlation_id TEXT,
+    source_ip TEXT,
+    user_agent TEXT,
+    origin TEXT NOT NULL CHECK (origin IN ('web', 'cli', 'api', 'mcp', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')),
+    payload TEXT NOT NULL,
+    CHECK (
+        (scope_class = 'org' AND project_id IS NULL AND env_id IS NULL)
+        OR (scope_class = 'project' AND project_id IS NOT NULL AND env_id IS NULL)
+        OR (scope_class = 'env' AND project_id IS NOT NULL AND env_id IS NOT NULL)
+    )
+);
+INSERT INTO audit_tenant_events_mcp SELECT * FROM audit_tenant_events;
+DROP TABLE audit_tenant_events;
+ALTER TABLE audit_tenant_events_mcp RENAME TO audit_tenant_events;
+CREATE INDEX audit_tenant_events_org_seq ON audit_tenant_events (org_id, seq);
+
+CREATE TABLE audit_instance_events_mcp (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    occurred_at TEXT NOT NULL,
+    occurred_asserted INTEGER NOT NULL CHECK (occurred_asserted IN (0, 1)),
+    recorded_at TEXT NOT NULL,
+    actor_id TEXT,
+    actor_class TEXT NOT NULL CHECK (actor_class IN ('human', 'machine', 'system', 'break-glass', 'unauthenticated')),
+    actor_credential_id TEXT,
+    authority_id TEXT,
+    object_type TEXT,
+    object_id TEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN ('intent', 'success', 'denied', 'failure', 'unknown', 'disconnected')),
+    correlation_id TEXT,
+    source_ip TEXT,
+    user_agent TEXT,
+    origin TEXT NOT NULL CHECK (origin IN ('web', 'cli', 'api', 'mcp', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')),
+    payload TEXT NOT NULL
+);
+INSERT INTO audit_instance_events_mcp SELECT * FROM audit_instance_events;
+DROP TABLE audit_instance_events;
+ALTER TABLE audit_instance_events_mcp RENAME TO audit_instance_events;
+
+-- +goose Down
+-- Existing mcp rows intentionally make this rollback fail closed.
+CREATE TABLE audit_tenant_events_pre_mcp (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    occurred_at TEXT NOT NULL,
+    occurred_asserted INTEGER NOT NULL CHECK (occurred_asserted IN (0, 1)),
+    recorded_at TEXT NOT NULL,
+    actor_id TEXT,
+    actor_class TEXT NOT NULL CHECK (actor_class IN ('human', 'machine', 'system', 'break-glass', 'unauthenticated')),
+    actor_credential_id TEXT,
+    authority_id TEXT,
+    scope_class TEXT NOT NULL CHECK (scope_class IN ('org', 'project', 'env')),
+    org_id TEXT NOT NULL,
+    project_id TEXT,
+    env_id TEXT,
+    object_type TEXT,
+    object_id TEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN ('intent', 'success', 'denied', 'failure', 'unknown', 'disconnected')),
+    correlation_id TEXT,
+    source_ip TEXT,
+    user_agent TEXT,
+    origin TEXT NOT NULL CHECK (origin IN ('web', 'cli', 'api', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')),
+    payload TEXT NOT NULL,
+    CHECK (
+        (scope_class = 'org' AND project_id IS NULL AND env_id IS NULL)
+        OR (scope_class = 'project' AND project_id IS NOT NULL AND env_id IS NULL)
+        OR (scope_class = 'env' AND project_id IS NOT NULL AND env_id IS NOT NULL)
+    )
+);
+INSERT INTO audit_tenant_events_pre_mcp SELECT * FROM audit_tenant_events;
+DROP TABLE audit_tenant_events;
+ALTER TABLE audit_tenant_events_pre_mcp RENAME TO audit_tenant_events;
+CREATE INDEX audit_tenant_events_org_seq ON audit_tenant_events (org_id, seq);
+
+CREATE TABLE audit_instance_events_pre_mcp (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    occurred_at TEXT NOT NULL,
+    occurred_asserted INTEGER NOT NULL CHECK (occurred_asserted IN (0, 1)),
+    recorded_at TEXT NOT NULL,
+    actor_id TEXT,
+    actor_class TEXT NOT NULL CHECK (actor_class IN ('human', 'machine', 'system', 'break-glass', 'unauthenticated')),
+    actor_credential_id TEXT,
+    authority_id TEXT,
+    object_type TEXT,
+    object_id TEXT,
+    outcome TEXT NOT NULL CHECK (outcome IN ('intent', 'success', 'denied', 'failure', 'unknown', 'disconnected')),
+    correlation_id TEXT,
+    source_ip TEXT,
+    user_agent TEXT,
+    origin TEXT NOT NULL CHECK (origin IN ('web', 'cli', 'api', 'operator-fetch', 'adapter-job', 'offline-reconciled', 'system')),
+    payload TEXT NOT NULL
+);
+INSERT INTO audit_instance_events_pre_mcp SELECT * FROM audit_instance_events;
+DROP TABLE audit_instance_events;
+ALTER TABLE audit_instance_events_pre_mcp RENAME TO audit_instance_events;


### PR DESCRIPTION
## Summary

- add feature-gated stateless JSON POST /mcp using official Go MCP SDK v1.7.0
- enforce closed registry, exact auth and audit policy mapping, security bounds, safe errors, and replica-independent requests
- add mcp audit-origin migrations plus operator configuration and disclosure docs

## Validation

- go test ./... -count=1: 4,564 passed across 74 packages
- go test ./internal/isolation -count=1 -timeout 30m: 1,419 passed
- go test -race ./internal/mcpserver -count=1: 30 passed
- go build ./...
- go vet ./...
- scripts/ci/verify-docs.sh
- independent spec review: CLEAN
- independent standards review: CLEAN

Closes #628