### PR TITLE
feat(web): restore environment lifecycle controls to project settings

### DIFF
--- a/web/e2e/flows/settings.spec.ts
+++ b/web/e2e/flows/settings.spec.ts
@@ -311,6 +311,64 @@ test.describe('project settings', () => {
     await expect(page).toHaveURL(before);
   });
 
+  test('creates, renames, clones, reorders, and deletes an environment through the SPA', async () => {
+    // The four lifecycle operations driven entirely through the rendered
+    // "Manage" disclosure, against the real server (#623 restores this surface).
+    // Every environment here is created and destroyed within the test, so the
+    // shared `staging` drill environment the other tests depend on is untouched.
+    await page.goto(`/orgs/${seed.org}/projects/${drillProject}/settings`);
+    const panel = page.locator('#project-environments');
+    const created = 'lifecycle';
+    const renamed = 'lifecycle-renamed';
+    const clone = 'lifecycle-clone';
+
+    // Create through the SPA form.
+    await panel.getByLabel('New environment name').fill(created);
+    await panel.getByRole('button', { name: 'Create' }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: `Environment ${created} created.` }),
+    ).toBeVisible();
+
+    // Open its disclosure once. The id is stable across rename and clone, so the
+    // same <details> stays open for all three actions below the summary.
+    await panel.locator('summary', { hasText: `Manage ${created}` }).click();
+    const open = panel.locator('details.environment-lifecycle[open]');
+
+    await open.getByLabel(`New name for ${created}`).fill(renamed);
+    await open.getByRole('button', { name: 'Rename environment' }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: `renamed to ${renamed}` }),
+    ).toBeVisible();
+
+    await open.getByLabel(`Clone ${renamed} into`).fill(clone);
+    await open.getByRole('button', { name: 'Clone environment' }).click();
+    await expect(page.locator('.notice').filter({ hasText: `cloned to ${clone}` })).toBeVisible();
+
+    // Reorder: the renamed row is not first (staging precedes it), so Move up is
+    // live and sends the whole ordered set.
+    await open.getByRole('button', { name: `Move ${renamed} up` }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: `Environment ${renamed} moved up` }),
+    ).toBeVisible();
+
+    // Typed-name delete of both environments this test created, through the SPA.
+    // The renamed row's disclosure is still open from the actions above, so
+    // delete it in place; the clone's is closed, so open it first.
+    await open.getByLabel(`Delete ${renamed}`).fill(renamed);
+    await open.getByRole('button', { name: 'Delete environment' }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: `Environment ${renamed} deleted.` }),
+    ).toBeVisible();
+
+    await panel.locator('summary', { hasText: `Manage ${clone}` }).click();
+    const cloneRow = panel.locator('details.environment-lifecycle[open]');
+    await cloneRow.getByLabel(`Delete ${clone}`).fill(clone);
+    await cloneRow.getByRole('button', { name: 'Delete environment' }).click();
+    await expect(
+      page.locator('.notice').filter({ hasText: `Environment ${clone} deleted.` }),
+    ).toBeVisible();
+  });
+
   test('rotates the project DEK and re-encrypts, resuming across a reload', async () => {
     // The project-scoped half of remote cryptographic maintenance (#503),
     // against the real server. Both jobs are content-invisible: they re-wrap

--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import { ApiError } from './client.ts';
 import {
+  cloneEnvironmentRefusalText,
   createEnvironmentRefusalText,
   createProjectRefusalText,
   DAY_SECONDS,
+  deleteEnvironmentRefusalText,
   environmentSettingsReadState,
   formatRetentionAge,
   orgTopologyReadiness,
+  renameEnvironmentRefusalText,
+  reorderEnvironmentsRefusalText,
   retentionSentence,
   settingsFailureText,
   settingsOperationFailure,
@@ -263,4 +267,36 @@ describe('authoring refusals', () => {
     );
   });
 
+  it('maps every environment lifecycle refusal without leaking uniform not-found state', () => {
+    expect(renameEnvironmentRefusalText(new ApiError(400, 'x'))).toContain(
+      'environment name is invalid',
+    );
+    expect(renameEnvironmentRefusalText(new ApiError(404, 'x'))).toBe(
+      renameEnvironmentRefusalText(new ApiError(403, 'x')),
+    );
+    expect(deleteEnvironmentRefusalText(new ApiError(409, 'x'))).toContain(
+      'current environment state refused deletion',
+    );
+    expect(reorderEnvironmentsRefusalText(new ApiError(400, 'x'))).toContain(
+      'complete environment order',
+    );
+    expect(cloneEnvironmentRefusalText(new ApiError(409, 'x', 'required secret missing'))).toBe(
+      'required secret missing',
+    );
+  });
+
+  it('states uncertain lifecycle outcomes instead of claiming failure', () => {
+    expect(renameEnvironmentRefusalText(new Error('network'))).toContain(
+      'whether the environment was renamed is unknown',
+    );
+    expect(deleteEnvironmentRefusalText(new ApiError(500, 'x'))).toContain(
+      'whether the environment was deleted is unknown',
+    );
+    expect(reorderEnvironmentsRefusalText(new Error('network'))).toContain(
+      'whether the order changed is unknown',
+    );
+    expect(cloneEnvironmentRefusalText(new ApiError(500, 'x'))).toContain(
+      'whether the environment was cloned is unknown',
+    );
+  });
 });

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -469,9 +469,22 @@ export function useCreateProject(org: string) {
  * key both this page's `useEnvironments` and the matrix's own read share, so a
  * created environment surfaces in the settings list AND the matrix at once.
  */
+/**
+ * The shared key every environment-topology mutation (create, rename, delete,
+ * reorder, clone) carries, so `useIsMutating` can gate the whole Environments
+ * panel on any one of them being in flight. Reorder replaces the complete
+ * ordered set, so two topology writes racing on the same stale snapshot would
+ * let the later response silently undo part of the earlier one; serialising
+ * them behind this key is what prevents that.
+ */
+export function environmentTopologyMutationKey(org: string, project: string) {
+  return ['environment-topology', org, project] as const;
+}
+
 export function useCreateEnvironment(org: string, project: string) {
   const queries = useQueryClient();
   return useMutation({
+    mutationKey: environmentTopologyMutationKey(org, project),
     mutationFn: (input: { name: string }) =>
       parsed(createEnvironmentOp, { path: { org, project }, body: { name: input.name } }),
     onSuccess: () => queries.invalidateQueries({ queryKey: environmentsKey(org, project) }),
@@ -497,6 +510,7 @@ function invalidateEnvironmentTopology(
 export function useRenameEnvironment(org: string, project: string) {
   const queries = useQueryClient();
   return useMutation({
+    mutationKey: environmentTopologyMutationKey(org, project),
     mutationFn: (input: { environment: string; name: string }) =>
       parsed(renameEnvironmentOp, {
         path: { org, project, environment: input.environment },
@@ -514,6 +528,7 @@ export function useDeleteEnvironment(
 ) {
   const queries = useQueryClient();
   return useMutation({
+    mutationKey: environmentTopologyMutationKey(org, project),
     mutationFn: (input: { environment: string }) =>
       ok(deleteEnvironmentOp, { path: { org, project, environment: input.environment } }),
     // The list invalidation unmounts the deleted row. Run its durable parent
@@ -530,6 +545,7 @@ export function useDeleteEnvironment(
 export function useReorderEnvironments(org: string, project: string) {
   const queries = useQueryClient();
   return useMutation({
+    mutationKey: environmentTopologyMutationKey(org, project),
     mutationFn: (input: { environmentIds: readonly string[] }) =>
       parsed(reorderEnvironmentsOp, {
         path: { org, project },
@@ -543,6 +559,7 @@ export function useReorderEnvironments(org: string, project: string) {
 export function useCloneEnvironment(org: string, project: string) {
   const queries = useQueryClient();
   return useMutation({
+    mutationKey: environmentTopologyMutationKey(org, project),
     mutationFn: (input: { sourceEnvironment: string; name: string }) =>
       parsed(cloneEnvironmentOp, {
         path: { org, project },
@@ -582,28 +599,101 @@ export function createProjectRefusalText(error: unknown): string {
 }
 
 /**
- * createEnvironmentRefusalText is the environment counterpart: the same uniform
- * 403/404, and the capability it names is `definitions-edit` on the project.
+ * Every environment lifecycle refusal (create, rename, delete, reorder, clone)
+ * needs `definitions-edit` on the project and keeps the same uniform 403/404,
+ * so the status mapping lives once here. Each caller supplies only the four
+ * sentences the shared status codes cannot know: the capability act it names,
+ * and the invalid/conflict/uncertain fallbacks for when the server sends no
+ * caller-safe detail of its own.
  */
-export function createEnvironmentRefusalText(error: unknown): string {
+function environmentLifecyclePermission(action: string): string {
+  return `You are not permitted to ${action} — that needs definitions-edit on the project.`;
+}
+
+type EnvironmentLifecycleRefusal = {
+  readonly action: string;
+  readonly invalid: string;
+  readonly conflict: string;
+  readonly uncertain: string;
+};
+
+function environmentLifecycleRefusalText(
+  error: unknown,
+  refusal: EnvironmentLifecycleRefusal,
+): string {
   if (error instanceof ApiError) {
     switch (error.status) {
       case 400:
-        return error.detail ?? 'The environment name is invalid.';
+        return error.detail ?? refusal.invalid;
       case 401:
         return 'Your session ended. Sign in again to continue.';
       case 403:
       case 404:
-        return 'You are not permitted to create an environment here — that needs definitions-edit on the project.';
+        return environmentLifecyclePermission(refusal.action);
       case 409:
-        return error.detail ?? 'This environment name is already in use.';
+        return error.detail ?? refusal.conflict;
       case 429:
         return 'Too many attempts right now. Wait a moment and try again.';
-      default:
-        return 'The server failed; whether the environment was created is unknown — reload to check.';
     }
   }
-  return 'The server failed; whether the environment was created is unknown — reload to check.';
+  return refusal.uncertain;
+}
+
+/**
+ * createEnvironmentRefusalText is the project counterpart of the create-project
+ * mapper: the same uniform 403/404, naming `definitions-edit` on the project.
+ */
+export function createEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'create an environment here',
+    invalid: 'The environment name is invalid.',
+    conflict: 'This environment name is already in use.',
+    uncertain:
+      'The server failed; whether the environment was created is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for environment rename, including uncertain network outcomes. */
+export function renameEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'rename this environment',
+    invalid: 'The environment name is invalid.',
+    conflict: 'This environment name is already in use.',
+    uncertain:
+      'The server failed; whether the environment was renamed is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for environment deletion, including uncertain network outcomes. */
+export function deleteEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'delete this environment',
+    invalid: 'The environment cannot be deleted from this request.',
+    conflict: 'The current environment state refused deletion. Reload before retrying.',
+    uncertain:
+      'The server failed; whether the environment was deleted is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for whole-set reorder, including uncertain network outcomes. */
+export function reorderEnvironmentsRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'reorder these environments',
+    invalid: 'The complete environment order is invalid. Reload before retrying.',
+    conflict: 'The current environment state refused reordering. Reload before retrying.',
+    uncertain: 'The server failed; whether the order changed is unknown — reload to check.',
+  });
+}
+
+/** Refusal text for clone-at-creation, including uncertain network outcomes. */
+export function cloneEnvironmentRefusalText(error: unknown): string {
+  return environmentLifecycleRefusalText(error, {
+    action: 'clone this environment',
+    invalid: 'The cloned environment name or source is invalid.',
+    conflict: 'The clone conflicts with the current environment state.',
+    uncertain:
+      'The server failed; whether the environment was cloned is unknown — reload to check.',
+  });
 }
 
 /**

--- a/web/src/routes/ProjectSettings.test.tsx
+++ b/web/src/routes/ProjectSettings.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment happy-dom
-import { act } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { act, useState } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AuthProvider } from '../app/AuthProvider.tsx';
-import { renderForm, settleTask, typeInto } from '../testkit/renderForm.tsx';
-import { ProjectSettings } from './ProjectSettings.tsx';
+import { created, renderForm, settleTask, typeInto } from '../testkit/renderForm.tsx';
+import { EnvironmentLifecycleActions, ProjectSettings } from './ProjectSettings.tsx';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -389,3 +390,291 @@ function definitionsWrites(calls: readonly Parameters<typeof fetch>[]): Request[
       : [];
   });
 }
+
+const DEV = {
+  id: 'env_123e4567-e89b-12d3-a456-426614174010',
+  name: 'dev',
+};
+const PROD = {
+  id: 'env_123e4567-e89b-12d3-a456-426614174011',
+  name: 'prod',
+};
+
+function environment(id: string, name: string, displayOrder: number) {
+  return {
+    id,
+    org_id: 'org_123e4567-e89b-12d3-a456-426614174001',
+    project_id: 'prj_123e4567-e89b-12d3-a456-426614174002',
+    name,
+    display_order: displayOrder,
+    created_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+function requestFromCall(call: Parameters<typeof fetch> | undefined): Request {
+  const request = call?.[0];
+  if (!(request instanceof Request)) {
+    throw new Error('fetch was not called with a Request');
+  }
+  return request;
+}
+
+function DeleteFeedbackHarness({ onDone }: { readonly onDone: (text: string) => void }) {
+  const [done, setDone] = useState('');
+  const environments = useQuery({
+    queryKey: ['environments', 'org_1', 'project_1'],
+    queryFn: () => Promise.resolve({ items: [], count: 0 }),
+    initialData: { items: [DEV], count: 1 },
+    staleTime: Infinity,
+  });
+  const current = environments.data.items[0];
+
+  return (
+    <>
+      {current === undefined ? null : (
+        <EnvironmentLifecycleActions
+          org="org_1"
+          project="project_1"
+          environment={current}
+          environments={environments.data.items}
+          onDone={(text) => {
+            setDone(text);
+            onDone(text);
+          }}
+        />
+      )}
+      <p role="status">{done}</p>
+    </>
+  );
+}
+
+describe('EnvironmentLifecycleActions', () => {
+  it('keeps deletion feedback after invalidation unmounts the deleted row', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+    const done = vi.fn();
+    const { container } = await renderForm(<DeleteFeedbackHarness onDone={done} />);
+    const confirmInput = container.querySelector(`input[placeholder="${DEV.name}"]`);
+    if (!(confirmInput instanceof HTMLInputElement)) {
+      throw new Error('delete confirmation input is missing');
+    }
+    await act(async () => typeInto(confirmInput, DEV.name));
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Delete environment',
+    );
+    if (deleteButton === undefined) {
+      throw new Error('delete button is missing');
+    }
+    await act(async () => deleteButton.click());
+    await settleTask();
+
+    expect(container.querySelector('input[name="rename-environment"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Environment dev deleted.',
+    );
+    expect(done).toHaveBeenCalledWith('Environment dev deleted.');
+  });
+
+  it('renames and deletes through deliberate user controls', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const request = requestFromCall(args);
+      if (request.method === 'PATCH') {
+        return Promise.resolve(
+          new Response(JSON.stringify(environment(DEV.id, 'development', 0)), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (request.method === 'DELETE') {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      throw new Error(`unexpected ${request.method} ${request.url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const done = vi.fn();
+    const { container } = await renderForm(
+      <EnvironmentLifecycleActions
+        org="org_1"
+        project="project_1"
+        environment={DEV}
+        environments={[DEV, PROD]}
+        onDone={done}
+      />,
+    );
+    const renameInput = container.querySelector('input[name="rename-environment"]');
+    if (!(renameInput instanceof HTMLInputElement)) {
+      throw new Error('rename input is missing');
+    }
+    await act(async () => typeInto(renameInput, 'development'));
+    const renameButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Rename environment',
+    );
+    if (renameButton === undefined) {
+      throw new Error('rename button is missing');
+    }
+    await act(async () => renameButton.click());
+    await settleTask();
+
+    const renameRequest = requestFromCall(fetchMock.mock.calls[0]);
+    expect(renameRequest.method).toBe('PATCH');
+    expect(new URL(renameRequest.url).pathname).toBe(
+      `/api/v1/orgs/org_1/projects/project_1/environments/${DEV.id}`,
+    );
+    expect(await renameRequest.json()).toEqual({ name: 'development' });
+    expect(done).toHaveBeenCalledWith('Environment dev renamed to development.');
+
+    const confirmInput = container.querySelector(`input[placeholder="${DEV.name}"]`);
+    if (!(confirmInput instanceof HTMLInputElement)) {
+      throw new Error('delete confirmation input is missing');
+    }
+    await act(async () => typeInto(confirmInput, DEV.name));
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Delete environment',
+    );
+    if (deleteButton === undefined) {
+      throw new Error('delete button is missing');
+    }
+    expect(deleteButton.disabled).toBe(false);
+    await act(async () => deleteButton.click());
+    await settleTask();
+
+    const deleteRequest = requestFromCall(fetchMock.mock.calls[1]);
+    expect(deleteRequest.method).toBe('DELETE');
+    expect(new URL(deleteRequest.url).pathname).toBe(
+      `/api/v1/orgs/org_1/projects/project_1/environments/${DEV.id}`,
+    );
+    expect(done).toHaveBeenCalledWith('Environment dev deleted.');
+  });
+
+  it('moves with the complete ordered set and clones into a named environment', async () => {
+    const fetchMock = vi.fn((...args: Parameters<typeof fetch>) => {
+      const request = requestFromCall(args);
+      if (request.method === 'PUT') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              items: [environment(PROD.id, PROD.name, 0), environment(DEV.id, DEV.name, 1)],
+              count: 2,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+      }
+      if (request.method === 'POST') {
+        return Promise.resolve(
+          created({
+            environment: environment(
+              'env_123e4567-e89b-12d3-a456-426614174012',
+              'staging',
+              2,
+            ),
+            copied: ['API_URL'],
+            uncopied_secrets: ['TOKEN'],
+          }),
+        );
+      }
+      throw new Error(`unexpected ${request.method} ${request.url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const done = vi.fn();
+    const { container, client } = await renderForm(
+      <EnvironmentLifecycleActions
+        org="org_1"
+        project="project_1"
+        environment={DEV}
+        environments={[DEV, PROD]}
+        onDone={done}
+      />,
+    );
+    const environmentsKey = ['environments', 'org_1', 'project_1'];
+    const matrixKeysKey = ['matrix-keys', 'org_1', 'project_1'];
+    client.setQueryData(environmentsKey, { items: [DEV, PROD], count: 2 });
+    client.setQueryData(matrixKeysKey, { items: [], count: 0 });
+
+    const moveDown = container.querySelector('button[aria-label="Move dev down"]');
+    if (!(moveDown instanceof HTMLButtonElement)) {
+      throw new Error('move-down button is missing');
+    }
+    await act(async () => moveDown.click());
+    await settleTask();
+    const reorderRequest = requestFromCall(fetchMock.mock.calls[0]);
+    expect(reorderRequest.method).toBe('PUT');
+    expect(new URL(reorderRequest.url).pathname).toBe(
+      '/api/v1/orgs/org_1/projects/project_1/environments/order',
+    );
+    expect(await reorderRequest.json()).toEqual({ environment_ids: [PROD.id, DEV.id] });
+    expect(client.getQueryState(environmentsKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(matrixKeysKey)?.isInvalidated).toBe(true);
+
+    const cloneInput = container.querySelector('input[name="clone-environment"]');
+    if (!(cloneInput instanceof HTMLInputElement)) {
+      throw new Error('clone input is missing');
+    }
+    await act(async () => typeInto(cloneInput, 'staging'));
+    const cloneButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Clone environment',
+    );
+    if (cloneButton === undefined) {
+      throw new Error('clone button is missing');
+    }
+    await act(async () => cloneButton.click());
+    await settleTask();
+    const cloneRequest = requestFromCall(fetchMock.mock.calls[1]);
+    expect(cloneRequest.method).toBe('POST');
+    expect(new URL(cloneRequest.url).pathname).toBe(
+      '/api/v1/orgs/org_1/projects/project_1/environments/clone',
+    );
+    expect(await cloneRequest.json()).toEqual({
+      name: 'staging',
+      source_environment_id: DEV.id,
+    });
+    expect(done).toHaveBeenCalledWith(
+      'Environment dev cloned to staging. Copied 1 value; 1 secret could not be copied.',
+    );
+  });
+
+  it('disables a sibling row while any topology mutation is in flight', async () => {
+    // A never-resolving reorder holds one mutation in flight so the shared busy
+    // gate can be observed: a second row's controls must go disabled too, which
+    // is what stops two rows submitting whole-set reorders from a stale set.
+    let release: (response: Response) => void = () => {};
+    const pending = new Promise<Response>((resolve) => {
+      release = resolve;
+    });
+    vi.stubGlobal('fetch', vi.fn(() => pending));
+    const { container } = await renderForm(
+      <>
+        <EnvironmentLifecycleActions
+          org="org_1"
+          project="project_1"
+          environment={DEV}
+          environments={[DEV, PROD]}
+          onDone={vi.fn()}
+        />
+        <EnvironmentLifecycleActions
+          org="org_1"
+          project="project_1"
+          environment={PROD}
+          environments={[DEV, PROD]}
+          onDone={vi.fn()}
+        />
+      </>,
+    );
+    const devMoveDown = container.querySelector('button[aria-label="Move dev down"]');
+    const prodMoveUp = container.querySelector('button[aria-label="Move prod up"]');
+    if (!(devMoveDown instanceof HTMLButtonElement) || !(prodMoveUp instanceof HTMLButtonElement)) {
+      throw new Error('move buttons are missing');
+    }
+    expect(prodMoveUp.disabled).toBe(false);
+    // The reorder is now in flight. `useIsMutating` disables every row through a
+    // cache subscription that re-renders on its own tick, so poll rather than
+    // assume the flip has landed by the time click() returns.
+    await act(async () => devMoveDown.click());
+    await vi.waitFor(() => {
+      if (!prodMoveUp.disabled) throw new Error('sibling row not disabled yet');
+    });
+
+    await act(async () => release(new Response(null, { status: 200 })));
+    await settleTask();
+  });
+});

--- a/web/src/routes/ProjectSettings.tsx
+++ b/web/src/routes/ProjectSettings.tsx
@@ -1,3 +1,4 @@
+import { useIsMutating } from '@tanstack/react-query';
 import { useEffect, useId, useState } from 'react';
 import { generatePath, Link, useNavigate, useParams } from 'react-router';
 
@@ -9,11 +10,18 @@ import {
   type DefinitionsSettings,
 } from '../api/definitions.ts';
 import {
+  cloneEnvironmentRefusalText,
   createEnvironmentRefusalText,
   cryptoFailureText,
+  deleteEnvironmentRefusalText,
+  environmentTopologyMutationKey,
+  renameEnvironmentRefusalText,
+  reorderEnvironmentsRefusalText,
   settingsFailureText,
   settingsOperationFailure,
+  useCloneEnvironment,
   useCreateEnvironment,
+  useDeleteEnvironment,
   useDeleteProject,
   useEnvironmentSettings,
   useEnvironments,
@@ -21,7 +29,9 @@ import {
   useProject,
   useProjectRetention,
   useReencryptProject,
+  useRenameEnvironment,
   useRenameProject,
+  useReorderEnvironments,
   useRotateDek,
   useSetEnvironmentSettings,
   useSetProjectRetention,
@@ -167,6 +177,13 @@ export function ProjectSettings() {
             {environments.data.items.map((environment) => (
               <li className="factor" key={environment.id}>
                 <strong className="mono">{environment.name}</strong>
+                <EnvironmentLifecycleActions
+                  org={org}
+                  project={project}
+                  environment={environment}
+                  environments={environments.data.items}
+                  onDone={feedback.ok}
+                />
               </li>
             ))}
           </ul>
@@ -478,6 +495,11 @@ function NewEnvironment({
   onDone: (text: string) => void;
 }) {
   const create = useCreateEnvironment(org, project);
+  // Any in-flight topology change (a rename/reorder/clone/delete on a row, or
+  // another create) disables creation too: all these writes share one mutation
+  // key, so creating mid-reorder cannot race the ordered set the server holds.
+  const topologyBusy =
+    useIsMutating({ mutationKey: environmentTopologyMutationKey(org, project) }) > 0;
   const nameId = useId();
   const [name, setName] = useState('');
   const [failure, setFailure] = useState<string | null>(null);
@@ -523,19 +545,250 @@ function NewEnvironment({
           className="settings-input settings-input--compact mono"
           value={name}
           placeholder="production"
-          disabled={disabled || create.isPending}
+          disabled={disabled || topologyBusy}
           onChange={(event) => setName(event.target.value)}
         />
         <button
           type="submit"
           className="btn btn--primary"
-          disabled={disabled || create.isPending || trimmed === ''}
+          disabled={disabled || topologyBusy || trimmed === ''}
         >
           Create
         </button>
       </form>
       {failure === null ? null : <Alert>{failure}</Alert>}
     </>
+  );
+}
+
+/**
+ * One environment-lifecycle refusal, tagged with the action that raised it so
+ * the alert renders beside that control rather than once at the top.
+ */
+type LifecycleFailure = {
+  readonly scope: 'rename' | 'order' | 'clone' | 'delete';
+  readonly text: string;
+};
+
+/**
+ * EnvironmentLifecycleActions gathers a project's environment-topology
+ * mutations under one per-row disclosure: rename, whole-set reorder,
+ * clone-at-creation, and typed-name delete. Each keeps its refusal beside the
+ * control that raised it; a success is announced through the page feedback the
+ * query invalidation then fills with the changed list.
+ */
+export function EnvironmentLifecycleActions({
+  org,
+  project,
+  environment,
+  environments,
+  onDone,
+}: {
+  readonly org: string;
+  readonly project: string;
+  readonly environment: { readonly id: string; readonly name: string };
+  readonly environments: readonly { readonly id: string; readonly name: string }[];
+  readonly onDone: (text: string) => void;
+}) {
+  const rename = useRenameEnvironment(org, project);
+  const remove = useDeleteEnvironment(org, project, () =>
+    onDone(`Environment ${environment.name} deleted.`),
+  );
+  const reorder = useReorderEnvironments(org, project);
+  const clone = useCloneEnvironment(org, project);
+  // Shared across every row: any topology write in flight (this row's or a
+  // sibling's) disables all of them, so two open disclosures cannot submit
+  // whole-set reorders from the same stale snapshot and silently undo each
+  // other. All four hooks plus create carry one mutation key for this count.
+  const busy =
+    useIsMutating({ mutationKey: environmentTopologyMutationKey(org, project) }) > 0;
+  const renameId = useId();
+  const cloneId = useId();
+  const [renameName, setRenameName] = useState('');
+  const [cloneName, setCloneName] = useState('');
+  const [failure, setFailure] = useState<LifecycleFailure | null>(null);
+
+  const index = environments.findIndex((candidate) => candidate.id === environment.id);
+  if (index === -1) {
+    throw new Error(`environment ${environment.id} is missing from its project order`);
+  }
+
+  // Reorder is a whole-set replacement: send every id once, with this
+  // environment and its neighbour swapped. A partial list would drop the
+  // environments it omits.
+  const move = (offset: -1 | 1) => {
+    const target = environments[index + offset];
+    if (target === undefined) return;
+    setFailure(null);
+    reorder.mutate(
+      {
+        environmentIds: environments.map((candidate) => {
+          if (candidate.id === environment.id) return target.id;
+          if (candidate.id === target.id) return environment.id;
+          return candidate.id;
+        }),
+      },
+      {
+        onSuccess: () =>
+          onDone(`Environment ${environment.name} moved ${offset === -1 ? 'up' : 'down'}.`),
+        onError: (error) =>
+          setFailure({ scope: 'order', text: reorderEnvironmentsRefusalText(error) }),
+      },
+    );
+  };
+
+  return (
+    <details className="environment-lifecycle">
+      <summary>Manage {environment.name}</summary>
+
+      <form
+        className="settings-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const name = renameName.trim();
+          if (name === '' || name === environment.name) return;
+          setFailure(null);
+          rename.mutate(
+            { environment: environment.id, name },
+            {
+              onSuccess: (renamed) => {
+                setRenameName('');
+                onDone(`Environment ${environment.name} renamed to ${renamed.name}.`);
+              },
+              onError: (error) =>
+                setFailure({ scope: 'rename', text: renameEnvironmentRefusalText(error) }),
+            },
+          );
+        }}
+      >
+        <div className="settings-row__copy">
+          <span className="settings-row__title">Rename</span>
+          <span className="settings-row__detail">give {environment.name} a new name</span>
+        </div>
+        <span className="settings-row__spacer" />
+        <label className="visually-hidden" htmlFor={renameId}>
+          New name for {environment.name}
+        </label>
+        <input
+          id={renameId}
+          name="rename-environment"
+          className="settings-input settings-input--compact mono"
+          value={renameName}
+          disabled={busy}
+          onChange={(event) => setRenameName(event.target.value)}
+        />
+        <button
+          type="submit"
+          className="btn"
+          disabled={busy || renameName.trim() === '' || renameName.trim() === environment.name}
+        >
+          Rename environment
+        </button>
+      </form>
+      {failure?.scope === 'rename' ? <Alert>{failure.text}</Alert> : null}
+
+      <div className="settings-row">
+        <div className="settings-row__copy">
+          <span className="settings-row__title">Order</span>
+          <span className="settings-row__detail">
+            move sends the complete project order as one atomic change
+          </span>
+        </div>
+        <span className="settings-row__spacer" />
+        <button
+          type="button"
+          className="btn"
+          aria-label={`Move ${environment.name} up`}
+          disabled={busy || index === 0}
+          onClick={() => move(-1)}
+        >
+          Move up
+        </button>
+        <button
+          type="button"
+          className="btn"
+          aria-label={`Move ${environment.name} down`}
+          disabled={busy || index === environments.length - 1}
+          onClick={() => move(1)}
+        >
+          Move down
+        </button>
+      </div>
+      {failure?.scope === 'order' ? <Alert>{failure.text}</Alert> : null}
+
+      <form
+        className="settings-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const name = cloneName.trim();
+          if (name === '') return;
+          setFailure(null);
+          clone.mutate(
+            { sourceEnvironment: environment.id, name },
+            {
+              onSuccess: (result) => {
+                setCloneName('');
+                const copied = result.copied.length;
+                const omitted = result.uncopied_secrets.length;
+                onDone(
+                  `Environment ${environment.name} cloned to ${result.environment.name}. Copied ${copied} ${copied === 1 ? 'value' : 'values'}; ${omitted} ${omitted === 1 ? 'secret' : 'secrets'} could not be copied.`,
+                );
+              },
+              onError: (error) =>
+                setFailure({ scope: 'clone', text: cloneEnvironmentRefusalText(error) }),
+            },
+          );
+        }}
+      >
+        <div className="settings-row__copy">
+          <span className="settings-row__title">Clone</span>
+          <span className="settings-row__detail">
+            copy {environment.name} into a new environment
+          </span>
+        </div>
+        <span className="settings-row__spacer" />
+        <label className="visually-hidden" htmlFor={cloneId}>
+          Clone {environment.name} into
+        </label>
+        <input
+          id={cloneId}
+          name="clone-environment"
+          className="settings-input settings-input--compact mono"
+          value={cloneName}
+          disabled={busy}
+          onChange={(event) => setCloneName(event.target.value)}
+        />
+        <button type="submit" className="btn" disabled={busy || cloneName.trim() === ''}>
+          Clone environment
+        </button>
+      </form>
+      {failure?.scope === 'clone' ? <Alert>{failure.text}</Alert> : null}
+
+      <TypedNameConfirm
+        key={environment.id}
+        label={`Delete ${environment.name}`}
+        expect={environment.name}
+        action="Delete environment"
+        busy={busy}
+        hint={
+          <>
+            This permanently deletes the environment and its values, drafts, revision history,
+            pins, and snapshots. Type its name exactly to continue.
+          </>
+        }
+        onConfirm={() => {
+          setFailure(null);
+          remove.mutate(
+            { environment: environment.id },
+            {
+              onError: (error) =>
+                setFailure({ scope: 'delete', text: deleteEnvironmentRefusalText(error) }),
+            },
+          );
+        }}
+      />
+      {failure?.scope === 'delete' ? <Alert>{failure.text}</Alert> : null}
+    </details>
   );
 }
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -4302,6 +4302,26 @@ select {
   border-top: 0;
 }
 
+/* The per-environment lifecycle disclosure sits on its own line inside the
+   flex factor row (its name shares the first line), so it spans the width and
+   stacks its actions with the panel's own spacing. */
+.environment-lifecycle {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Keep the native disclosure marker: `display: flex`/`block` on a summary drops
+   it in most browsers, so leave the default list-item display and only pad it
+   up to the touch target. */
+.environment-lifecycle > summary {
+  min-height: var(--touch);
+  padding: 10px 0;
+  cursor: pointer;
+  font-weight: 650;
+}
+
 .page--chrome .factor__meta {
   color: var(--tx-dim);
   font-family: var(--font-mono);


### PR DESCRIPTION
Closes #623 (option A: restore the UI).

## Why

#509 (chrome alignment) removed the project-settings UI that drove
`renameEnvironment` / `deleteEnvironment` / `reorderEnvironments` /
`cloneEnvironment`, leaving the hooks and generated-client imports reachable
only as `api/parity.yaml` evidence. The four `webui: project-settings` rows
claimed a surface no rendered code called. This restores the surface (the
feature originally landed as #446), so the rows are truthful again.

## What

- **`ProjectSettings.tsx`** — each Environments-panel row now carries a
  `Manage <name>` disclosure with rename, whole-set reorder (Move up/down),
  clone-at-creation, and typed-name delete, built from the panel's existing
  `settings-row` chrome so it reads as one dialect with the surface around it.
- **`settings.ts`** — the four `*RefusalText` mappers return, folded (with
  `createEnvironmentRefusalText`) into one `environmentLifecycleRefusalText`
  helper rather than standing beside a parallel switch.
- **Shared topology-busy gate** — all five topology writes (create included)
  carry one `mutationKey`, and a single `useIsMutating` gate disables every row
  and the create form while any is in flight. This closes a real race: two open
  disclosures could otherwise submit whole-set reorders from the same stale
  snapshot and silently undo each other.
- Refusals render beside the control that raised them; the disclosure keeps its
  native marker and a per-environment accessible name.

## Review

Three-axis + cross-model, blocking (3-round cap, closed in R2):

- **Standards** CLEAN · **Spec** (#623 + handoff #446) all seven Contract points met.
- **Codex R1** BLOCKING (3 findings: the reorder race above, lost disclosure
  marker + ambiguous a11y name, single top-level refusal alert) → all fixed →
  **Codex R2 CLEAN**, no new criticals.

## Tests

- Unit: all four requests, refusal mapping, rename/delete confirmation flow, and
  the shared-busy gate. `node --run typecheck` PASS, `node --run test` **665
  passed**, `go test ./api/ -run TestParity` ok.
- **e2e caveat:** a UI-driven `settings.spec.ts` flow (create → rename → clone →
  reorder → delete through the SPA, self-cleaning so the `staging` drill
  environment is untouched) is added and typechecks, but was **not run
  locally** (needs a real backend + Playwright). It validates on CI/preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)