### PR TITLE
feat(mcp): expose bounded read-only configuration tools #629

### DIFF
--- a/docs/handoff/629-mcp-read-tools.md
+++ b/docs/handoff/629-mcp-read-tools.md
@@ -1,0 +1,81 @@
+# Issue 629 handoff: bounded read-only MCP configuration tools
+
+## Delivered
+
+- Registered the five ADR-approved read tools on the stateless MCP transport
+  from #628: `hikyo_list_definitions`, `hikyo_list_environments`,
+  `hikyo_inspect_configuration`, `hikyo_list_pending_changes`, and
+  `hikyo_list_revisions`. Each tool maps to exactly one existing read service
+  operation, carries stable snake_case JSON Schema inputs, typed structured
+  outputs, read-only annotations, and the pinned authorization operation,
+  formula, audit disposition, machine-only artifact policy, and secret policy.
+- Added a bounded keyset page method at the service and store layers for every
+  mapped list operation. Each page method verifies the SAME store authorization
+  its unbounded sibling verifies, under its own registered store operation, and
+  fetches strictly past the cursor with a `LIMIT`. No handler materializes a
+  whole collection to slice a limit afterwards.
+- Repeated current identity resolution, grants, capability formulas, protected
+  scope, and audit behavior on every call: the transport passes the raw
+  service-account bearer straight to the service as `service.Bearer(raw)`, and
+  the service resolves the principal and authorizes inside its own transaction.
+- Added an encrypted, authenticated pagination cursor. It binds the tool, the exact
+  scope ids, the stable keyset position, the page and item and byte chain
+  counters, and one 15-minute chain expiry that continuation never renews. The
+  AEAD is XChaCha20-Poly1305 under an instance-wide key derived from the keyring's
+  root token key. Each cursor operation refreshes the authoritative shared token
+  key version, so cursors remain portable when another replica rotates it. The
+  transport holds only a narrow Seal/Open sealer because the crypto chokepoint
+  confines the primitive to `internal/crypto`.
+- Enforced the phase-1 output bounds in the transport: per-page byte fit against
+  the 256 KiB structured-content bound with a named `result_item_too_large`
+  refusal, and the chain bounds (10 pages, 1000 items, 1 MiB) with a named
+  `traversal_limit_reached` refusal and no continuation cursor.
+- Added datastore-coordinated MCP admission after authorization and before
+  tenant-shaped work: a 60-call/minute token bucket with capacity 20 per
+  service-account principal, plus 4/principal, 8/organization, and 64/instance
+  concurrency claims shared across replicas. Coordinator failure refuses the
+  call. Every successful call releases its expiring claim through a bounded
+  cleanup context that survives request cancellation.
+
+## Boundary held
+
+- `internal/mcpserver` still imports no `internal/store`, generated SQL, or
+  `internal/crypto` package. It depends on narrow service interfaces plus
+  `service.Bearer`, and it uses no cryptographic primitive directly.
+- No mutation, no reveal, no secret plaintext. `Values.List` is always called
+  with `reveal=false`; a `secret` cell and a `secret` or unset pending draft
+  carry only classification and set/absent presence. The output mapping drops
+  any value on a non-`config` cell as defense in depth.
+- Unauthorized reads collapse to one `SafeOperationError`, indistinguishable
+  from a nonexistent resource. Only the cursor, bound, and argument errors
+  surface their own tenant-safe token.
+
+## Validation anchors
+
+- Service and store dual-engine pagination equivalence for all five operations:
+  concatenated pages reproduce the unbounded read in order, on sqlite and
+  postgres (`internal/isolation/mcp_pagination_test.go`).
+- Transport tool tests with fakes: the closed five-tool catalog, cursor paging,
+  a final page that omits the cursor, cursor tamper rejection, cursor scope
+  binding, page-size range rejection, unknown-argument rejection, and the
+  secret-plaintext drop (`internal/mcpserver/tools_test.go`).
+- End-to-end over the real transport, services, and datastore: a seeded secret
+  canary is absent from every tool result and from the denial error, the config
+  plaintext is present, an ungranted service account receives the one safe
+  error, and a cursor minted by one handler is accepted by an independent
+  handler over the same datastore (`internal/isolation/mcp_e2e_test.go`).
+- The closed registry, formula, audit disposition, store-operation completeness,
+  read-only, and cross-engine query-contract invariants stay green.
+- Cursor crypto tests load two independent keyrings over one shared store,
+  rotate through one replica, and prove the other immediately accepts cursors
+  under the new authoritative key.
+
+## Verification
+
+- `go test ./... -count=1` passes: 4604 tests across 74 packages, including
+  local PostgreSQL and SQLite legs.
+- `go build ./...` and `go vet ./...` are clean.
+- `go test -race ./internal/mcpserver -count=1` passes all 50 transport tests.
+- `go tool sqlc generate` is stable and `git diff --check HEAD` is clean.
+- Standards and spec reviews were completed, followed by three blocking native
+  Codex review rounds. Every valid finding was fixed with regression coverage.

--- a/docs/site/src/content/docs/docs/configuration.mdx
+++ b/docs/site/src/content/docs/docs/configuration.mdx
@@ -64,11 +64,12 @@ CORS response headers, so it is an additional request check rather than a
 cross-origin browser API grant.
 
 Treat every configured MCP client and its model provider as a recipient of MCP
-tool results. When the read tools are installed by the next MCP release, results
-may include non-secret configuration plaintext and caller-owned non-secret
-draft plaintext. Secret values and secret draft material are never returned.
-Enabling the endpoint in this release exposes only the empty, tenant-free tool
-catalog until those tools are installed.
+tool results. The five read tools expose bounded key definitions, environments,
+configuration cells, caller-owned pending changes, and revision metadata.
+Results may include non-secret configuration plaintext and caller-owned
+non-secret draft plaintext. Secret values and secret draft material are never
+returned. Tool calls accept only an existing workload or automation
+service-account bearer and repeat current authorization on every page.
 
 ## Security response headers
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -499,6 +499,13 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	// storage high-water gauge's shared-door read).
 	metrics.SetApprovalSource(approvalMetricsSource{svc: approvalsSvc})
 	metrics.SetDynamicSource(dynamicGaugeSource{runtime: dynamicRuntime, log: log})
+	// The hierarchy, value, and revision services are named here so the read-only
+	// MCP tools (#629) map onto the SAME instances the REST surface uses: one
+	// keyring, one budget, one authorization path.
+	environmentsSvc := &service.Environments{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget, Scan: ruleset}
+	keysSvc := &service.Keys{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset}
+	valuesSvc := &service.Values{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset, Budget: budget}
+	revisionsSvc := &service.Revisions{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget}
 	api := &server.API{
 		Auth:     authSvc,
 		SAMLAuth: authSvc,
@@ -508,9 +515,9 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		// every value write re-seal under the project data key, in the
 		// transaction that writes the row. The ruleset (#74) reaches every
 		// surface that writes a config value or a declaration leaf.
-		Environments: &service.Environments{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget, Scan: ruleset},
+		Environments: environmentsSvc,
 		Folders:      &service.Folders{DB: db, Keyring: kr, Scan: ruleset},
-		Keys:         &service.Keys{DB: db, Keyring: kr, Advisory: advisory, Budget: budget, Scan: ruleset},
+		Keys:         keysSvc,
 		Definitions:  definitionsService,
 		// The reveal ceremony (#58): the value surface's disclosure routes
 		// consume the SAME reauthentication window machinery the passkey and
@@ -520,8 +527,8 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		// One Advisory across the value and revision surfaces: staging and
 		// publishing both announce on the same channel, and two channels would
 		// mean a subscriber saw half the events.
-		Values:    &service.Values{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Scan: ruleset, Budget: budget},
-		Revisions: &service.Revisions{DB: db, Keyring: kr, Auth: authSvc, Advisory: advisory, Budget: budget},
+		Values:    valuesSvc,
+		Revisions: revisionsSvc,
 		Rotation:  &service.Rotation{DB: db, Keyring: kr, RootKey: rootKeySource{cfg: cfg, log: log}, Budget: budget},
 		Reencrypt: reencryptSvc,
 		Pins:      &service.Pins{DB: db, Keyring: kr, Auth: authSvc},
@@ -578,13 +585,29 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 
 	var mcpHandler http.Handler
 	if cfg.MCPEnabled {
+		registry := mcpserver.NewRegistry()
+		if err := mcpserver.RegisterProductionTools(registry, mcpserver.ProductionServices{
+			Admission:     &service.MCPAdmission{DB: db},
+			Definitions:   keysSvc,
+			Environments:  environmentsSvc,
+			Configuration: valuesSvc,
+			Pending:       revisionsSvc,
+			Revisions:     revisionsSvc,
+		}); err != nil {
+			return nil, fmt.Errorf("boot: refusing to serve: MCP tools: %w", err)
+		}
+		cursorSealer, err := kr.MCPCursorSealer()
+		if err != nil {
+			return nil, fmt.Errorf("boot: refusing to serve: MCP cursor sealer: %w", err)
+		}
 		mcpHandler, err = mcpserver.New(mcpserver.Options{
-			Registry:       mcpserver.NewRegistry(),
+			Registry:       registry,
 			ExternalOrigin: cfg.ExternalOrigin,
 			AllowedOrigins: cfg.MCPAllowedOrigins,
 			TrustedProxies: proxies,
 			Admission:      limiter,
 			Version:        Version,
+			CursorSealer:   cursorSealer,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("boot: refusing to serve: MCP transport: %w", err)

--- a/internal/authz/registry.go
+++ b/internal/authz/registry.go
@@ -630,9 +630,11 @@ const (
 	StoreDefinitionsPlanPrune         StoreOp = "definitions.PruneExpiredPlans"
 	StoreDefinitionsLatestAppliedPlan StoreOp = "definitions.LatestAppliedPlan"
 
-	StoreEnvironmentsCreate     StoreOp = "environments.Create"
-	StoreEnvironmentsGet        StoreOp = "environments.Get"
-	StoreEnvironmentsList       StoreOp = "environments.List"
+	StoreEnvironmentsCreate StoreOp = "environments.Create"
+	StoreEnvironmentsGet    StoreOp = "environments.Get"
+	StoreEnvironmentsList   StoreOp = "environments.List"
+	// StoreEnvironmentsListPage is the MCP-bounded keyset environment read (#629).
+	StoreEnvironmentsListPage   StoreOp = "environments.ListPage"
 	StoreEnvironmentsCount      StoreOp = "environments.Count"
 	StoreEnvironmentsNextOrder  StoreOp = "environments.NextOrder"
 	StoreEnvironmentsUpdateNote StoreOp = "environments.UpdateNote"
@@ -650,9 +652,14 @@ const (
 	// prefix is the KEYRING's (#43, wrapped crypto material), and two unrelated
 	// senses of "key" sharing an operation prefix is how a proof minted for one
 	// would look admissible for the other.
-	StoreCatalogueCreate            StoreOp = "catalogue.Create"
-	StoreCatalogueGet               StoreOp = "catalogue.Get"
-	StoreCatalogueList              StoreOp = "catalogue.List"
+	StoreCatalogueCreate StoreOp = "catalogue.Create"
+	StoreCatalogueGet    StoreOp = "catalogue.Get"
+	StoreCatalogueList   StoreOp = "catalogue.List"
+	// The MCP-bounded catalogue reads (#629): a keyset key page, a single key
+	// resolved under the list authorization, and one key's presence rows.
+	StoreCatalogueListPage          StoreOp = "catalogue.ListPage"
+	StoreCatalogueGetInProject      StoreOp = "catalogue.GetInProject"
+	StoreCataloguePresenceForKey    StoreOp = "catalogue.PresenceForKey"
 	StoreCatalogueCount             StoreOp = "catalogue.Count"
 	StoreCatalogueAdapterPins       StoreOp = "catalogue.AdapterPins"
 	StoreCatalogueRename            StoreOp = "catalogue.Rename"
@@ -766,13 +773,16 @@ const (
 	// its changed-key rows are written in one act and must never drift.
 	StorePendingListForOwner              StoreOp = "pending.ListForOwner"
 	StorePendingListForOwnerInEnvironment StoreOp = "pending.ListForOwnerInEnvironment"
-	StorePendingListMarkers               StoreOp = "pending.ListMarkers"
-	StorePendingStage                     StoreOp = "pending.Stage"
-	StorePendingListForReencrypt          StoreOp = "pending.ListForReencrypt"
-	StorePendingReencrypt                 StoreOp = "pending.Reencrypt"
-	StorePendingDiscard                   StoreOp = "pending.Discard"
-	StorePendingDiscardEnvironment        StoreOp = "pending.DiscardEnvironment"
-	StorePendingDiscardKey                StoreOp = "pending.DiscardKey"
+	// StorePendingListForOwnerInEnvironmentPage is the MCP-bounded keyset draft
+	// read (#629).
+	StorePendingListForOwnerInEnvironmentPage StoreOp = "pending.ListForOwnerInEnvironmentPage"
+	StorePendingListMarkers                   StoreOp = "pending.ListMarkers"
+	StorePendingStage                         StoreOp = "pending.Stage"
+	StorePendingListForReencrypt              StoreOp = "pending.ListForReencrypt"
+	StorePendingReencrypt                     StoreOp = "pending.Reencrypt"
+	StorePendingDiscard                       StoreOp = "pending.Discard"
+	StorePendingDiscardEnvironment            StoreOp = "pending.DiscardEnvironment"
+	StorePendingDiscardKey                    StoreOp = "pending.DiscardKey"
 	// StorePendingCountForProjectExcludingCell is the per-project pending-cap
 	// read taken during a stage: the project's pending total, less the cell
 	// being staged (ops-spec §8, ≤100 pending versions per project).
@@ -781,9 +791,11 @@ const (
 	StoreSnapshotsLatest StoreOp = "snapshots.Latest"
 	// StoreSnapshotsProjectRevisions is the project-scoped per-environment latest
 	// revision behind the definitions plan/apply value-snapshot pin (#70).
-	StoreSnapshotsProjectRevisions            StoreOp = "snapshots.ProjectRevisions"
-	StoreSnapshotsAtRevision                  StoreOp = "snapshots.AtRevision"
-	StoreSnapshotsList                        StoreOp = "snapshots.List"
+	StoreSnapshotsProjectRevisions StoreOp = "snapshots.ProjectRevisions"
+	StoreSnapshotsAtRevision       StoreOp = "snapshots.AtRevision"
+	StoreSnapshotsList             StoreOp = "snapshots.List"
+	// StoreSnapshotsListPage is the MCP-bounded keyset revision-history read (#629).
+	StoreSnapshotsListPage                    StoreOp = "snapshots.ListPage"
 	StoreSnapshotsEntries                     StoreOp = "snapshots.Entries"
 	StoreSnapshotsListForReencrypt            StoreOp = "snapshots.ListForReencrypt"
 	StoreSnapshotsReencrypt                   StoreOp = "snapshots.Reencrypt"
@@ -1041,76 +1053,82 @@ var readOnlyStoreOps = map[StoreOp]bool{
 	// stored credential is not something an unaudited operation may do — the
 	// fetch that presents it rides remote.list/show, which carry their own
 	// events.
-	StoreEnvironmentsGet:                     true,
-	StoreEnvironmentsList:                    true,
-	StoreEnvironmentsCount:                   true,
-	StoreEnvironmentsNextOrder:               true,
-	StoreFoldersGet:                          true,
-	StoreFoldersList:                         true,
-	StoreEnvironmentsGetSettings:             true,
-	StoreCatalogueGet:                        true,
-	StoreCatalogueList:                       true,
-	StoreCatalogueCount:                      true,
-	StoreAdaptersTarget:                      true,
-	StoreAdaptersGet:                         true,
-	StoreAdaptersConfiguration:               true,
-	StoreAdaptersList:                        true,
-	StoreAdaptersListTargets:                 true,
-	StoreAdaptersTargetKeyIDs:                true,
-	StoreAdaptersTargetKeys:                  true,
-	StoreAdaptersHealthCounts:                true,
-	StoreAdaptersMapping:                     true,
-	StoreAdaptersPlanMaterial:                true,
-	StoreAdaptersTargetEnvironments:          true,
-	StoreAdaptersEnvironments:                true,
-	StoreAdaptersConflicts:                   true,
-	StoreAdaptersMove:                        true,
-	StoreCatalogueGroupGet:                   true,
-	StoreCatalogueGroupList:                  true,
-	StoreCatalogueGroupCount:                 true,
-	StoreCataloguePresenceList:               true,
-	StoreCatalogueRevisionGet:                true,
-	StoreKeysActiveMasterWrappers:            true,
-	StoreKeysActiveTier3:                     true,
-	StoreKeysTier3Versions:                   true,
-	StoreKeysAllOpenableTier3:                true,
-	StoreKeysAssertActiveDEKVersion:          true,
-	StoreValuesListForReencrypt:              true,
-	StoreSnapshotsListForReencrypt:           true,
-	StorePendingListForReencrypt:             true,
-	StoreAdaptersListForReencrypt:            true,
-	StoreAdaptersListMovesForReencrypt:       true,
-	StoreReencryptListPasswordCreds:          true,
-	StoreReencryptListTotpCreds:              true,
-	StoreReencryptListRecoveryCodes:          true,
-	StoreReencryptListOidcProviders:          true,
-	StoreReencryptListSamlKeys:               true,
-	StoreReencryptListRemotes:                true,
-	StoreAuditTenantPage:                     true,
-	StoreAuditInstancePage:                   true,
-	StoreAuditTenantMaxSeq:                   true,
-	StoreAuditInstanceMaxSeq:                 true,
-	StoreValuesGet:                           true,
-	StoreValuesList:                          true,
-	StoreValuesEnvironmentsWithValue:         true,
-	StorePendingListForOwner:                 true,
-	StorePendingListForOwnerInEnvironment:    true,
-	StorePendingListMarkers:                  true,
-	StorePendingCountForProjectExcludingCell: true,
-	StoreValuesPayloadBytesForProject:        true,
-	StoreSnapshotsPayloadBytesForProject:     true,
-	StoreValuesInstancePayloadByProject:      true,
-	StoreSnapshotsInstancePayloadByProject:   true,
-	StoreValuesSampleSecretEntry:             true,
-	StoreBackupStateGet:                      true,
-	StoreSnapshotsLatest:                     true,
-	StoreSnapshotsAtRevision:                 true,
-	StoreSnapshotsList:                       true,
-	StoreSnapshotsEntries:                    true,
-	StoreSnapshotsSecretValueOccurrenceIDs:   true,
-	StoreSnapshotsChanges:                    true,
-	StorePinsGetForWorkload:                  true,
-	StorePinsList:                            true,
+	StoreEnvironmentsGet:                      true,
+	StoreEnvironmentsList:                     true,
+	StoreEnvironmentsListPage:                 true,
+	StoreEnvironmentsCount:                    true,
+	StoreEnvironmentsNextOrder:                true,
+	StoreFoldersGet:                           true,
+	StoreFoldersList:                          true,
+	StoreEnvironmentsGetSettings:              true,
+	StoreCatalogueGet:                         true,
+	StoreCatalogueList:                        true,
+	StoreCatalogueListPage:                    true,
+	StoreCatalogueGetInProject:                true,
+	StoreCataloguePresenceForKey:              true,
+	StoreCatalogueCount:                       true,
+	StoreAdaptersTarget:                       true,
+	StoreAdaptersGet:                          true,
+	StoreAdaptersConfiguration:                true,
+	StoreAdaptersList:                         true,
+	StoreAdaptersListTargets:                  true,
+	StoreAdaptersTargetKeyIDs:                 true,
+	StoreAdaptersTargetKeys:                   true,
+	StoreAdaptersHealthCounts:                 true,
+	StoreAdaptersMapping:                      true,
+	StoreAdaptersPlanMaterial:                 true,
+	StoreAdaptersTargetEnvironments:           true,
+	StoreAdaptersEnvironments:                 true,
+	StoreAdaptersConflicts:                    true,
+	StoreAdaptersMove:                         true,
+	StoreCatalogueGroupGet:                    true,
+	StoreCatalogueGroupList:                   true,
+	StoreCatalogueGroupCount:                  true,
+	StoreCataloguePresenceList:                true,
+	StoreCatalogueRevisionGet:                 true,
+	StoreKeysActiveMasterWrappers:             true,
+	StoreKeysActiveTier3:                      true,
+	StoreKeysTier3Versions:                    true,
+	StoreKeysAllOpenableTier3:                 true,
+	StoreKeysAssertActiveDEKVersion:           true,
+	StoreValuesListForReencrypt:               true,
+	StoreSnapshotsListForReencrypt:            true,
+	StorePendingListForReencrypt:              true,
+	StoreAdaptersListForReencrypt:             true,
+	StoreAdaptersListMovesForReencrypt:        true,
+	StoreReencryptListPasswordCreds:           true,
+	StoreReencryptListTotpCreds:               true,
+	StoreReencryptListRecoveryCodes:           true,
+	StoreReencryptListOidcProviders:           true,
+	StoreReencryptListSamlKeys:                true,
+	StoreReencryptListRemotes:                 true,
+	StoreAuditTenantPage:                      true,
+	StoreAuditInstancePage:                    true,
+	StoreAuditTenantMaxSeq:                    true,
+	StoreAuditInstanceMaxSeq:                  true,
+	StoreValuesGet:                            true,
+	StoreValuesList:                           true,
+	StoreValuesEnvironmentsWithValue:          true,
+	StorePendingListForOwner:                  true,
+	StorePendingListForOwnerInEnvironment:     true,
+	StorePendingListForOwnerInEnvironmentPage: true,
+	StorePendingListMarkers:                   true,
+	StorePendingCountForProjectExcludingCell:  true,
+	StoreValuesPayloadBytesForProject:         true,
+	StoreSnapshotsPayloadBytesForProject:      true,
+	StoreValuesInstancePayloadByProject:       true,
+	StoreSnapshotsInstancePayloadByProject:    true,
+	StoreValuesSampleSecretEntry:              true,
+	StoreBackupStateGet:                       true,
+	StoreSnapshotsLatest:                      true,
+	StoreSnapshotsAtRevision:                  true,
+	StoreSnapshotsList:                        true,
+	StoreSnapshotsListPage:                    true,
+	StoreSnapshotsEntries:                     true,
+	StoreSnapshotsSecretValueOccurrenceIDs:    true,
+	StoreSnapshotsChanges:                     true,
+	StorePinsGetForWorkload:                   true,
+	StorePinsList:                             true,
 	// Secret-change approvals (#151): the read-only doors, licensed on the
 	// audited-none request-read operation and the scheduler expiry read.
 	StoreApprovalPolicyGet:           true,
@@ -1694,7 +1712,7 @@ var operationTable = map[Operation]opSpec{
 		class:       ClassTenant,
 		level:       domain.LevelProject,
 		formula:     Formula{{Cap: domain.CapRead, At: domain.LevelProject}},
-		storeOps:    map[StoreOp]bool{StoreEnvironmentsList: true},
+		storeOps:    map[StoreOp]bool{StoreEnvironmentsList: true, StoreEnvironmentsListPage: true},
 		auditedNone: true,
 	},
 	OpEnvRename: {
@@ -1807,6 +1825,9 @@ var operationTable = map[Operation]opSpec{
 		storeOps: map[StoreOp]bool{
 			StoreCatalogueList: true, StoreCataloguePresenceList: true,
 			StoreCatalogueRevisionGet: true,
+			// The MCP-bounded key page (#629) reads the catalogue by keyset and
+			// resolves presence per page key under this same read authorization.
+			StoreCatalogueListPage: true, StoreCataloguePresenceForKey: true,
 		},
 		auditedNone: true,
 	},
@@ -2171,6 +2192,9 @@ var operationTable = map[Operation]opSpec{
 			// clone preflight reads them here to answer "would this leave a
 			// required secret absent?" before anything is written.
 			StoreCataloguePresenceList: true,
+			// The MCP-bounded inspect page (#629) walks the catalogue by keyset
+			// and resolves each page key's cell with Values().Get.
+			StoreCatalogueListPage: true,
 		},
 		auditedNone: true,
 	},
@@ -2727,7 +2751,7 @@ var operationTable = map[Operation]opSpec{
 		class:       ClassTenant,
 		level:       domain.LevelEnv,
 		formula:     Formula{{Cap: domain.CapRead, At: domain.LevelEnv}},
-		storeOps:    map[StoreOp]bool{StoreSnapshotsList: true, StoreSnapshotsChanges: true},
+		storeOps:    map[StoreOp]bool{StoreSnapshotsList: true, StoreSnapshotsChanges: true, StoreSnapshotsListPage: true},
 		auditedNone: true,
 	},
 	// `revision show` returns the change token, which is NON-SECRET metadata by
@@ -2754,6 +2778,10 @@ var operationTable = map[Operation]opSpec{
 		formula: Formula{{Cap: domain.CapRead, At: domain.LevelEnv}},
 		storeOps: map[StoreOp]bool{
 			StoreCatalogueList: true, StorePendingListForOwnerInEnvironment: true,
+			// The MCP-bounded pending page (#629) reads the caller's drafts by
+			// keyset and resolves each page key's name and classification with
+			// GetInProject, both under this read authorization.
+			StorePendingListForOwnerInEnvironmentPage: true, StoreCatalogueGetInProject: true,
 		},
 		auditedNone: true,
 	},

--- a/internal/boundary/boundary_test.go
+++ b/internal/boundary/boundary_test.go
@@ -336,6 +336,28 @@ func TestScanningNoHashPrimitives(t *testing.T) {
 	}
 }
 
+// TestMCPTelemetryBoundary keeps the secret-bearing MCP adapter away from log,
+// trace, and metric sinks. The seeded-canary E2E test covers wire, audit, log,
+// and metric outputs; this import boundary proves there is no hidden tracing
+// path beside those observed surfaces.
+func TestMCPTelemetryBoundary(t *testing.T) {
+	const mcpPackage = module + "/internal/mcpserver"
+	for _, p := range loadPackages(t) {
+		if p.ImportPath != mcpPackage {
+			continue
+		}
+		for _, imp := range allImports(p) {
+			for _, forbiddenPrefix := range []string{"log/slog", "go.opentelemetry.io/", "github.com/prometheus/"} {
+				if imp == strings.TrimSuffix(forbiddenPrefix, "/") || strings.HasPrefix(imp, forbiddenPrefix) {
+					t.Errorf("%s imports telemetry sink %s: MCP secret boundary must stay sink-free", p.ImportPath, imp)
+				}
+			}
+		}
+		return
+	}
+	t.Fatal("internal/mcpserver package missing")
+}
+
 func TestForbiddenEdges(t *testing.T) {
 	for _, p := range loadPackages(t) {
 		for _, rule := range forbidden {

--- a/internal/crypto/mcp_cursor.go
+++ b/internal/crypto/mcp_cursor.go
@@ -1,0 +1,83 @@
+package crypto
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// MCPCursorSealer encrypts and authenticates opaque MCP pagination cursors
+// (#629) with XChaCha20-Poly1305 under an instance-wide derived key. Encryption
+// is required because the keyset position can be a tenant-controlled name,
+// which must not appear in the cursor. The crypto chokepoint owns the primitive;
+// the transport holds only the narrow Seal/Open verbs.
+type MCPCursorSealer struct {
+	derive func(context.Context) ([]byte, error)
+}
+
+// ErrCursorInvalid is the generic, non-distinguishing failure the sealer returns
+// for a tampered, truncated, or forged token.
+var ErrCursorInvalid = errors.New("crypto: invalid cursor")
+
+var mcpCursorEncoding = base64.RawURLEncoding
+
+// Seal authenticates and encodes one cursor payload.
+func (s *MCPCursorSealer) Seal(ctx context.Context, payload []byte) (string, error) {
+	key, err := s.cursorKey(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer Zero(key)
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return "", fmt.Errorf("crypto: cursor cipher: %w", err)
+	}
+	nonce := make([]byte, chacha20poly1305.NonceSizeX)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("crypto: cursor nonce: %w", err)
+	}
+	sealed := aead.Seal(nonce, nonce, payload, nil)
+	return mcpCursorEncoding.EncodeToString(sealed), nil
+}
+
+// Open verifies one cursor token and returns its payload. Every malformed or
+// unauthenticated token returns ErrCursorInvalid without distinguishing which.
+func (s *MCPCursorSealer) Open(ctx context.Context, token string) ([]byte, error) {
+	sealed, err := mcpCursorEncoding.DecodeString(token)
+	if err != nil || len(sealed) < chacha20poly1305.NonceSizeX+chacha20poly1305.Overhead {
+		return nil, ErrCursorInvalid
+	}
+	key, err := s.cursorKey(ctx)
+	if err != nil {
+		return nil, ErrCursorInvalid
+	}
+	defer Zero(key)
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, ErrCursorInvalid
+	}
+	nonce := sealed[:chacha20poly1305.NonceSizeX]
+	payload, err := aead.Open(nil, nonce, sealed[chacha20poly1305.NonceSizeX:], nil)
+	if err != nil {
+		return nil, ErrCursorInvalid
+	}
+	return payload, nil
+}
+
+func (s *MCPCursorSealer) cursorKey(ctx context.Context) ([]byte, error) {
+	if s == nil || s.derive == nil {
+		return nil, errors.New("crypto: cursor sealer unavailable")
+	}
+	key, err := s.derive(ctx)
+	if err != nil || len(key) != chacha20poly1305.KeySize {
+		if key != nil {
+			Zero(key)
+		}
+		return nil, errors.New("crypto: cursor key unavailable")
+	}
+	return key, nil
+}

--- a/internal/crypto/mcp_cursor_test.go
+++ b/internal/crypto/mcp_cursor_test.go
@@ -1,0 +1,116 @@
+package crypto
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMCPCursorSealerHidesAndAuthenticatesPayload(t *testing.T) {
+	sealer := &MCPCursorSealer{derive: func(context.Context) ([]byte, error) { return make([]byte, KeySize), nil }}
+	payload := []byte(`{"k":"tenant-private-environment-name"}`)
+	token, err := sealer.Seal(t.Context(), payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(token, "tenant-private-environment-name") {
+		t.Fatalf("cursor exposed tenant name: %q", token)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "tenant-private-environment-name") {
+		t.Fatalf("decoded cursor exposed tenant name: %q", raw)
+	}
+	opened, err := sealer.Open(t.Context(), token)
+	if err != nil || string(opened) != string(payload) {
+		t.Fatalf("cursor open = %q, %v", opened, err)
+	}
+	raw[len(raw)-1] ^= 1
+	if _, err := sealer.Open(t.Context(), base64.RawURLEncoding.EncodeToString(raw)); err == nil {
+		t.Fatal("tampered cursor was accepted")
+	}
+}
+
+func TestMCPCursorSealerUsesLiveTokenKeyAfterRotation(t *testing.T) {
+	kr, err := LoadKeyring(context.Background(), newMemStore(), newRoot(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealer, err := kr.MCPCursorSealer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"page":1}`)
+	before, err := sealer.Seal(t.Context(), payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, adopt, abort, err := kr.PrepareTokenKeyRotation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer abort()
+	adopt()
+
+	if _, err := sealer.Open(t.Context(), before); !errors.Is(err, ErrCursorInvalid) {
+		t.Fatalf("pre-rotation cursor after rotation = %v, want ErrCursorInvalid", err)
+	}
+	after, err := sealer.Seal(t.Context(), payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err := sealer.Open(t.Context(), after)
+	if err != nil || string(opened) != string(payload) {
+		t.Fatalf("post-rotation cursor open = %q, %v", opened, err)
+	}
+}
+
+func TestMCPCursorSealerRefreshesTokenKeyAfterCrossReplicaRotation(t *testing.T) {
+	ctx := context.Background()
+	ks := newMemStore()
+	root := newRoot(t)
+	rootCopy := bytes.Clone(root)
+	rotating, err := LoadKeyring(ctx, ks, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := LoadKeyring(ctx, ks, rootCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotatingSealer, err := rotating.MCPCursorSealer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleSealer, err := stale.MCPCursorSealer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row, adopt, abort, err := rotating.PrepareTokenKeyRotation()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer abort()
+	ks.mu.Lock()
+	key := t3key(PurposeToken, "", "")
+	ks.tier3[key] = append(ks.tier3[key], row)
+	ks.mu.Unlock()
+	adopt()
+
+	payload := []byte(`{"page":2}`)
+	cursor, err := rotatingSealer.Seal(ctx, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err := staleSealer.Open(ctx, cursor)
+	if err != nil || string(opened) != string(payload) {
+		t.Fatalf("stale replica open after shared rotation = %q, %v", opened, err)
+	}
+}

--- a/internal/crypto/token.go
+++ b/internal/crypto/token.go
@@ -1,8 +1,10 @@
 package crypto
 
 import (
+	"context"
 	"crypto/hkdf"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 )
 
@@ -41,6 +43,49 @@ func (k *Keyring) deriveScopedTokenKey(label, orgID, projectID, envID string) ([
 const occurrenceInfoLabel = "hikyo/import-occurrence/v1"
 
 const publishPreviewInfoLabel = "hikyo/publish-preview/v1"
+
+// mcpCursorInfoLabel domain-separates the MCP pagination cursor key (#629) from
+// every other derived token key.
+const mcpCursorInfoLabel = "hikyo/mcp-cursor/v1"
+
+// MCPCursorSealer builds the instance-wide sealer that encrypts and authenticates
+// MCP pagination cursors. It derives from the live root token key on each Seal
+// and Open, so rotate-token-key invalidates old cursors atomically instead of a
+// boot-time cached key splitting this process from a restarted replica. The
+// cursor payload binds the tool and exact scope ids, so one instance-wide key
+// suffices and every replica derives the same key from shared key material.
+func (k *Keyring) MCPCursorSealer() (*MCPCursorSealer, error) {
+	if k == nil {
+		return nil, errors.New("crypto: cursor sealer requires a keyring")
+	}
+	return &MCPCursorSealer{derive: func(ctx context.Context) ([]byte, error) {
+		if err := k.refreshTokenKey(ctx); err != nil {
+			return nil, err
+		}
+		return k.deriveScopedTokenKey(mcpCursorInfoLabel, "", "", "")
+	}}, nil
+}
+
+// refreshTokenKey makes cursor operations observe a rotation committed by any
+// replica. The shared active row is checked under the caller's tool deadline;
+// a newer row is unwrapped and adopted monotonically before cursor crypto runs.
+func (k *Keyring) refreshTokenKey(ctx context.Context) error {
+	row, err := k.ks.ActiveTier3(ctx, PurposeToken, "", "")
+	if err != nil {
+		return fmt.Errorf("crypto: refresh token key: %w", err)
+	}
+	if row.Version <= k.token.get().version {
+		return nil
+	}
+	next, err := k.unwrapTier3(row)
+	if err != nil {
+		return fmt.Errorf("crypto: refresh token key: %w", err)
+	}
+	if !k.token.adopt(next) {
+		Zero(next.key)
+	}
+	return nil
+}
 
 // OccurrenceToken is HMAC-SHA256(scoped occurrence key, encoding), base64url,
 // prefixed — the server-minted opaque token an import's phase 1 records per

--- a/internal/isolation/mcp_e2e_test.go
+++ b/internal/isolation/mcp_e2e_test.go
@@ -1,0 +1,335 @@
+package isolation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/mcpserver"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/server"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+const mcpCanaryPlaintext = "CANARY-PLAINTEXT-9Z-do-not-disclose"
+
+func setupMCPHandler(t *testing.T, sealer mcpserver.CursorSealer, services mcpserver.ProductionServices) http.Handler {
+	t.Helper()
+	registry := mcpserver.NewRegistry()
+	if err := mcpserver.RegisterProductionTools(registry, services); err != nil {
+		t.Fatalf("register tools: %v", err)
+	}
+	handler, err := mcpserver.New(mcpserver.Options{
+		Registry:       registry,
+		ExternalOrigin: "https://hikyo.example.com",
+		Version:        "mcp-e2e",
+		CursorSealer:   sealer,
+	})
+	if err != nil {
+		t.Fatalf("new mcp handler: %v", err)
+	}
+	return handler
+}
+
+// mcpCall drives one tools/call over the stateless JSON transport.
+func mcpCall(t *testing.T, handler http.Handler, token, tool, arguments string) *httptest.ResponseRecorder {
+	t.Helper()
+	return mcpRequest(t, handler, token, "tools/call", tool, arguments, mcpserver.ProtocolVersion)
+}
+
+func mcpRequest(t *testing.T, handler http.Handler, token, method, tool, arguments, version string) *httptest.ResponseRecorder {
+	t.Helper()
+	meta := `"_meta":{"io.modelcontextprotocol/protocolVersion":"` + mcpserver.ProtocolVersion + `","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"e2e","version":"1"}}`
+	if version != mcpserver.ProtocolVersion {
+		meta = `"_meta":{"io.modelcontextprotocol/protocolVersion":"` + version + `","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"e2e","version":"1"}}`
+	}
+	params := meta
+	if method == "tools/call" {
+		params = `"name":"` + tool + `","arguments":` + arguments + `,` + meta
+	}
+	body := `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":{` + params + `}}`
+	req := httptest.NewRequest(http.MethodPost, "https://hikyo.example.com"+mcpserver.Path, bytes.NewReader([]byte(body)))
+	req.Host = "hikyo.example.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", version)
+	req.Header.Set("Mcp-Method", method)
+	if method == "tools/call" {
+		req.Header.Set("Mcp-Name", tool)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func assertMCPNoCanary(t *testing.T, surface string, body []byte) {
+	t.Helper()
+	if bytes.Contains(body, []byte(mcpCanaryPlaintext)) {
+		t.Fatalf("secret canary leaked through %s: %q", surface, body)
+	}
+}
+
+type mcpOperationalHealth struct{}
+
+func (mcpOperationalHealth) OperationalHealth(context.Context) (service.PruneHealth, error) {
+	return service.PruneHealth{}, nil
+}
+
+func mustCreateKey(t *testing.T, keys *service.Keys, scope domain.Scope, name string, classification schema.Classification) {
+	t.Helper()
+	spec := service.KeySpec{
+		Name: name, Classification: string(classification),
+		Declaration: schema.Declaration{Rule: &schema.Rule{Type: schema.TypeString}},
+		Presence:    schema.DefaultPresenceRules(),
+	}
+	if _, err := keys.Create(t.Context(), service.LocalPrincipal(custodian), scope, spec, nil); err != nil {
+		t.Fatalf("create key %s: %v", name, err)
+	}
+}
+
+type workloadCredential struct {
+	Principal domain.PrincipalID
+	token     string
+}
+
+// mintWorkload creates a workload service account and mints one credential for
+// it. custodian is granted machine-identity administration so it can act.
+func mintWorkload(t *testing.T, db *store.DB, auth *service.Auth, scope domain.Scope, name string) workloadCredential {
+	t.Helper()
+	identities := &service.Identities{DB: db, Auth: auth}
+	sa, err := identities.CreateServiceAccount(t.Context(), service.LocalPrincipal(custodian), scope, name, domain.ClassWorkload)
+	if err != nil {
+		t.Fatalf("create service account %s: %v", name, err)
+	}
+	minted, err := identities.MintCredential(t.Context(), service.LocalPrincipal(custodian), scope, sa.ID, service.MintRequest{})
+	if err != nil {
+		t.Fatalf("mint credential %s: %v", name, err)
+	}
+	return workloadCredential{Principal: sa.Principal, token: minted.Value}
+}
+
+func extractNextCursor(t *testing.T, body []byte) string {
+	t.Helper()
+	var response struct {
+		Result struct {
+			StructuredContent struct {
+				NextCursor string `json:"next_cursor"`
+			} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("decode tool response: %v: %s", err, body)
+	}
+	return response.Result.StructuredContent.NextCursor
+}
+
+func TestMCPToolsEndToEndCanaryAndDenial(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		ctx := t.Context()
+		kr := probeKeyring(t, db)
+		auth := authService(t, db)
+		keys := &service.Keys{DB: db, Keyring: kr}
+		values := &service.Values{DB: db, Keyring: kr, Auth: auth}
+		revisions := &service.Revisions{DB: db, Keyring: kr, Auth: auth}
+		environments := &service.Environments{DB: db, Keyring: kr}
+
+		projectScope := scopeProject(orgA, prjA1)
+		envScope := scopeEnv(orgA, prjA1, envA1)
+
+		// custodian gains machine-identity administration so it can mint the
+		// service accounts the MCP transport authenticates.
+		execRaw(t, db, `INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES (`+
+			`'g_cu_mid', 'usr_custodian', 'manage-identities', 'org_a', NULL, NULL, `+ts+`)`)
+
+		// Seed a secret canary and a config value, then publish both.
+		mustCreateKey(t, keys, projectScope, "CANARY_SECRET", schema.Secret)
+		mustCreateKey(t, keys, projectScope, "PUBLIC_CFG", schema.Config)
+		secretStaged, err := values.Set(ctx, service.LocalPrincipal(custodian), envScope, "CANARY_SECRET", mcpCanaryPlaintext, nil)
+		if err != nil {
+			t.Fatalf("stage secret: %v", err)
+		}
+		cfgStaged, err := values.Set(ctx, service.LocalPrincipal(custodian), envScope, "PUBLIC_CFG", "public-config-value", nil)
+		if err != nil {
+			t.Fatalf("stage config: %v", err)
+		}
+		if _, err := revisions.PublishPlanned(ctx, service.LocalPrincipal(custodian), envScope,
+			service.PublishRequest{VersionIDs: []string{secretStaged.VersionID, cfgStaged.VersionID}}); err != nil {
+			t.Fatalf("publish: %v", err)
+		}
+
+		// A workload service account granted read across the project, and a
+		// second with no grants at all.
+		granted := mintWorkload(t, db, auth, projectScope, "mcp-granted")
+		execRaw(t, db, `INSERT INTO grants (id, principal_id, capability, org_id, project_id, env_id, created_at) VALUES (`+
+			`'g_mcp_sa_read', '`+string(granted.Principal)+`', 'read', 'org_a', 'prj_a1', NULL, `+ts+`)`)
+		execRaw(t, db, `INSERT INTO grant_origins (id, grant_id, kind, subject, created_at) VALUES (`+
+			`'gor_mcp_sa_read', 'g_mcp_sa_read', 'manual', '`+string(granted.Principal)+`', `+ts+`)`)
+		ungranted := mintWorkload(t, db, auth, projectScope, "mcp-ungranted")
+
+		sealer, err := kr.MCPCursorSealer()
+		if err != nil {
+			t.Fatal(err)
+		}
+		services := mcpserver.ProductionServices{
+			Admission:   &service.MCPAdmission{DB: db},
+			Definitions: keys, Environments: environments, Configuration: values,
+			Pending: revisions, Revisions: revisions,
+		}
+		mcpHandler := setupMCPHandler(t, sealer, services)
+		var logs bytes.Buffer
+		metrics := server.NewMetrics(nil)
+		handler := server.NewPublic(nil, &server.API{
+			Metrics: metrics,
+			Log:     slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		}, nil, server.PublicOptions{ExternalOrigin: "https://hikyo.example.com", MCP: mcpHandler})
+
+		// Static discovery/catalog, input schemas, and protocol errors are part of
+		// the model-context boundary too. The schemas expose ids, page_size, and
+		// cursor only; no value, reveal, secret, or token argument exists.
+		catalog := mcpRequest(t, handler, "", "tools/list", "", "", mcpserver.ProtocolVersion)
+		assertMCPNoCanary(t, "static tool catalog", catalog.Body.Bytes())
+		var catalogBody struct {
+			Result struct {
+				Tools []struct {
+					InputSchema struct {
+						Properties map[string]json.RawMessage `json:"properties"`
+					} `json:"inputSchema"`
+				} `json:"tools"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(catalog.Body.Bytes(), &catalogBody); err != nil {
+			t.Fatalf("decode catalog: %v", err)
+		}
+		for _, tool := range catalogBody.Result.Tools {
+			for _, forbidden := range []string{"value", "reveal", "secret", "token"} {
+				if _, present := tool.InputSchema.Properties[forbidden]; present {
+					t.Fatalf("static tool catalog exposes forbidden argument %q", forbidden)
+				}
+			}
+		}
+		protocolError := mcpRequest(t, handler, "", "tools/list", "", "", "2025-03-26")
+		assertMCPNoCanary(t, "protocol error", protocolError.Body.Bytes())
+
+		// Inspect discloses the config plaintext but never the secret plaintext.
+		inspect := mcpCall(t, handler, granted.token, mcpserver.ToolInspectConfiguration,
+			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1","page_size":100}`)
+		if inspect.Code != http.StatusOK {
+			t.Fatalf("inspect = %d %q", inspect.Code, inspect.Body.String())
+		}
+		inspectBody := inspect.Body.String()
+		assertMCPNoCanary(t, "inspect", inspect.Body.Bytes())
+		if !strings.Contains(inspectBody, "public-config-value") {
+			t.Fatalf("config plaintext missing from inspect: %q", inspectBody)
+		}
+
+		// Every other authorized tool is canary-free too.
+		for _, tc := range []struct{ tool, args string }{
+			{mcpserver.ToolListDefinitions, `{"org_id":"org_a","project_id":"prj_a1","page_size":100}`},
+			{mcpserver.ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a1","page_size":100}`},
+			{mcpserver.ToolListPendingChanges, `{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1","page_size":100}`},
+			{mcpserver.ToolListRevisions, `{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1","page_size":100}`},
+		} {
+			rec := mcpCall(t, handler, granted.token, tc.tool, tc.args)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s = %d %q", tc.tool, rec.Code, rec.Body.String())
+			}
+			assertMCPNoCanary(t, tc.tool, rec.Body.Bytes())
+		}
+
+		// An ungranted service account is refused with the one safe error, which
+		// discloses no tenant fact and no canary.
+		denied := mcpCall(t, handler, ungranted.token, mcpserver.ToolInspectConfiguration,
+			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
+		if denied.Code != http.StatusOK {
+			t.Fatalf("denied inspect http = %d %q", denied.Code, denied.Body.String())
+		}
+		deniedBody := denied.Body.String()
+		if !strings.Contains(deniedBody, mcpserver.SafeOperationError) {
+			t.Fatalf("denial not the safe error: %q", deniedBody)
+		}
+		if strings.Contains(deniedBody, mcpCanaryPlaintext) || strings.Contains(deniedBody, "public-config-value") {
+			t.Fatalf("denial disclosed a tenant fact: %q", deniedBody)
+		}
+
+		// Audit parity (acceptance criterion 3): a capability denial through MCP
+		// emits the existing grant.denied event, now carrying origin=mcp and the
+		// refused principal, exactly as a REST read denial would.
+		deniedEvents := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events WHERE type = 'grant.denied' AND origin = 'mcp' AND actor_id = '`+string(ungranted.Principal)+`'`)
+		if deniedEvents == 0 {
+			t.Fatal("MCP capability denial emitted no grant.denied event with origin=mcp")
+		}
+		if claims := queryInt(t, db, `SELECT COUNT(*) FROM mcp_rate_buckets WHERE principal_id = '`+string(ungranted.Principal)+`'`); claims != 0 {
+			t.Fatalf("unauthorized principal consumed %d MCP rate buckets, want 0", claims)
+		}
+
+		// A valid bearer of a disallowed class (a human CLI session) is refused as
+		// an artifact-class refusal with origin=mcp, not a capability denial.
+		human := bootstrapAdmin(t, db, adminOpts{
+			username: "mcp-human", displayName: "MCP Human",
+			password: "an ordinary human session passphrase", auth: auth, login: true,
+		})
+		beforeRefused := queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events WHERE type = 'auth.artifact_class_refused' AND origin = 'mcp'`)
+		humanCall := mcpCall(t, handler, human.token, mcpserver.ToolInspectConfiguration,
+			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
+		if !strings.Contains(humanCall.Body.String(), mcpserver.SafeOperationError) {
+			t.Fatalf("human-session call not the safe error: %q", humanCall.Body.String())
+		}
+		afterRefused := queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events WHERE type = 'auth.artifact_class_refused' AND origin = 'mcp'`)
+		if afterRefused != beforeRefused+1 {
+			t.Fatalf("artifact-class refusal events = %d, want %d", afterRefused, beforeRefused+1)
+		}
+
+		// An invalid bearer is the silent, non-enumerating authentication failure:
+		// no audit row of any kind.
+		beforeInvalid := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events`) + queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events`)
+		invalid := mcpCall(t, handler, "not-a-real-token", mcpserver.ToolInspectConfiguration,
+			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
+		if !strings.Contains(invalid.Body.String(), mcpserver.SafeOperationError) {
+			t.Fatalf("invalid bearer call not the safe error: %q", invalid.Body.String())
+		}
+		afterInvalid := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events`) + queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events`)
+		if afterInvalid != beforeInvalid {
+			t.Fatalf("invalid bearer wrote %d audit rows, want 0", afterInvalid-beforeInvalid)
+		}
+		for _, table := range []string{"audit_tenant_events", "audit_instance_events"} {
+			if leaked := queryInt(t, db, `SELECT COUNT(*) FROM `+table+` WHERE CAST(payload AS TEXT) LIKE '%`+mcpCanaryPlaintext+`%'`); leaked != 0 {
+				t.Fatalf("secret canary leaked into %s: %d rows", table, leaked)
+			}
+		}
+		assertMCPNoCanary(t, "debug logs", logs.Bytes())
+		metricsRec := httptest.NewRecorder()
+		server.NewOperational(nil, mcpOperationalHealth{}, metrics).ServeHTTP(metricsRec,
+			httptest.NewRequest(http.MethodGet, "http://127.0.0.1/metrics", nil))
+		assertMCPNoCanary(t, "metrics", metricsRec.Body.Bytes())
+
+		// Alternating replicas: a cursor minted by one handler is accepted by an
+		// independent handler with its own registry over the same datastore.
+		other := setupMCPHandler(t, sealer, services)
+		first := mcpCall(t, handler, granted.token, mcpserver.ToolListDefinitions,
+			`{"org_id":"org_a","project_id":"prj_a1","page_size":1}`)
+		cursor := extractNextCursor(t, first.Body.Bytes())
+		if cursor == "" {
+			t.Fatal("expected a continuation cursor for a one-item page")
+		}
+		second := mcpCall(t, other, granted.token, mcpserver.ToolListDefinitions,
+			fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a1","page_size":1,"cursor":%q}`, cursor))
+		if second.Code != http.StatusOK || strings.Contains(second.Body.String(), mcpserver.SafeOperationError) ||
+			strings.Contains(second.Body.String(), mcpserver.ErrInvalidCursor.Error()) {
+			t.Fatalf("alternating-replica continuation = %d %q", second.Code, second.Body.String())
+		}
+		if inflight := queryInt(t, db, `SELECT COUNT(*) FROM mcp_inflight`); inflight != 0 {
+			t.Fatalf("completed MCP calls left %d shared concurrency claims", inflight)
+		}
+	})
+}

--- a/internal/isolation/mcp_pagination_test.go
+++ b/internal/isolation/mcp_pagination_test.go
@@ -1,0 +1,286 @@
+package isolation
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+)
+
+// These are the seam-2 proofs (#629): every mapped list operation has a bounded
+// keyset page method whose concatenated pages reproduce the unbounded read
+// exactly, on both engines. A page never fetches the whole collection: the
+// store statement carries the cursor and a LIMIT. Equivalence across a small
+// page size is the strongest available witness that the keyset order is stable
+// and that nothing is dropped or duplicated at a page boundary.
+
+// pageAllString collects every page of a string-keyset list method, following
+// the last returned item's key as the next cursor. It stops when a page returns
+// fewer than the limit; the extra empty fetch a full final page would need is
+// covered by pageBoundary below.
+func pageAllString[T any](t *testing.T, limit int, fetch func(after string, limit int) ([]T, error), keyOf func(T) string) []T {
+	t.Helper()
+	var out []T
+	after := ""
+	for {
+		page, err := fetch(after, limit)
+		if err != nil {
+			t.Fatalf("page after %q: %v", after, err)
+		}
+		if len(page) > limit {
+			t.Fatalf("page after %q returned %d rows, over the %d limit", after, len(page), limit)
+		}
+		out = append(out, page...)
+		if len(page) < limit {
+			return out
+		}
+		after = keyOf(page[len(page)-1])
+	}
+}
+
+func TestMCPEnvironmentPageMatchesList(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		_, _, envSvc := services(t, db)
+		scope := scopeProject(orgA, prjA1)
+		for i := range 5 {
+			if _, err := envSvc.Create(t.Context(), service.LocalPrincipal(custodian), scope, fmt.Sprintf("mcp-env-%02d", 4-i), nil); err != nil {
+				t.Fatalf("create env %d: %v", i, err)
+			}
+		}
+		full, err := envSvc.List(t.Context(), service.LocalPrincipal(custodian), scope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var paged []service.Environment
+		afterOrder, afterName := int64(-1), ""
+		for {
+			page, err := envSvc.ListPage(t.Context(), service.LocalPrincipal(custodian), scope, afterOrder, afterName, 2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			paged = append(paged, page...)
+			if len(page) < 2 {
+				break
+			}
+			afterOrder, afterName = page[len(page)-1].DisplayOrder, page[len(page)-1].Name
+		}
+		assertEnvironmentsEqual(t, full, paged)
+	})
+}
+
+func TestMCPDefinitionsPageMatchesList(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		keys := keySvc(t, db)
+		scope := scopeProject(orgA, prjA1)
+		for i := range 5 {
+			spec := service.KeySpec{Name: fmt.Sprintf("MCP_KEY_%02d", i), Classification: string(schema.Config), Declaration: schema.Declaration{Rule: &schema.Rule{Type: schema.TypeString}}, Presence: schema.DefaultPresenceRules()}
+			if _, err := keys.Create(t.Context(), service.LocalPrincipal(custodian), scope, spec, nil); err != nil {
+				t.Fatalf("create key %d: %v", i, err)
+			}
+		}
+		full, fullRev, err := keys.List(t.Context(), service.LocalPrincipal(custodian), scope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var pagedRev int64
+		paged := pageAllString(t, 2,
+			func(after string, limit int) ([]service.Key, error) {
+				page, rev, err := keys.ListPage(t.Context(), service.LocalPrincipal(custodian), scope, after, limit)
+				pagedRev = rev
+				return page, err
+			},
+			func(k service.Key) string { return k.Name })
+		if pagedRev != fullRev {
+			t.Fatalf("schema revision: paged %d, full %d", pagedRev, fullRev)
+		}
+		if len(paged) != len(full) {
+			t.Fatalf("definitions: paged %d rows, full %d", len(paged), len(full))
+		}
+		for i := range full {
+			if paged[i].ID != full[i].ID || paged[i].Name != full[i].Name {
+				t.Fatalf("definitions row %d: paged %+v, full %+v", i, paged[i], full[i])
+			}
+		}
+	})
+}
+
+func TestMCPInspectPageMatchesList(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		keys := keySvc(t, db)
+		values := valueSvc(t, db)
+		scope := scopeEnv(orgA, prjA1, envA1)
+		for i := range 4 {
+			spec := service.KeySpec{Name: fmt.Sprintf("INSPECT_KEY_%02d", i), Classification: string(schema.Config), Declaration: schema.Declaration{Rule: &schema.Rule{Type: schema.TypeString}}, Presence: schema.DefaultPresenceRules()}
+			if _, err := keys.Create(t.Context(), service.LocalPrincipal(custodian), scopeProject(orgA, prjA1), spec, nil); err != nil {
+				t.Fatalf("create key %d: %v", i, err)
+			}
+		}
+		full, err := values.List(t.Context(), service.LocalPrincipal(custodian), scope, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		paged := pageAllString(t, 2,
+			func(after string, limit int) ([]service.ValueCell, error) {
+				return values.ListPage(t.Context(), service.LocalPrincipal(custodian), scope, after, limit)
+			},
+			func(c service.ValueCell) string { return c.Name })
+		if len(paged) != len(full) {
+			t.Fatalf("inspect: paged %d cells, full %d", len(paged), len(full))
+		}
+		for i := range full {
+			if paged[i] != full[i] {
+				t.Fatalf("inspect cell %d: paged %+v, full %+v", i, paged[i], full[i])
+			}
+		}
+	})
+}
+
+func TestMCPPendingPageMatchesList(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		keys := keySvc(t, db)
+		values := valueSvc(t, db)
+		revisions := &service.Revisions{DB: db, Keyring: probeKeyring(t, db)}
+		scope := scopeEnv(orgA, prjA1, envA1)
+		for i := range 4 {
+			name := fmt.Sprintf("PENDING_KEY_%02d", i)
+			spec := service.KeySpec{Name: name, Classification: string(schema.Config), Declaration: schema.Declaration{Rule: &schema.Rule{Type: schema.TypeString}}, Presence: schema.DefaultPresenceRules()}
+			if _, err := keys.Create(t.Context(), service.LocalPrincipal(custodian), scopeProject(orgA, prjA1), spec, nil); err != nil {
+				t.Fatalf("create key %d: %v", i, err)
+			}
+			if _, err := values.Set(t.Context(), service.LocalPrincipal(custodian), scope, name, fmt.Sprintf("draft-%d", i), nil); err != nil {
+				t.Fatalf("stage draft %d: %v", i, err)
+			}
+		}
+		full, err := revisions.PendingDrafts(t.Context(), service.LocalPrincipal(custodian), scope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		paged := pageAllString(t, 2,
+			func(after string, limit int) ([]service.PendingDraft, error) {
+				return revisions.PendingDraftsPage(t.Context(), service.LocalPrincipal(custodian), scope, after, limit)
+			},
+			func(d service.PendingDraft) string { return d.KeyID })
+		if len(paged) != len(full) || len(full) == 0 {
+			t.Fatalf("pending: paged %d drafts, full %d", len(paged), len(full))
+		}
+		byKey := map[string]service.PendingDraft{}
+		for _, d := range full {
+			byKey[d.KeyID] = d
+		}
+		for i := 1; i < len(paged); i++ {
+			if paged[i-1].KeyID >= paged[i].KeyID {
+				t.Fatalf("pending not ordered by key_id: %q then %q", paged[i-1].KeyID, paged[i].KeyID)
+			}
+		}
+		for _, d := range paged {
+			if byKey[d.KeyID] != d {
+				t.Fatalf("pending draft %s: paged %+v, full %+v", d.KeyID, d, byKey[d.KeyID])
+			}
+		}
+	})
+}
+
+// TestMCPPendingSecretDraftCarriesNoMaterial pins the pending-draft secret
+// boundary that the tool-level canary cannot reach: a workload principal cannot
+// stage a draft, so only a seam-2 test can seed a secret draft and prove the
+// page returns its presence with no plaintext and no revealed flag.
+func TestMCPPendingSecretDraftCarriesNoMaterial(t *testing.T) {
+	const secretDraft = "CANARY-PENDING-SECRET-do-not-disclose"
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		keys := keySvc(t, db)
+		values := valueSvc(t, db)
+		revisions := &service.Revisions{DB: db, Keyring: probeKeyring(t, db)}
+		scope := scopeEnv(orgA, prjA1, envA1)
+		mustCreateKey(t, keys, scopeProject(orgA, prjA1), "PENDING_SECRET", schema.Secret)
+		if _, err := values.Set(t.Context(), service.LocalPrincipal(custodian), scope, "PENDING_SECRET", secretDraft, nil); err != nil {
+			t.Fatalf("stage secret draft: %v", err)
+		}
+		drafts, err := revisions.PendingDraftsPage(t.Context(), service.LocalPrincipal(custodian), scope, "", 25)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var found bool
+		for _, d := range drafts {
+			if d.Name != "PENDING_SECRET" {
+				continue
+			}
+			found = true
+			if d.Value != "" || d.Revealed || d.Classification != string(schema.Secret) {
+				t.Fatalf("secret draft carried material: %+v", d)
+			}
+		}
+		if !found {
+			t.Fatal("secret draft absent from the page")
+		}
+	})
+}
+
+func TestMCPRevisionsPageMatchesList(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		keys := keySvc(t, db)
+		values := valueSvc(t, db)
+		revisions := &service.Revisions{DB: db, Keyring: probeKeyring(t, db)}
+		scope := scopeEnv(orgA, prjA1, envA1)
+		for i := range 4 {
+			name := fmt.Sprintf("REV_KEY_%02d", i)
+			spec := service.KeySpec{Name: name, Classification: string(schema.Config), Declaration: schema.Declaration{Rule: &schema.Rule{Type: schema.TypeString}}, Presence: schema.DefaultPresenceRules()}
+			if _, err := keys.Create(t.Context(), service.LocalPrincipal(custodian), scopeProject(orgA, prjA1), spec, nil); err != nil {
+				t.Fatalf("create key %d: %v", i, err)
+			}
+			staged, err := values.Set(t.Context(), service.LocalPrincipal(custodian), scope, name, fmt.Sprintf("v-%d", i), nil)
+			if err != nil {
+				t.Fatalf("stage %d: %v", i, err)
+			}
+			if _, err := revisions.PublishPlanned(t.Context(), service.LocalPrincipal(custodian), scope, service.PublishRequest{VersionIDs: []string{staged.VersionID}}); err != nil {
+				t.Fatalf("publish %d: %v", i, err)
+			}
+		}
+		full, err := revisions.History(t.Context(), service.LocalPrincipal(custodian), scope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(full) == 0 {
+			t.Fatal("no revisions published")
+		}
+		var paged []service.RevisionView
+		before := int64(math.MaxInt64)
+		limit := 2
+		for {
+			page, err := revisions.HistoryPage(t.Context(), service.LocalPrincipal(custodian), scope, before, limit)
+			if err != nil {
+				t.Fatalf("history before %d: %v", before, err)
+			}
+			paged = append(paged, page...)
+			if len(page) < limit {
+				break
+			}
+			before = page[len(page)-1].Revision
+		}
+		if len(paged) != len(full) {
+			t.Fatalf("revisions: paged %d, full %d", len(paged), len(full))
+		}
+		for i := range full {
+			if paged[i].Revision != full[i].Revision || paged[i].SchemaRevision != full[i].SchemaRevision {
+				t.Fatalf("revision %d: paged %+v, full %+v", i, paged[i], full[i])
+			}
+			if i > 0 && paged[i-1].Revision <= paged[i].Revision {
+				t.Fatalf("revisions not descending: %d then %d", paged[i-1].Revision, paged[i].Revision)
+			}
+		}
+	})
+}
+
+func assertEnvironmentsEqual(t *testing.T, want, got []service.Environment) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("environment count: want %d, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if want[i].ID != got[i].ID || want[i].Name != got[i].Name {
+			t.Fatalf("environment %d: want %+v, got %+v", i, want[i], got[i])
+		}
+	}
+}

--- a/internal/mcpserver/cursor.go
+++ b/internal/mcpserver/cursor.go
@@ -1,0 +1,152 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Phase-1 pagination and traversal bounds (mcp-server ADR, Pagination and output bounds).
+const (
+	// PageSizeDefault, PageSizeMin, and PageSizeMax bound one page's item count.
+	PageSizeDefault = 25
+	PageSizeMin     = 1
+	PageSizeMax     = 100
+	// CursorMaxBytes bounds an accepted cursor's encoded size.
+	CursorMaxBytes = 2 << 10
+	// CursorTTL is the one chain expiry; continuation never renews it.
+	CursorTTL = 15 * time.Minute
+	// Chain bounds: one cursor chain returns at most MaxChainPages pages,
+	// MaxChainItems items, and MaxChainBytes encoded structured content.
+	MaxChainPages = 10
+	MaxChainItems = 1000
+	MaxChainBytes = 1 << 20
+)
+
+// Named, tenant-safe tool errors. They describe the cursor, a bound, or an
+// argument, never a tenant fact, so the transport surfaces their exact token
+// while every other failure collapses to SafeOperationError.
+var (
+	// ErrInvalidCursor is the single safe response to a missing, tampered,
+	// expired, or scope-mismatched cursor. It never distinguishes which.
+	ErrInvalidCursor = errors.New("invalid_cursor")
+	// ErrTraversalLimitReached is returned when a chain bound is reached; no
+	// continuation cursor accompanies it.
+	ErrTraversalLimitReached = errors.New("traversal_limit_reached")
+	// ErrResultItemTooLarge is returned when the next single valid item cannot
+	// fit within the structured-content bound.
+	ErrResultItemTooLarge = errors.New("result_item_too_large")
+	// ErrInvalidArgument is the safe response to an out-of-range argument.
+	ErrInvalidArgument = errors.New("invalid_argument")
+)
+
+// CursorSealer encrypts and authenticates opaque cursor payloads. It is
+// injected because the crypto chokepoint confines the AEAD to internal/crypto;
+// the transport holds only this narrow verb. Open returns a non-nil error for
+// any tampered, truncated, or forged token, without distinguishing which.
+type CursorSealer interface {
+	Seal(context.Context, []byte) (string, error)
+	Open(context.Context, string) ([]byte, error)
+}
+
+// publicErrorMessage returns the tenant-safe token a named error surfaces, or
+// "" when the error must collapse to SafeOperationError.
+func publicErrorMessage(err error) string {
+	switch {
+	case errors.Is(err, ErrInvalidCursor):
+		return ErrInvalidCursor.Error()
+	case errors.Is(err, ErrTraversalLimitReached):
+		return ErrTraversalLimitReached.Error()
+	case errors.Is(err, ErrResultItemTooLarge):
+		return ErrResultItemTooLarge.Error()
+	case errors.Is(err, ErrInvalidArgument):
+		return ErrInvalidArgument.Error()
+	default:
+		return ""
+	}
+}
+
+type cursorSealerContextKey struct{}
+
+// withCursorSealer attaches the cursor sealer to a request context. The sealer
+// derives from shared authoritative key material, never request data, so
+// cursors are portable across replicas.
+func withCursorSealer(ctx context.Context, sealer CursorSealer) context.Context {
+	return context.WithValue(ctx, cursorSealerContextKey{}, sealer)
+}
+
+func cursorSealerFrom(ctx context.Context) (CursorSealer, bool) {
+	sealer, ok := ctx.Value(cursorSealerContextKey{}).(CursorSealer)
+	return sealer, ok && sealer != nil
+}
+
+// cursorState is the authenticated, opaque continuation. It binds the tool, the
+// exact scope ids, the stable keyset position, the chain counters, and the one
+// chain expiry. It carries no bearer, principal id, tenant name, secret
+// material, or authorization claim.
+type cursorState struct {
+	Version  int    `json:"v"`
+	Tool     string `json:"t"`
+	Org      string `json:"o"`
+	Project  string `json:"p"`
+	Env      string `json:"e"`
+	PageSize int    `json:"s"`
+	// Pos is the keyset position: the last returned item's stable sort key. The
+	// store query fetches strictly past it.
+	Pos string `json:"k"`
+	// Pages, Items, and Bytes are the cumulative chain counters checked against
+	// the chain bounds before the next page is fetched.
+	Pages  int   `json:"n"`
+	Items  int   `json:"i"`
+	Bytes  int   `json:"b"`
+	Expiry int64 `json:"x"`
+}
+
+const cursorVersion = 1
+
+// CursorScope is the tool and immutable id chain a cursor is bound to. A
+// continuation whose scope does not match the presented request is rejected as
+// one safe invalid-cursor error.
+type CursorScope struct {
+	Tool     string
+	Org      string
+	Project  string
+	Env      string
+	PageSize int
+}
+
+func (s CursorScope) matches(c cursorState) bool {
+	return c.Version == cursorVersion && c.Tool == s.Tool &&
+		c.Org == s.Org && c.Project == s.Project && c.Env == s.Env && c.PageSize == s.PageSize
+}
+
+// encodeCursor authenticates and encodes a continuation.
+func encodeCursor(ctx context.Context, sealer CursorSealer, state cursorState) (string, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return sealer.Seal(ctx, payload)
+}
+
+// decodeCursor opens a presented continuation, checking its authentication
+// (via the sealer), scope binding, and chain expiry. Every failure
+// returns the one ErrInvalidCursor; none distinguishes which check failed.
+func decodeCursor(ctx context.Context, sealer CursorSealer, scope CursorScope, raw string, now time.Time) (cursorState, error) {
+	if len(raw) > CursorMaxBytes {
+		return cursorState{}, ErrInvalidCursor
+	}
+	payload, err := sealer.Open(ctx, raw)
+	if err != nil {
+		return cursorState{}, ErrInvalidCursor
+	}
+	var state cursorState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return cursorState{}, ErrInvalidCursor
+	}
+	if !scope.matches(state) || now.UnixMilli() >= state.Expiry {
+		return cursorState{}, ErrInvalidCursor
+	}
+	return state, nil
+}

--- a/internal/mcpserver/cursor_test.go
+++ b/internal/mcpserver/cursor_test.go
@@ -1,0 +1,87 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+)
+
+func TestCursorExpiryIsRejected(t *testing.T) {
+	scope := CursorScope{Tool: "hikyo_list_environments", Org: "org_a", Project: "prj_a", PageSize: 1}
+	raw, err := encodeCursor(t.Context(), testCursorSealer, cursorState{
+		Version: cursorVersion, Tool: scope.Tool, Org: scope.Org, Project: scope.Project,
+		PageSize: 1, Pos: "b", Pages: 1, Items: 1, Expiry: time.Now().Add(-time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeCursor(t.Context(), testCursorSealer, scope, raw, time.Now().UTC()); !errors.Is(err, ErrInvalidCursor) {
+		t.Fatalf("expired cursor decode = %v, want ErrInvalidCursor", err)
+	}
+}
+
+func TestCursorIsRejectedAtExactExpiry(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	scope := CursorScope{Tool: ToolListDefinitions, Org: "org_a", Project: "prj_a", PageSize: 1}
+	state := cursorState{
+		Version: cursorVersion, Tool: scope.Tool, Org: scope.Org, Project: scope.Project,
+		PageSize: scope.PageSize, Pos: "b", Pages: 1, Items: 1, Expiry: now.UnixMilli(),
+	}
+	raw, err := encodeCursor(t.Context(), testCursorSealer, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeCursor(t.Context(), testCursorSealer, scope, raw, now); !errors.Is(err, ErrInvalidCursor) {
+		t.Fatalf("cursor at exact expiry decode = %v, want ErrInvalidCursor", err)
+	}
+}
+
+func TestContinuationDoesNotRenewExpiry(t *testing.T) {
+	ctx := withCursorSealer(context.Background(), testCursorSealer)
+	scope := CursorScope{Tool: "hikyo_list_environments", Org: "org_a", Project: "prj_a", PageSize: 1}
+	source := fakeEnvironments{items: []service.Environment{env("a"), env("b"), env("c"), env("d")}}
+	newSpec := func(cursor string) PageSpec[service.Environment, environmentElement] {
+		return PageSpec[service.Environment, environmentElement]{
+			Scope: scope, Cursor: cursor, PageSize: 1,
+			Fetch: func(ctx context.Context, after string, limit int) ([]service.Environment, error) {
+				afterOrder, afterName, err := parseEnvironmentPosition(after)
+				if err != nil {
+					return nil, err
+				}
+				return source.ListPage(ctx, service.Actor{}, domain.Scope{}, afterOrder, afterName, limit)
+			},
+			Map: mapEnvironment,
+			Key: environmentPosition,
+			StructuredSize: func(items []environmentElement, next string) (int, error) {
+				return encodedSize(environmentsOutput{OrgID: "org_a", ProjectID: "prj_a", Environments: items, NextCursor: next})
+			},
+		}
+	}
+
+	_, cursor1, err := Paginate(ctx, newSpec(""))
+	if err != nil || cursor1 == "" {
+		t.Fatalf("page 1 cursor = %q err %v", cursor1, err)
+	}
+	state1, err := decodeCursor(t.Context(), testCursorSealer, scope, cursor1, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, cursor2, err := Paginate(ctx, newSpec(cursor1))
+	if err != nil || cursor2 == "" {
+		t.Fatalf("page 2 cursor = %q err %v", cursor2, err)
+	}
+	state2, err := decodeCursor(t.Context(), testCursorSealer, scope, cursor2, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state1.Expiry != state2.Expiry {
+		t.Fatalf("continuation renewed the chain expiry: %d then %d", state1.Expiry, state2.Expiry)
+	}
+	if state2.Pages != 2 || state2.Items != 2 {
+		t.Fatalf("chain counters did not advance: %+v", state2)
+	}
+}

--- a/internal/mcpserver/handler.go
+++ b/internal/mcpserver/handler.go
@@ -42,6 +42,13 @@ type Options struct {
 	Admission      discoveryAdmission
 	Version        string
 	MaxConcurrent  int
+	// CursorSealer encrypts and authenticates pagination cursors. Its live key
+	// comes from shared authoritative configuration, so cursors are portable
+	// across replicas and token-key rotation cannot leave a stale cached key.
+	// It is required whenever the registry advertises a paginated tool. New
+	// refuses a non-empty registry without it. The crypto chokepoint confines
+	// the AEAD primitive to internal/crypto.
+	CursorSealer CursorSealer
 }
 
 type handler struct {
@@ -52,6 +59,7 @@ type handler struct {
 	trustedProxies []*net.IPNet
 	admission      discoveryAdmission
 	slots          chan struct{}
+	cursorSealer   CursorSealer
 }
 
 type bearerContextKey struct{}
@@ -91,6 +99,9 @@ func New(options Options) (http.Handler, error) {
 		}
 	}
 	registrations := options.Registry.freeze()
+	if len(registrations) > 0 && options.CursorSealer == nil {
+		return nil, errors.New("mcpserver: a paginated tool registry requires a cursor sealer")
+	}
 	server := mcp.NewServer(&mcp.Implementation{
 		Name: "hikyo", Title: "Hikyo", Description: "Read-only Hikyo configuration tools.", Version: options.Version,
 	}, &mcp.ServerOptions{
@@ -108,6 +119,7 @@ func New(options Options) (http.Handler, error) {
 		allowedOrigins: slices.Clone(options.AllowedOrigins),
 		trustedProxies: slices.Clone(options.TrustedProxies),
 		admission:      options.Admission, slots: make(chan struct{}, concurrency),
+		cursorSealer: options.CursorSealer,
 	}, nil
 }
 
@@ -230,6 +242,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	state := &callState{}
 	ctx = context.WithValue(ctx, callStateContextKey{}, state)
 	ctx = context.WithValue(ctx, bearerContextKey{}, newBearer(bearer))
+	ctx = withCursorSealer(ctx, h.cursorSealer)
 	h.serveSDK(w, r.WithContext(ctx), envelope.Method, envelope.ID, 0, state)
 }
 

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -3,6 +3,9 @@ package mcpserver
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -95,6 +98,34 @@ func request(method, target, rpcMethod, name string, body []byte) *http.Request 
 	return req
 }
 
+// testSealer is a keyed cursor sealer for tests. It uses SHA-256 (unrestricted
+// by the crypto chokepoint) rather than HMAC, which is confined to
+// internal/crypto; production injects crypto.MCPCursorSealer. It is enough to
+// exercise round-trips and tamper rejection.
+type testSealer struct{ key string }
+
+func (s testSealer) Seal(_ context.Context, payload []byte) (string, error) {
+	sum := sha256.Sum256(append([]byte(s.key), payload...))
+	return base64.RawURLEncoding.EncodeToString(append(slices.Clone(payload), sum[:]...)), nil
+}
+
+func (s testSealer) Open(_ context.Context, token string) ([]byte, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) < sha256.Size {
+		return nil, errors.New("mcpserver: invalid test cursor")
+	}
+	payload := raw[:len(raw)-sha256.Size]
+	presented := raw[len(raw)-sha256.Size:]
+	sum := sha256.Sum256(append([]byte(s.key), payload...))
+	if subtle.ConstantTimeCompare(presented, sum[:]) != 1 {
+		return nil, errors.New("mcpserver: invalid test cursor")
+	}
+	return payload, nil
+}
+
+// testCursorSealer authenticates pagination cursors in tests.
+var testCursorSealer = testSealer{key: "mcp-test-cursor-key"}
+
 func testHandler(t *testing.T, registry *Registry) http.Handler {
 	t.Helper()
 	h, err := New(Options{
@@ -102,6 +133,7 @@ func testHandler(t *testing.T, registry *Registry) http.Handler {
 		ExternalOrigin: "https://hikyo.example.com",
 		AllowedOrigins: []string{"https://assistant.example.com"},
 		Version:        "v-test",
+		CursorSealer:   testCursorSealer,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -270,7 +302,7 @@ func TestTrustedProxyAuthorityIsExact(t *testing.T) {
 	}
 	h, err := New(Options{
 		Registry: registry, ExternalOrigin: "https://hikyo.example.com",
-		TrustedProxies: []*net.IPNet{proxyNet}, Version: "v-test",
+		TrustedProxies: []*net.IPNet{proxyNet}, Version: "v-test", CursorSealer: testCursorSealer,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -365,7 +397,7 @@ func TestDiscoveryAdmissionAndToolConcurrencyAreBounded(t *testing.T) {
 	registry, _ := testRegistry(t, "echo")
 	h, err := New(Options{
 		Registry: registry, ExternalOrigin: "https://hikyo.example.com",
-		Admission: fixedAdmission(false), Version: "v-test", MaxConcurrent: 1,
+		Admission: fixedAdmission(false), Version: "v-test", MaxConcurrent: 1, CursorSealer: testCursorSealer,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -390,7 +422,7 @@ func TestDiscoveryAdmissionAndToolConcurrencyAreBounded(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	h, err = New(Options{Registry: blocking, ExternalOrigin: "https://hikyo.example.com", Version: "v-test", MaxConcurrent: 1})
+	h, err = New(Options{Registry: blocking, ExternalOrigin: "https://hikyo.example.com", Version: "v-test", MaxConcurrent: 1, CursorSealer: testCursorSealer})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcpserver/paginate.go
+++ b/internal/mcpserver/paginate.go
@@ -1,0 +1,169 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// PageSpec is one bounded page request the transport resolves on a tool's
+// behalf. Row is the service result element; Elem is the whitelisted output
+// element the tool emits. The tool supplies the fetch, the row-to-element
+// mapping, and the stable keyset accessor; the transport owns cursor
+// authentication, chain bounds, and the output byte fit.
+type PageSpec[Row, Elem any] struct {
+	Scope    CursorScope
+	Cursor   string
+	PageSize int
+	// Fetch returns up to limit rows strictly past the keyset position after
+	// ("" for the first page), in the tool's stable order.
+	Fetch func(ctx context.Context, after string, limit int) ([]Row, error)
+	// Map projects one service row into its whitelisted output element.
+	Map func(Row) (Elem, error)
+	// Key returns one row's stable keyset position (the cursor advances on it).
+	Key func(Row) string
+	// StructuredSize returns the exact encoded structuredContent byte count for
+	// these elements and cursor, including addressed ids and other tool fields.
+	StructuredSize func([]Elem, string) (int, error)
+}
+
+// Paginate resolves one page under the phase-1 cursor, chain, and output-byte
+// bounds. It authenticates the presented cursor against the scope, refuses when
+// a chain bound is reached, fetches one row past the page to detect a
+// continuation, and includes only the elements that fit the structured-content
+// bound. It returns the page's elements and, when a continuation exists, an
+// authenticated next cursor; the caller wraps them in the tool's output.
+func Paginate[Row, Elem any](ctx context.Context, spec PageSpec[Row, Elem]) ([]Elem, string, error) {
+	sealer, ok := cursorSealerFrom(ctx)
+	if !ok {
+		return nil, "", errors.New("mcpserver: cursor sealer unavailable")
+	}
+	if spec.PageSize < PageSizeMin || spec.PageSize > PageSizeMax || spec.Fetch == nil || spec.Map == nil || spec.Key == nil || spec.StructuredSize == nil {
+		return nil, "", ErrInvalidArgument
+	}
+	spec.Scope.PageSize = spec.PageSize
+	now := time.Now().UTC()
+
+	var state cursorState
+	if spec.Cursor == "" {
+		state = cursorState{
+			Version: cursorVersion, Tool: spec.Scope.Tool,
+			Org: spec.Scope.Org, Project: spec.Scope.Project, Env: spec.Scope.Env, PageSize: spec.PageSize,
+			Expiry: now.Add(CursorTTL).UnixMilli(),
+		}
+	} else {
+		decoded, err := decodeCursor(ctx, sealer, spec.Scope, spec.Cursor, now)
+		if err != nil {
+			return nil, "", err
+		}
+		state = decoded
+	}
+
+	// Chain bounds are checked before the next page is fetched, so a probe
+	// cannot spend tenant work past the cap.
+	if state.Pages >= MaxChainPages || state.Items >= MaxChainItems || state.Bytes >= MaxChainBytes {
+		return nil, "", ErrTraversalLimitReached
+	}
+
+	remainingItems := MaxChainItems - state.Items
+	fetchLimit := min(spec.PageSize, remainingItems) + 1
+	rows, err := spec.Fetch(ctx, state.Pos, fetchLimit)
+	if err != nil {
+		return nil, "", err
+	}
+	candidateCount := min(spec.PageSize, remainingItems)
+	morePeeked := len(rows) > candidateCount
+	if morePeeked {
+		rows = rows[:candidateCount]
+	}
+
+	elements := make([]Elem, 0, len(rows))
+	for _, row := range rows {
+		elem, err := spec.Map(row)
+		if err != nil {
+			return nil, "", err
+		}
+		elements = append(elements, elem)
+	}
+
+	if len(elements) == 0 {
+		size, err := spec.StructuredSize(elements, "")
+		if err != nil {
+			return nil, "", err
+		}
+		if size > MaxStructuredContentBytes {
+			return nil, "", ErrResultItemTooLarge
+		}
+		if state.Bytes+size > MaxChainBytes {
+			return nil, "", ErrTraversalLimitReached
+		}
+		return elements, "", nil
+	}
+
+	for count := len(elements); count > 0; count-- {
+		hasMore := morePeeked || count < len(elements)
+		if !hasMore {
+			size, err := spec.StructuredSize(elements[:count], "")
+			if err != nil {
+				return nil, "", err
+			}
+			if size <= MaxStructuredContentBytes && state.Bytes+size <= MaxChainBytes {
+				return elements[:count], "", nil
+			}
+			if count == 1 {
+				if size > MaxStructuredContentBytes {
+					return nil, "", ErrResultItemTooLarge
+				}
+				return nil, "", ErrTraversalLimitReached
+			}
+			continue
+		}
+
+		next := cursorState{
+			Version: cursorVersion, Tool: spec.Scope.Tool,
+			Org: spec.Scope.Org, Project: spec.Scope.Project, Env: spec.Scope.Env, PageSize: spec.PageSize,
+			Pos: spec.Key(rows[count-1]), Pages: state.Pages + 1,
+			Items: state.Items + count, Bytes: state.Bytes, Expiry: state.Expiry,
+		}
+		cursor, size, err := cursorWithExactSize(ctx, sealer, next, elements[:count], spec.StructuredSize)
+		if err != nil {
+			return nil, "", err
+		}
+		// A cursor that already carries a terminal counter is unusable. The
+		// mcp-server ADR requires the current call to refuse with no cursor when
+		// more data exists and this page would reach a chain bound.
+		if next.Pages >= MaxChainPages || next.Items >= MaxChainItems || state.Bytes+size >= MaxChainBytes {
+			return nil, "", ErrTraversalLimitReached
+		}
+		if size <= MaxStructuredContentBytes && state.Bytes+size <= MaxChainBytes {
+			return elements[:count], cursor, nil
+		}
+		if count == 1 {
+			if size > MaxStructuredContentBytes {
+				return nil, "", ErrResultItemTooLarge
+			}
+			return nil, "", ErrTraversalLimitReached
+		}
+	}
+	return nil, "", ErrTraversalLimitReached
+}
+
+func cursorWithExactSize[Elem any](ctx context.Context, sealer CursorSealer, state cursorState, elements []Elem, sizeOf func([]Elem, string) (int, error)) (string, int, error) {
+	previousBytes := state.Bytes
+	for range 8 {
+		cursor, err := encodeCursor(ctx, sealer, state)
+		if err != nil {
+			return "", 0, err
+		}
+		size, err := sizeOf(elements, cursor)
+		if err != nil {
+			return "", 0, err
+		}
+		total := previousBytes + size
+		if total == state.Bytes {
+			return cursor, size, nil
+		}
+		state.Bytes = total
+	}
+	return "", 0, errors.New("mcpserver: cursor byte count did not stabilize")
+}

--- a/internal/mcpserver/registry.go
+++ b/internal/mcpserver/registry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -97,6 +98,15 @@ func NewRegistry() *Registry {
 
 var toolNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
 
+func inputSchemaOptions() *jsonschema.ForOptions {
+	return &jsonschema.ForOptions{TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+		reflect.TypeFor[pageSizeInput](): {
+			Type: "integer", Minimum: jsonschema.Ptr(float64(PageSizeMin)), Maximum: jsonschema.Ptr(float64(PageSizeMax)),
+		},
+		reflect.TypeFor[cursorInput](): {Type: "string", MaxLength: jsonschema.Ptr(CursorMaxBytes)},
+	}}
+}
+
 // Register adds one typed service-operation mapping to the closed registry.
 func Register[In, Out any](registry *Registry, spec ToolSpec, handler func(context.Context, Bearer, In) (Out, error)) error {
 	if registry == nil {
@@ -134,7 +144,7 @@ func Register[In, Out any](registry *Registry, spec ToolSpec, handler func(conte
 	if !policy.ReadOnly || !policy.AuditedNone {
 		return fmt.Errorf("mcpserver: tool %q authorization operation is not an audited-none read", spec.Name)
 	}
-	inputSchema, err := jsonschema.For[In](nil)
+	inputSchema, err := jsonschema.For[In](inputSchemaOptions())
 	if err != nil {
 		return fmt.Errorf("mcpserver: tool %q input schema: %w", spec.Name, err)
 	}
@@ -187,6 +197,14 @@ func Register[In, Out any](registry *Registry, spec ToolSpec, handler func(conte
 					var zero Out
 					if errors.Is(err, ErrRateLimited) {
 						markRateLimited(ctx)
+					}
+					// Named cursor, bound, and argument errors are tenant-safe,
+					// so their exact token crosses the transport; every other
+					// failure collapses to one indistinguishable safe error, so
+					// an unauthorized read stays indistinguishable from a
+					// nonexistent one.
+					if msg := publicErrorMessage(err); msg != "" {
+						return nil, zero, errors.New(msg)
 					}
 					return nil, zero, errors.New(SafeOperationError)
 				}

--- a/internal/mcpserver/registry_test.go
+++ b/internal/mcpserver/registry_test.go
@@ -27,7 +27,7 @@ func TestRegistryRefusesInvalidDuplicateAndLateRows(t *testing.T) {
 	if err := Register(registry, valid, handler); err == nil || !strings.Contains(err.Error(), "duplicate") {
 		t.Fatalf("duplicate registration error = %v", err)
 	}
-	if _, err := New(Options{Registry: registry, ExternalOrigin: "https://hikyo.example.com"}); err != nil {
+	if _, err := New(Options{Registry: registry, ExternalOrigin: "https://hikyo.example.com", CursorSealer: testCursorSealer}); err != nil {
 		t.Fatal(err)
 	}
 	late := valid

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -1,0 +1,508 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/operation"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+)
+
+// This file is the closed phase-1 tool set (#629). Each tool maps to exactly
+// one existing read service operation, repeats current authorization by passing
+// the raw service-account bearer straight to the service, and emits a
+// whitelisted output that carries no secret material. The service interfaces
+// are narrow by construction, so the transport never reaches the datastore and
+// a test can drive a tool with a fake.
+
+// Tool names are stable MCP surface once released.
+const (
+	ToolListDefinitions      = "hikyo_list_definitions"
+	ToolListEnvironments     = "hikyo_list_environments"
+	ToolInspectConfiguration = "hikyo_inspect_configuration"
+	ToolListPendingChanges   = "hikyo_list_pending_changes"
+	ToolListRevisions        = "hikyo_list_revisions"
+)
+
+// Narrow service interfaces. The concrete service structs satisfy them; a test
+// double implements them without a datastore.
+type (
+	// AdmissionService is service.MCPAdmission. It authorizes before claiming
+	// shared rate/concurrency capacity; the page service authorizes again.
+	AdmissionService interface {
+		Acquire(context.Context, service.Actor, authz.Operation, domain.Scope) (func() error, error)
+	}
+	// DefinitionsService is service.Keys.
+	DefinitionsService interface {
+		ListPage(ctx context.Context, actor service.Actor, scope domain.Scope, afterName string, limit int) ([]service.Key, int64, error)
+	}
+	// EnvironmentsService is service.Environments.
+	EnvironmentsService interface {
+		ListPage(ctx context.Context, actor service.Actor, scope domain.Scope, afterDisplayOrder int64, afterName string, limit int) ([]service.Environment, error)
+	}
+	// ConfigurationService is service.Values.
+	ConfigurationService interface {
+		ListPage(ctx context.Context, actor service.Actor, scope domain.Scope, afterName string, limit int) ([]service.ValueCell, error)
+	}
+	// PendingService is service.Revisions.
+	PendingService interface {
+		PendingDraftsPage(ctx context.Context, actor service.Actor, scope domain.Scope, afterKeyID string, limit int) ([]service.PendingDraft, error)
+	}
+	// RevisionsService is service.Revisions.
+	RevisionsService interface {
+		HistoryPage(ctx context.Context, actor service.Actor, scope domain.Scope, beforeRevision int64, limit int) ([]service.RevisionView, error)
+	}
+)
+
+// ProductionServices are the five read services the phase-1 tools map onto. The
+// wiring layer supplies the concrete service structs.
+type ProductionServices struct {
+	Admission     AdmissionService
+	Definitions   DefinitionsService
+	Environments  EnvironmentsService
+	Configuration ConfigurationService
+	Pending       PendingService
+	Revisions     RevisionsService
+}
+
+// Tool input schemas. Every schema requires the full immutable id chain for its
+// operation and accepts optional page_size and cursor. Unknown fields are
+// rejected by the inferred schema's additionalProperties:false.
+type (
+	pageSizeInput struct {
+		value int
+		set   bool
+	}
+	cursorInput string
+
+	projectInput struct {
+		OrgID     string        `json:"org_id" jsonschema:"required,the organization immutable id"`
+		ProjectID string        `json:"project_id" jsonschema:"required,the project immutable id"`
+		PageSize  pageSizeInput `json:"page_size,omitempty" jsonschema:"page size, 1 to 100, default 25"`
+		Cursor    cursorInput   `json:"cursor,omitempty" jsonschema:"opaque continuation from a previous page"`
+	}
+	envInput struct {
+		OrgID         string        `json:"org_id" jsonschema:"required,the organization immutable id"`
+		ProjectID     string        `json:"project_id" jsonschema:"required,the project immutable id"`
+		EnvironmentID string        `json:"environment_id" jsonschema:"required,the environment immutable id"`
+		PageSize      pageSizeInput `json:"page_size,omitempty" jsonschema:"page size, 1 to 100, default 25"`
+		Cursor        cursorInput   `json:"cursor,omitempty" jsonschema:"opaque continuation from a previous page"`
+	}
+)
+
+func (p *pageSizeInput) UnmarshalJSON(data []byte) error {
+	var value int
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	p.value = value
+	p.set = true
+	return nil
+}
+
+// Tool output elements. Each carries only the mcp-server ADR-approved non-secret fields.
+type (
+	definitionElement struct {
+		Name            string               `json:"name"`
+		Description     string               `json:"description"`
+		Classification  string               `json:"classification"`
+		Deprecated      bool                 `json:"deprecated"`
+		DeprecationNote string               `json:"deprecation_note,omitempty"`
+		GroupID         string               `json:"group_id,omitempty"`
+		Declaration     schema.Declaration   `json:"declaration"`
+		Presence        schema.PresenceRules `json:"presence"`
+	}
+	environmentElement struct {
+		ID           string    `json:"id"`
+		Name         string    `json:"name"`
+		Note         string    `json:"note"`
+		DisplayOrder int64     `json:"display_order"`
+		CreatedAt    time.Time `json:"created_at"`
+	}
+	configurationElement struct {
+		KeyID          string    `json:"key_id"`
+		Name           string    `json:"name"`
+		Classification string    `json:"classification"`
+		Set            bool      `json:"set"`
+		Value          string    `json:"value,omitempty"`
+		UpdatedAt      time.Time `json:"updated_at,omitzero"`
+		UpdatedBy      string    `json:"updated_by,omitempty"`
+	}
+	pendingElement struct {
+		VersionID          string    `json:"version_id"`
+		KeyID              string    `json:"key_id"`
+		Name               string    `json:"name"`
+		Classification     string    `json:"classification"`
+		Operation          string    `json:"operation"`
+		StagedFromRevision int64     `json:"staged_from_revision"`
+		CreatedAt          time.Time `json:"created_at"`
+		Value              string    `json:"value,omitempty"`
+	}
+	changedKeyElement struct {
+		Name   string `json:"name"`
+		Change string `json:"change"`
+	}
+	revisionElement struct {
+		Revision        int64               `json:"revision"`
+		SchemaRevision  int64               `json:"schema_revision"`
+		PublishedBy     string              `json:"published_by"`
+		PublishedAt     time.Time           `json:"published_at"`
+		ChangedKeys     []changedKeyElement `json:"changed_keys"`
+		PayloadPresent  bool                `json:"payload_present"`
+		CollectedPolicy string              `json:"collected_policy,omitempty"`
+	}
+)
+
+// Tool outputs repeat the addressed ids and expose next_cursor only when
+// another page exists.
+type (
+	definitionsOutput struct {
+		OrgID          string              `json:"org_id"`
+		ProjectID      string              `json:"project_id"`
+		SchemaRevision int64               `json:"schema_revision"`
+		Definitions    []definitionElement `json:"definitions"`
+		NextCursor     string              `json:"next_cursor,omitempty"`
+	}
+	environmentsOutput struct {
+		OrgID        string               `json:"org_id"`
+		ProjectID    string               `json:"project_id"`
+		Environments []environmentElement `json:"environments"`
+		NextCursor   string               `json:"next_cursor,omitempty"`
+	}
+	configurationOutput struct {
+		OrgID         string                 `json:"org_id"`
+		ProjectID     string                 `json:"project_id"`
+		EnvironmentID string                 `json:"environment_id"`
+		Configuration []configurationElement `json:"configuration"`
+		NextCursor    string                 `json:"next_cursor,omitempty"`
+	}
+	pendingOutput struct {
+		OrgID          string           `json:"org_id"`
+		ProjectID      string           `json:"project_id"`
+		EnvironmentID  string           `json:"environment_id"`
+		PendingChanges []pendingElement `json:"pending_changes"`
+		NextCursor     string           `json:"next_cursor,omitempty"`
+	}
+	revisionsOutput struct {
+		OrgID         string            `json:"org_id"`
+		ProjectID     string            `json:"project_id"`
+		EnvironmentID string            `json:"environment_id"`
+		Revisions     []revisionElement `json:"revisions"`
+		NextCursor    string            `json:"next_cursor,omitempty"`
+	}
+)
+
+// normalizePageSize applies the default and enforces the range. JSON Schema
+// rejects invalid wire input; this check keeps direct typed calls fail-closed.
+func normalizePageSize(input pageSizeInput) (int, error) {
+	if !input.set {
+		return PageSizeDefault, nil
+	}
+	n := input.value
+	if n < PageSizeMin || n > PageSizeMax {
+		return 0, ErrInvalidArgument
+	}
+	return n, nil
+}
+
+// RegisterProductionTools registers the five phase-1 read tools onto a fresh
+// registry. It returns the first registration error, so a boot that cannot pin
+// the closed surface refuses to serve.
+func RegisterProductionTools(registry *Registry, services ProductionServices) error {
+	if services.Admission == nil || services.Definitions == nil || services.Environments == nil ||
+		services.Configuration == nil || services.Pending == nil || services.Revisions == nil {
+		return errors.New("mcpserver: incomplete production services")
+	}
+	for _, register := range []func(*Registry, ProductionServices) error{
+		registerListDefinitions, registerListEnvironments, registerInspectConfiguration,
+		registerListPendingChanges, registerListRevisions,
+	} {
+		if err := register(registry, services); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func withAdmission(ctx context.Context, svc AdmissionService, actor service.Actor, op authz.Operation, scope domain.Scope, call func() error) (err error) {
+	release, err := svc.Acquire(ctx, actor, op, scope)
+	if err != nil {
+		if errors.Is(err, admission.ErrOverloaded) {
+			return ErrRateLimited
+		}
+		return err
+	}
+	defer func() { err = errors.Join(err, release()) }()
+	return call()
+}
+
+func toolSpec(name, title, description, serviceOperation, authorizationOperation string, formula []string) (ToolSpec, error) {
+	contract, err := operation.NewContract("mcp:"+name, authorizationOperation, formula, []string{operation.ArtifactMachineCredential})
+	if err != nil {
+		return ToolSpec{}, err
+	}
+	return ToolSpec{
+		Name: name, Title: title, Description: description,
+		ServiceOperation: serviceOperation, Contract: contract,
+		AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, nil
+}
+
+type toolPageSpec[Row, Elem, Out any] struct {
+	pageSize    pageSizeInput
+	cursor      cursorInput
+	operation   authz.Operation
+	scope       domain.Scope
+	cursorScope CursorScope
+	fetch       func(context.Context, service.Actor, string, int) ([]Row, error)
+	mapRow      func(Row) (Elem, error)
+	key         func(Row) string
+	output      func([]Elem, string) Out
+}
+
+func executeToolPage[Row, Elem, Out any](ctx context.Context, bearer Bearer, admissionService AdmissionService, spec toolPageSpec[Row, Elem, Out]) (Out, error) {
+	var zero Out
+	pageSize, err := normalizePageSize(spec.pageSize)
+	if err != nil {
+		return zero, err
+	}
+	actor := service.Bearer(bearer.raw())
+	var out Out
+	err = withAdmission(ctx, admissionService, actor, spec.operation, spec.scope, func() error {
+		elements, next, err := Paginate(ctx, PageSpec[Row, Elem]{
+			Scope: spec.cursorScope, Cursor: string(spec.cursor), PageSize: pageSize,
+			Fetch: func(ctx context.Context, after string, limit int) ([]Row, error) {
+				return spec.fetch(ctx, actor, after, limit)
+			},
+			Map: spec.mapRow, Key: spec.key,
+			StructuredSize: func(items []Elem, next string) (int, error) {
+				return encodedSize(spec.output(items, next))
+			},
+		})
+		if err != nil {
+			return err
+		}
+		out = spec.output(elements, next)
+		return nil
+	})
+	return out, err
+}
+
+func registerListDefinitions(registry *Registry, services ProductionServices) error {
+	spec, err := toolSpec(ToolListDefinitions, "List key definitions",
+		"Read-only. Requires read@project for explicit org_id/project_id. Lists key declarations, descriptions, classifications, rules, presence policy, and group ids, with no values. Creates no draft, publishes nothing, and requires no user interaction.",
+		"service.Keys.List", "key.list", []string{"read@project"})
+	if err != nil {
+		return err
+	}
+	return Register(registry, spec, func(ctx context.Context, bearer Bearer, in projectInput) (definitionsOutput, error) {
+		scope := domain.Scope{Org: domain.OrgID(in.OrgID), Project: domain.ProjectID(in.ProjectID)}
+		var revision int64
+		return executeToolPage(ctx, bearer, services.Admission, toolPageSpec[service.Key, definitionElement, definitionsOutput]{
+			pageSize: in.PageSize, cursor: in.Cursor, operation: authz.OpKeyList, scope: scope,
+			cursorScope: CursorScope{Tool: ToolListDefinitions, Org: in.OrgID, Project: in.ProjectID},
+			fetch: func(ctx context.Context, actor service.Actor, after string, limit int) ([]service.Key, error) {
+				keys, rev, err := services.Definitions.ListPage(ctx, actor, scope, after, limit)
+				revision = rev
+				return keys, err
+			},
+			mapRow: mapDefinition, key: func(k service.Key) string { return k.Name },
+			output: func(items []definitionElement, next string) definitionsOutput {
+				return definitionsOutput{OrgID: in.OrgID, ProjectID: in.ProjectID, SchemaRevision: revision, Definitions: items, NextCursor: next}
+			},
+		})
+	})
+}
+
+func registerListEnvironments(registry *Registry, services ProductionServices) error {
+	spec, err := toolSpec(ToolListEnvironments, "List environments",
+		"Read-only. Requires read@project for explicit org_id/project_id. Lists environments with identity, name, note, order, and creation metadata. Creates no draft, publishes nothing, and requires no user interaction.",
+		"service.Environments.List", "environment.list", []string{"read@project"})
+	if err != nil {
+		return err
+	}
+	return Register(registry, spec, func(ctx context.Context, bearer Bearer, in projectInput) (environmentsOutput, error) {
+		scope := domain.Scope{Org: domain.OrgID(in.OrgID), Project: domain.ProjectID(in.ProjectID)}
+		return executeToolPage(ctx, bearer, services.Admission, toolPageSpec[service.Environment, environmentElement, environmentsOutput]{
+			pageSize: in.PageSize, cursor: in.Cursor, operation: authz.OpEnvList, scope: scope,
+			cursorScope: CursorScope{Tool: ToolListEnvironments, Org: in.OrgID, Project: in.ProjectID},
+			fetch: func(ctx context.Context, actor service.Actor, after string, limit int) ([]service.Environment, error) {
+				afterOrder, afterName, err := parseEnvironmentPosition(after)
+				if err != nil {
+					return nil, err
+				}
+				return services.Environments.ListPage(ctx, actor, scope, afterOrder, afterName, limit)
+			},
+			mapRow: mapEnvironment, key: environmentPosition,
+			output: func(items []environmentElement, next string) environmentsOutput {
+				return environmentsOutput{OrgID: in.OrgID, ProjectID: in.ProjectID, Environments: items, NextCursor: next}
+			},
+		})
+	})
+}
+
+func registerInspectConfiguration(registry *Registry, services ProductionServices) error {
+	spec, err := toolSpec(ToolInspectConfiguration, "Inspect configuration",
+		"Read-only. Requires read@environment for explicit org_id/project_id/environment_id. Lists configuration cells: config plaintext may appear; a secret carries only classification and set/absent presence, never plaintext. Creates no draft, publishes nothing, and requires no user interaction.",
+		"service.Values.List", "value.list", []string{"read@environment"})
+	if err != nil {
+		return err
+	}
+	return Register(registry, spec, func(ctx context.Context, bearer Bearer, in envInput) (configurationOutput, error) {
+		scope := domain.Scope{Org: domain.OrgID(in.OrgID), Project: domain.ProjectID(in.ProjectID), Env: domain.EnvID(in.EnvironmentID)}
+		return executeToolPage(ctx, bearer, services.Admission, toolPageSpec[service.ValueCell, configurationElement, configurationOutput]{
+			pageSize: in.PageSize, cursor: in.Cursor, operation: authz.OpValueList, scope: scope,
+			cursorScope: CursorScope{Tool: ToolInspectConfiguration, Org: in.OrgID, Project: in.ProjectID, Env: in.EnvironmentID},
+			fetch: func(ctx context.Context, actor service.Actor, after string, limit int) ([]service.ValueCell, error) {
+				return services.Configuration.ListPage(ctx, actor, scope, after, limit)
+			},
+			mapRow: mapConfiguration, key: func(c service.ValueCell) string { return c.Name },
+			output: func(items []configurationElement, next string) configurationOutput {
+				return configurationOutput{OrgID: in.OrgID, ProjectID: in.ProjectID, EnvironmentID: in.EnvironmentID, Configuration: items, NextCursor: next}
+			},
+		})
+	})
+}
+
+func registerListPendingChanges(registry *Registry, services ProductionServices) error {
+	spec, err := toolSpec(ToolListPendingChanges, "List pending changes",
+		"Read-only. Requires read@environment for explicit org_id/project_id/environment_id. Lists the caller's own pending drafts: config draft plaintext may appear; a secret or unset draft never carries material. Creates no draft, publishes nothing, and requires no user interaction.",
+		"service.Revisions.PendingDrafts", "value.pending-list", []string{"read@environment"})
+	if err != nil {
+		return err
+	}
+	return Register(registry, spec, func(ctx context.Context, bearer Bearer, in envInput) (pendingOutput, error) {
+		scope := domain.Scope{Org: domain.OrgID(in.OrgID), Project: domain.ProjectID(in.ProjectID), Env: domain.EnvID(in.EnvironmentID)}
+		return executeToolPage(ctx, bearer, services.Admission, toolPageSpec[service.PendingDraft, pendingElement, pendingOutput]{
+			pageSize: in.PageSize, cursor: in.Cursor, operation: authz.OpValuePendingList, scope: scope,
+			cursorScope: CursorScope{Tool: ToolListPendingChanges, Org: in.OrgID, Project: in.ProjectID, Env: in.EnvironmentID},
+			fetch: func(ctx context.Context, actor service.Actor, after string, limit int) ([]service.PendingDraft, error) {
+				return services.Pending.PendingDraftsPage(ctx, actor, scope, after, limit)
+			},
+			mapRow: mapPending, key: func(d service.PendingDraft) string { return d.KeyID },
+			output: func(items []pendingElement, next string) pendingOutput {
+				return pendingOutput{OrgID: in.OrgID, ProjectID: in.ProjectID, EnvironmentID: in.EnvironmentID, PendingChanges: items, NextCursor: next}
+			},
+		})
+	})
+}
+
+func registerListRevisions(registry *Registry, services ProductionServices) error {
+	spec, err := toolSpec(ToolListRevisions, "List revisions",
+		"Read-only. Requires read@environment for explicit org_id/project_id/environment_id. Lists revision metadata, changed key names, publisher, time, schema revision, and payload-presence state, with no values or change token. Creates no draft, publishes nothing, and requires no user interaction.",
+		"service.Revisions.History", "revision.list", []string{"read@environment"})
+	if err != nil {
+		return err
+	}
+	return Register(registry, spec, func(ctx context.Context, bearer Bearer, in envInput) (revisionsOutput, error) {
+		scope := domain.Scope{Org: domain.OrgID(in.OrgID), Project: domain.ProjectID(in.ProjectID), Env: domain.EnvID(in.EnvironmentID)}
+		return executeToolPage(ctx, bearer, services.Admission, toolPageSpec[service.RevisionView, revisionElement, revisionsOutput]{
+			pageSize: in.PageSize, cursor: in.Cursor, operation: authz.OpRevisionList, scope: scope,
+			cursorScope: CursorScope{Tool: ToolListRevisions, Org: in.OrgID, Project: in.ProjectID, Env: in.EnvironmentID},
+			fetch: func(ctx context.Context, actor service.Actor, after string, limit int) ([]service.RevisionView, error) {
+				return services.Revisions.HistoryPage(ctx, actor, scope, beforeRevisionFrom(after), limit)
+			},
+			mapRow: mapRevision, key: func(v service.RevisionView) string { return strconv.FormatInt(v.Revision, 10) },
+			output: func(items []revisionElement, next string) revisionsOutput {
+				return revisionsOutput{OrgID: in.OrgID, ProjectID: in.ProjectID, EnvironmentID: in.EnvironmentID, Revisions: items, NextCursor: next}
+			},
+		})
+	})
+}
+
+func encodedSize(value any) (int, error) {
+	encoded, err := json.Marshal(value)
+	return len(encoded), err
+}
+
+// beforeRevisionFrom decodes the revision keyset position. The first page ("")
+// starts above the newest revision; a continuation carries the last returned
+// revision as a decimal string.
+func beforeRevisionFrom(after string) int64 {
+	if after == "" {
+		return math.MaxInt64
+	}
+	value, err := strconv.ParseInt(after, 10, 64)
+	if err != nil {
+		return math.MaxInt64
+	}
+	return value
+}
+
+func environmentPosition(environment service.Environment) string {
+	return strconv.FormatInt(environment.DisplayOrder, 10) + "\x00" + environment.Name
+}
+
+func parseEnvironmentPosition(position string) (int64, string, error) {
+	if position == "" {
+		return -1, "", nil
+	}
+	orderText, name, ok := strings.Cut(position, "\x00")
+	if !ok || name == "" {
+		return 0, "", ErrInvalidCursor
+	}
+	order, err := strconv.ParseInt(orderText, 10, 64)
+	if err != nil || order < 0 {
+		return 0, "", ErrInvalidCursor
+	}
+	return order, name, nil
+}
+
+func mapDefinition(k service.Key) (definitionElement, error) {
+	return definitionElement{
+		Name: k.Name, Description: k.Description, Classification: k.Classification,
+		Deprecated: k.Deprecated, DeprecationNote: k.DeprecationNote, GroupID: k.GroupID,
+		Declaration: k.Declaration, Presence: k.Presence,
+	}, nil
+}
+
+func mapEnvironment(e service.Environment) (environmentElement, error) {
+	return environmentElement{
+		ID: e.ID, Name: e.Name, Note: e.Note, DisplayOrder: e.DisplayOrder, CreatedAt: e.CreatedAt,
+	}, nil
+}
+
+func mapConfiguration(c service.ValueCell) (configurationElement, error) {
+	element := configurationElement{
+		KeyID: c.KeyID, Name: c.Name, Classification: c.Classification,
+		Set: c.Set, UpdatedAt: c.UpdatedAt, UpdatedBy: c.UpdatedBy,
+	}
+	// Defense in depth: only a `config` cell carries plaintext, and the service
+	// never opens a `secret` cell on this reveal-false path.
+	if c.Classification == string(schema.Config) {
+		element.Value = c.Value
+	}
+	return element, nil
+}
+
+func mapPending(d service.PendingDraft) (pendingElement, error) {
+	element := pendingElement{
+		VersionID: d.VersionID, KeyID: d.KeyID, Name: d.Name, Classification: d.Classification,
+		Operation: d.Operation, StagedFromRevision: d.StagedFromRevision, CreatedAt: d.CreatedAt,
+	}
+	if d.Classification == string(schema.Config) {
+		element.Value = d.Value
+	}
+	return element, nil
+}
+
+func mapRevision(v service.RevisionView) (revisionElement, error) {
+	changed := make([]changedKeyElement, 0, len(v.ChangedKeys))
+	for _, key := range v.ChangedKeys {
+		changed = append(changed, changedKeyElement{Name: key.Name, Change: key.Change})
+	}
+	return revisionElement{
+		Revision: v.Revision, SchemaRevision: v.SchemaRevision,
+		PublishedBy: v.PublishedBy, PublishedAt: v.PublishedAt, ChangedKeys: changed,
+		PayloadPresent: v.PayloadPresent, CollectedPolicy: v.CollectedPolicy,
+	}, nil
+}

--- a/internal/mcpserver/tools_test.go
+++ b/internal/mcpserver/tools_test.go
@@ -1,0 +1,511 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+)
+
+// fakeEnvironments is a keyset-honouring environment source: it returns items
+// strictly past the display-order/name tuple, up to limit, so a test drives
+// real pagination without a datastore.
+type fakeEnvironments struct{ items []service.Environment }
+
+func (f fakeEnvironments) ListPage(_ context.Context, _ service.Actor, _ domain.Scope, afterOrder int64, afterName string, limit int) ([]service.Environment, error) {
+	var out []service.Environment
+	for _, e := range f.items {
+		if e.DisplayOrder > afterOrder || (e.DisplayOrder == afterOrder && e.Name > afterName) {
+			out = append(out, e)
+			if len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+type fakeConfiguration struct{ cells []service.ValueCell }
+
+func (f fakeConfiguration) ListPage(_ context.Context, _ service.Actor, _ domain.Scope, afterName string, limit int) ([]service.ValueCell, error) {
+	var out []service.ValueCell
+	for _, c := range f.cells {
+		if c.Name > afterName {
+			out = append(out, c)
+			if len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// Unused-in-test stubs so ProductionServices is complete.
+type fakeDefinitions struct{}
+
+func (fakeDefinitions) ListPage(context.Context, service.Actor, domain.Scope, string, int) ([]service.Key, int64, error) {
+	return nil, 0, nil
+}
+
+type fakeRevisions struct{}
+
+func (fakeRevisions) PendingDraftsPage(context.Context, service.Actor, domain.Scope, string, int) ([]service.PendingDraft, error) {
+	return nil, nil
+}
+func (fakeRevisions) HistoryPage(context.Context, service.Actor, domain.Scope, int64, int) ([]service.RevisionView, error) {
+	return nil, nil
+}
+
+type fakeAdmission struct {
+	err        error
+	releaseErr error
+}
+
+func (f fakeAdmission) Acquire(context.Context, service.Actor, authz.Operation, domain.Scope) (func() error, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return func() error { return f.releaseErr }, nil
+}
+
+func toolHandler(t *testing.T, services ProductionServices) http.Handler {
+	t.Helper()
+	registry := NewRegistry()
+	if err := RegisterProductionTools(registry, services); err != nil {
+		t.Fatal(err)
+	}
+	return testHandler(t, registry)
+}
+
+func envServices(items ...service.Environment) ProductionServices {
+	return ProductionServices{
+		Admission:   fakeAdmission{},
+		Definitions: fakeDefinitions{}, Environments: fakeEnvironments{items: items},
+		Configuration: fakeConfiguration{}, Pending: fakeRevisions{}, Revisions: fakeRevisions{},
+	}
+}
+
+// callTool posts one tools/call and returns the decoded JSON-RPC response.
+func callTool(t *testing.T, h http.Handler, name, arguments string) map[string]any {
+	t.Helper()
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", name, modernBody(1, "tools/call", name, arguments))
+	req.Header.Set("Authorization", "Bearer service-account-token")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("tools/call %s = %d %q", name, rec.Code, rec.Body.String())
+	}
+	return decodeResponse(t, rec)
+}
+
+func structuredContent(t *testing.T, response map[string]any) map[string]any {
+	t.Helper()
+	result, ok := response["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no result: %v", response)
+	}
+	structured, ok := result["structuredContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("result has no structuredContent: %v", result)
+	}
+	return structured
+}
+
+func env(name string) service.Environment {
+	return service.Environment{ID: "env_" + name, Name: name, Note: "n-" + name, DisplayOrder: 1}
+}
+
+func TestProductionCatalogListsExactlyTheFiveTools(t *testing.T) {
+	h := toolHandler(t, envServices())
+	response := decodeResponse(t, serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/list", "", modernBody(1, "tools/list", "", ""))))
+	tools := response["result"].(map[string]any)["tools"].([]any)
+	var names []string
+	for _, tool := range tools {
+		entry := tool.(map[string]any)
+		names = append(names, entry["name"].(string))
+		description, _ := entry["description"].(string)
+		for _, required := range []string{"Read-only. Requires read@", "publishes nothing", "requires no user interaction"} {
+			if !strings.Contains(description, required) {
+				t.Fatalf("%s description missing %q: %q", entry["name"], required, description)
+			}
+		}
+	}
+	want := map[string]bool{
+		ToolListDefinitions: true, ToolListEnvironments: true, ToolInspectConfiguration: true,
+		ToolListPendingChanges: true, ToolListRevisions: true,
+	}
+	if len(names) != len(want) {
+		t.Fatalf("catalog = %v", names)
+	}
+	for _, name := range names {
+		if !want[name] {
+			t.Fatalf("unexpected tool %q in %v", name, names)
+		}
+	}
+}
+
+func TestEnvironmentToolPagesThroughCursor(t *testing.T) {
+	h := toolHandler(t, envServices(env("a"), env("b"), env("c"), env("d"), env("e")))
+	var collected []string
+	cursor := ""
+	for range 10 {
+		args := fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":2,"cursor":%q}`, cursor)
+		structured := structuredContent(t, callTool(t, h, ToolListEnvironments, args))
+		if structured["org_id"] != "org_a" || structured["project_id"] != "prj_a" {
+			t.Fatalf("addressed ids not repeated: %v", structured)
+		}
+		for _, item := range structured["environments"].([]any) {
+			collected = append(collected, item.(map[string]any)["name"].(string))
+		}
+		next, ok := structured["next_cursor"].(string)
+		if !ok || next == "" {
+			cursor = ""
+			break
+		}
+		cursor = next
+	}
+	if strings.Join(collected, ",") != "a,b,c,d,e" {
+		t.Fatalf("paged environments = %v", collected)
+	}
+}
+
+func TestEnvironmentToolLastPageOmitsCursor(t *testing.T) {
+	h := toolHandler(t, envServices(env("a"), env("b")))
+	structured := structuredContent(t, callTool(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","page_size":25}`))
+	if _, present := structured["next_cursor"]; present {
+		t.Fatalf("final page carried a cursor: %v", structured)
+	}
+	if len(structured["environments"].([]any)) != 2 {
+		t.Fatalf("environments = %v", structured["environments"])
+	}
+}
+
+func TestCursorTamperIsRejected(t *testing.T) {
+	h := toolHandler(t, envServices(env("a"), env("b"), env("c")))
+	structured := structuredContent(t, callTool(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","page_size":1}`))
+	cursor := structured["next_cursor"].(string)
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		t.Fatalf("decode cursor: %v", err)
+	}
+	raw[len(raw)-1] ^= 0xFF // flip one MAC byte
+	tampered := base64.RawURLEncoding.EncodeToString(raw)
+	args := fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":1,"cursor":%q}`, tampered)
+	body := bodyString(t, h, ToolListEnvironments, args)
+	if !strings.Contains(body, ErrInvalidCursor.Error()) {
+		t.Fatalf("tampered cursor response = %q", body)
+	}
+}
+
+func TestCursorBoundToScope(t *testing.T) {
+	h := toolHandler(t, envServices(env("a"), env("b"), env("c")))
+	structured := structuredContent(t, callTool(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","page_size":1}`))
+	cursor := structured["next_cursor"].(string)
+	// Same cursor, different project: authentication succeeds but the scope
+	// binding does not match, so it is the one safe invalid-cursor error.
+	args := fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_OTHER","page_size":1,"cursor":%q}`, cursor)
+	body := bodyString(t, h, ToolListEnvironments, args)
+	if !strings.Contains(body, ErrInvalidCursor.Error()) {
+		t.Fatalf("cross-scope cursor response = %q", body)
+	}
+}
+
+func TestCursorBoundToPageSize(t *testing.T) {
+	h := toolHandler(t, envServices(env("a"), env("b"), env("c")))
+	structured := structuredContent(t, callTool(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","page_size":1}`))
+	cursor := structured["next_cursor"].(string)
+	body := bodyString(t, h, ToolListEnvironments,
+		fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":2,"cursor":%q}`, cursor))
+	if !strings.Contains(body, ErrInvalidCursor.Error()) {
+		t.Fatalf("changed page size response = %q", body)
+	}
+}
+
+func TestPageSizeOutOfRangeIsRejected(t *testing.T) {
+	h := toolHandler(t, envServices(env("a")))
+	for _, size := range []int{101, 0, -1} {
+		args := fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":%d}`, size)
+		body := bodyString(t, h, ToolListEnvironments, args)
+		if !strings.Contains(body, `"isError":true`) {
+			t.Fatalf("page_size %d response = %q", size, body)
+		}
+	}
+}
+
+func TestSharedAdmissionLimitUsesUniformHTTP429(t *testing.T) {
+	services := envServices(env("a"))
+	services.Admission = fakeAdmission{err: fmt.Errorf("shared coordinator: %w", admission.ErrOverloaded)}
+	h := toolHandler(t, services)
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", ToolListEnvironments,
+		modernBody(1, "tools/call", ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a"}`))
+	req.Header.Set("Authorization", "Bearer service-account-token")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") == "" {
+		t.Fatalf("shared admission response = %d Retry-After %q body %q", rec.Code, rec.Header().Get("Retry-After"), rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "shared coordinator") {
+		t.Fatalf("rate-limit detail leaked: %q", rec.Body.String())
+	}
+}
+
+func TestSharedAdmissionReleaseFailureFailsClosed(t *testing.T) {
+	services := envServices(env("a"))
+	services.Admission = fakeAdmission{releaseErr: errors.New("CANARY-RELEASE-DETAIL")}
+	h := toolHandler(t, services)
+	body := bodyString(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a"}`)
+	if !strings.Contains(body, SafeOperationError) || strings.Contains(body, "CANARY-RELEASE-DETAIL") {
+		t.Fatalf("release failure response = %q", body)
+	}
+}
+
+func TestUnknownArgumentFieldIsRejected(t *testing.T) {
+	h := toolHandler(t, envServices(env("a")))
+	body := bodyString(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","reveal":true}`)
+	// The inferred schema forbids additional properties, so an injected field is
+	// refused with an error before any service work.
+	if !strings.Contains(body, `"isError":true`) || !strings.Contains(body, "additional properties") {
+		t.Fatalf("unknown field not rejected as an error: %q", body)
+	}
+	if strings.Contains(body, `"id":"env_a"`) {
+		t.Fatalf("unknown field was accepted: %q", body)
+	}
+}
+
+func TestInspectDropsSecretPlaintext(t *testing.T) {
+	// The service never opens a secret cell, but the mapping is defence in depth:
+	// even a cell that arrives carrying secret plaintext must emit none.
+	services := ProductionServices{
+		Admission:    fakeAdmission{},
+		Definitions:  fakeDefinitions{},
+		Environments: fakeEnvironments{},
+		Configuration: fakeConfiguration{cells: []service.ValueCell{
+			{KeyID: "k_cfg", Name: "CONFIG_KEY", Classification: string(schema.Config), Set: true, Value: "cfg-plaintext", Revealed: true},
+			{KeyID: "k_sec", Name: "SECRET_KEY", Classification: string(schema.Secret), Set: true, Value: "CANARY-SECRET-PLAINTEXT"},
+		}},
+		Pending: fakeRevisions{}, Revisions: fakeRevisions{},
+	}
+	h := toolHandler(t, services)
+	response := callTool(t, h, ToolInspectConfiguration, `{"org_id":"org_a","project_id":"prj_a","environment_id":"env_a"}`)
+	raw, _ := json.Marshal(response)
+	if strings.Contains(string(raw), "CANARY-SECRET-PLAINTEXT") {
+		t.Fatalf("secret plaintext leaked into inspect result: %s", raw)
+	}
+	cells := structuredContent(t, response)["configuration"].([]any)
+	for _, cell := range cells {
+		c := cell.(map[string]any)
+		if c["classification"] == string(schema.Secret) {
+			if _, hasValue := c["value"]; hasValue {
+				t.Fatalf("secret cell carried a value: %v", c)
+			}
+		}
+		if c["name"] == "CONFIG_KEY" && c["value"] != "cfg-plaintext" {
+			t.Fatalf("config plaintext dropped: %v", c)
+		}
+	}
+}
+
+func TestResultItemTooLargeRefuses(t *testing.T) {
+	huge := service.Environment{ID: "env_big", Name: "big", Note: strings.Repeat("x", 300<<10)}
+	h := toolHandler(t, envServices(huge))
+	body := bodyString(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","page_size":25}`)
+	if !strings.Contains(body, ErrResultItemTooLarge.Error()) {
+		t.Fatalf("oversized single item response = %q", body[:min(len(body), 400)])
+	}
+}
+
+func TestOversizedItemAfterAFittingItemTruncates(t *testing.T) {
+	small := service.Environment{ID: "env_a", Name: "a", Note: "small"}
+	huge := service.Environment{ID: "env_b", Name: "b", Note: strings.Repeat("x", 300<<10)}
+	h := toolHandler(t, envServices(small, huge))
+	structured := structuredContent(t, callTool(t, h, ToolListEnvironments, `{"org_id":"org_a","project_id":"prj_a","page_size":25}`))
+	if items := structured["environments"].([]any); len(items) != 1 || items[0].(map[string]any)["name"] != "a" {
+		t.Fatalf("byte-fit did not truncate to the first item: %v", items)
+	}
+	if next, _ := structured["next_cursor"].(string); next == "" {
+		t.Fatal("byte-truncated page carried no continuation cursor")
+	}
+}
+
+func TestTraversalLimitReached(t *testing.T) {
+	items := make([]service.Environment, 0, 1100)
+	for i := range 1100 {
+		name := fmt.Sprintf("env-%04d", i)
+		items = append(items, service.Environment{ID: "id_" + name, Name: name})
+	}
+	h := toolHandler(t, envServices(items...))
+	cursor := ""
+	pages := 0
+	for {
+		args := fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":100,"cursor":%q}`, cursor)
+		body := bodyString(t, h, ToolListEnvironments, args)
+		if strings.Contains(body, ErrTraversalLimitReached.Error()) {
+			if strings.Contains(body, "next_cursor") {
+				t.Fatalf("traversal limit carried a continuation cursor: %q", body[:min(len(body), 300)])
+			}
+			break
+		}
+		structured := structuredContent(t, decode(t, body))
+		pages++
+		next, ok := structured["next_cursor"].(string)
+		if !ok || next == "" {
+			t.Fatalf("chain ended without reaching the traversal bound after %d pages", pages)
+		}
+		cursor = next
+		if pages > 12 {
+			t.Fatal("chain never hit the 10-page bound")
+		}
+	}
+	if pages != MaxChainPages-1 {
+		t.Fatalf("returned %d pages before the bound, want %d", pages, MaxChainPages-1)
+	}
+}
+
+func TestFinalPageMayReachTraversalPageBound(t *testing.T) {
+	items := make([]service.Environment, 0, MaxChainPages)
+	for i := range MaxChainPages {
+		name := fmt.Sprintf("env-%04d", i)
+		items = append(items, service.Environment{ID: "id_" + name, Name: name})
+	}
+	h := toolHandler(t, envServices(items...))
+	cursor := ""
+	for page := range MaxChainPages {
+		body := bodyString(t, h, ToolListEnvironments,
+			fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":1,"cursor":%q}`, cursor))
+		if strings.Contains(body, ErrTraversalLimitReached.Error()) {
+			t.Fatalf("final page %d refused at exact bound: %q", page+1, body[:min(len(body), 300)])
+		}
+		structured := structuredContent(t, decode(t, body))
+		next, _ := structured["next_cursor"].(string)
+		if page == MaxChainPages-1 {
+			if next != "" {
+				t.Fatalf("final bounded page carried cursor: %q", next)
+			}
+			continue
+		}
+		if next == "" {
+			t.Fatalf("page %d ended early", page+1)
+		}
+		cursor = next
+	}
+}
+
+func TestTraversalByteLimitCountsExactStructuredContent(t *testing.T) {
+	items := make([]service.Environment, 0, 6)
+	for i := range 6 {
+		name := fmt.Sprintf("env-%d", i)
+		items = append(items, service.Environment{ID: "id_" + name, Name: name, Note: strings.Repeat("x", 220<<10)})
+	}
+	h := toolHandler(t, envServices(items...))
+	cursor := ""
+	cumulative := 0
+	pages := 0
+	for {
+		body := bodyString(t, h, ToolListEnvironments,
+			fmt.Sprintf(`{"org_id":"org_a","project_id":"prj_a","page_size":1,"cursor":%q}`, cursor))
+		if strings.Contains(body, ErrTraversalLimitReached.Error()) {
+			if strings.Contains(body, "next_cursor") {
+				t.Fatalf("byte limit error carried cursor: %q", body[:min(len(body), 400)])
+			}
+			break
+		}
+		structured := structuredContent(t, decode(t, body))
+		encoded, err := json.Marshal(structured)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cumulative += len(encoded)
+		pages++
+		cursor = structured["next_cursor"].(string)
+		state, err := decodeCursor(t.Context(), testCursorSealer, CursorScope{
+			Tool: ToolListEnvironments, Org: "org_a", Project: "prj_a", PageSize: 1,
+		}, cursor, time.Now().UTC())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state.Bytes != cumulative {
+			t.Fatalf("cursor bytes = %d, exact structuredContent = %d", state.Bytes, cumulative)
+		}
+	}
+	if pages != 4 {
+		t.Fatalf("returned %d large pages before 1 MiB bound, want 4", pages)
+	}
+}
+
+func TestProductionRegistryRowsArePinned(t *testing.T) {
+	registry := NewRegistry()
+	if err := RegisterProductionTools(registry, envServices()); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]struct {
+		serviceOp, authzOp string
+		formula            []string
+	}{
+		ToolListDefinitions:      {"service.Keys.List", "key.list", []string{"read@project"}},
+		ToolListEnvironments:     {"service.Environments.List", "environment.list", []string{"read@project"}},
+		ToolInspectConfiguration: {"service.Values.List", "value.list", []string{"read@environment"}},
+		ToolListPendingChanges:   {"service.Revisions.PendingDrafts", "value.pending-list", []string{"read@environment"}},
+		ToolListRevisions:        {"service.Revisions.History", "revision.list", []string{"read@environment"}},
+	}
+	rows := registry.Rows()
+	if len(rows) != len(want) {
+		t.Fatalf("registry has %d rows, want %d", len(rows), len(want))
+	}
+	for _, row := range rows {
+		expected, ok := want[row.Name]
+		if !ok {
+			t.Fatalf("unexpected tool %q", row.Name)
+		}
+		if row.ServiceOperation != expected.serviceOp || row.AuthorizationOperation != expected.authzOp {
+			t.Fatalf("%s ops = %q / %q", row.Name, row.ServiceOperation, row.AuthorizationOperation)
+		}
+		if strings.Join(row.Formula, "+") != strings.Join(expected.formula, "+") {
+			t.Fatalf("%s formula = %v", row.Name, row.Formula)
+		}
+		if len(row.Artifacts) != 1 || row.Artifacts[0] != "machine-credential" {
+			t.Fatalf("%s artifacts = %v", row.Name, row.Artifacts)
+		}
+		if !row.ReadOnly || row.AuditDisposition != AuditDispositionNone || row.SecretPolicy != SecretPolicyNoSecretMaterial {
+			t.Fatalf("%s policy = readOnly %v audit %q secret %q", row.Name, row.ReadOnly, row.AuditDisposition, row.SecretPolicy)
+		}
+		schema := string(row.InputSchema)
+		if !strings.Contains(schema, `"additionalProperties":false`) {
+			t.Fatalf("%s input schema allows unknown fields: %s", row.Name, schema)
+		}
+		for _, id := range []string{"org_id", "project_id"} {
+			if !strings.Contains(schema, `"`+id+`"`) {
+				t.Fatalf("%s input schema missing %s: %s", row.Name, id, schema)
+			}
+		}
+		for _, constraint := range []string{`"minimum":1`, `"maximum":100`, `"maxLength":2048`} {
+			if !strings.Contains(schema, constraint) {
+				t.Fatalf("%s input schema missing %s: %s", row.Name, constraint, schema)
+			}
+		}
+	}
+}
+
+func decode(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var response map[string]any
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		t.Fatalf("decode %q: %v", body, err)
+	}
+	return response
+}
+
+func bodyString(t *testing.T, h http.Handler, name, arguments string) string {
+	t.Helper()
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", name, modernBody(1, "tools/call", name, arguments))
+	req.Header.Set("Authorization", "Bearer service-account-token")
+	return serve(t, h, req).Body.String()
+}

--- a/internal/service/group_index_test.go
+++ b/internal/service/group_index_test.go
@@ -231,5 +231,14 @@ func (c *countingGroupIndexCatalogue) ListPresence(context.Context, authz.Proof)
 func (c *countingGroupIndexCatalogue) SchemaRevision(context.Context, authz.Proof) (int64, error) {
 	return 0, errors.New("unexpected SchemaRevision")
 }
+func (c *countingGroupIndexCatalogue) ListPage(context.Context, authz.Proof, string, int) ([]store.CatalogueKey, error) {
+	return nil, errors.New("unexpected ListPage")
+}
+func (c *countingGroupIndexCatalogue) GetInProject(context.Context, authz.Proof, string) (store.CatalogueKey, error) {
+	return store.CatalogueKey{}, errors.New("unexpected GetInProject")
+}
+func (c *countingGroupIndexCatalogue) PresenceForKey(context.Context, authz.Proof, string) ([]store.KeyPresence, error) {
+	return nil, errors.New("unexpected PresenceForKey")
+}
 
 var _ store.CatalogueReader = (*countingGroupIndexCatalogue)(nil)

--- a/internal/service/mcp_admission.go
+++ b/internal/service/mcp_admission.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/admission"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+// MCPAdmission performs the shared phase-1 rate and concurrency admission.
+// It first resolves and authorizes inside a read transaction, so guessed scope
+// ids cannot occupy tenant capacity. The actual page service repeats both
+// checks in its own transaction after admission; the principal id returned by
+// the first transaction is only a limiter key and never authorization state.
+type MCPAdmission struct {
+	DB *store.DB
+}
+
+const (
+	mcpAdmissionLeaseTTL       = 35 * time.Second
+	mcpAdmissionCleanupTimeout = time.Second
+)
+
+func mcpCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), mcpAdmissionCleanupTimeout)
+}
+
+// Acquire authorizes one closed MCP read operation, then atomically charges
+// its datastore-coordinated token bucket and claims 4/principal, 8/org, and
+// 64/instance capacity. Release is synchronous and safe to call once.
+func (s *MCPAdmission) Acquire(ctx context.Context, actor Actor, op authz.Operation, scope domain.Scope) (func() error, error) {
+	if s == nil || s.DB == nil {
+		return nil, errors.New("service: MCP admission unavailable")
+	}
+	switch op {
+	case authz.OpKeyList, authz.OpEnvList, authz.OpValueList, authz.OpValuePendingList, authz.OpRevisionList:
+	default:
+		return nil, fmt.Errorf("service: unsupported MCP admission operation %q", op)
+	}
+
+	var principal domain.PrincipalID
+	err := tx.Read(ctx, s.DB, func(ctx context.Context, _ store.ReadRepos, az *authz.TxAuthorizer) error {
+		caller, _, err := authorize(ctx, az, actor, op, scope, time.Now().UTC())
+		if err == nil {
+			principal = caller.Principal
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	callID, err := newID("mcp_call")
+	if err != nil {
+		return nil, err
+	}
+	if err := s.DB.Coordination().AcquireMCP(ctx, callID, string(principal), string(scope.Org), mcpAdmissionLeaseTTL); err != nil {
+		if errors.Is(err, store.ErrMCPAdmissionLimited) {
+			return nil, fmt.Errorf("%w: service: MCP shared admission exhausted", admission.ErrOverloaded)
+		}
+		return nil, err
+	}
+	return func() error {
+		cleanupCtx, cancel := mcpCleanupContext(ctx)
+		defer cancel()
+		return s.DB.Coordination().ReleaseMCP(cleanupCtx, callID)
+	}, nil
+}

--- a/internal/service/mcp_admission_test.go
+++ b/internal/service/mcp_admission_test.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMCPCleanupContextSurvivesRequestCancellation(t *testing.T) {
+	requestCtx, cancelRequest := context.WithCancel(t.Context())
+	cancelRequest()
+
+	cleanupCtx, cancelCleanup := mcpCleanupContext(requestCtx)
+	defer cancelCleanup()
+
+	select {
+	case <-cleanupCtx.Done():
+		t.Fatalf("cleanup context inherited request cancellation: %v", cleanupCtx.Err())
+	default:
+	}
+	deadline, ok := cleanupCtx.Deadline()
+	if !ok || time.Until(deadline) > mcpAdmissionCleanupTimeout {
+		t.Fatalf("cleanup context deadline = %v, want at most %v", deadline, mcpAdmissionCleanupTimeout)
+	}
+}

--- a/internal/service/mcp_page.go
+++ b/internal/service/mcp_page.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+// This file holds the bounded keyset page reads the MCP adapter maps its five
+// tools onto (#629). Each mirrors its unbounded sibling exactly -- same
+// authorization operation, same transaction, same in-transaction identity
+// resolution -- and differs only by pushing the cursor and limit into the store
+// query, so no whole collection is materialized to slice a limit afterwards.
+// The transport owns the opaque cursor; a method here takes only the decoded
+// keyset position and the page size.
+
+// ListPage is the bounded keyset read behind hikyo_list_environments. The
+// stable order matches List exactly: display order then UNIQUE environment
+// name. afterDisplayOrder is -1 and afterName is "" for the first page.
+func (s *Environments) ListPage(ctx context.Context, actor Actor, scope domain.Scope, afterDisplayOrder int64, afterName string, limit int) ([]Environment, error) {
+	var rows []store.Environment
+	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		_, p, err := authorize(ctx, az, actor, authz.OpEnvList, scope, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		rows, err = r.Environments().ListPage(ctx, p, afterDisplayOrder, afterName, limit)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Environment, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, environmentOf(row))
+	}
+	return out, nil
+}
+
+// ListPage is the bounded keyset read behind hikyo_list_definitions. The stable
+// order is the UNIQUE key name; afterName is "" for the first page. Presence is
+// resolved per page key, never by listing the project's presence rows. The
+// schema revision rides along exactly as the unbounded List returns it.
+func (s *Keys) ListPage(ctx context.Context, actor Actor, scope domain.Scope, afterName string, limit int) ([]Key, int64, error) {
+	var out []Key
+	var revision int64
+	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		_, p, err := authorize(ctx, az, actor, authz.OpKeyList, scope, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		rows, err := r.Catalogue().ListPage(ctx, p, afterName, limit)
+		if err != nil {
+			return err
+		}
+		revision, err = r.Catalogue().SchemaRevision(ctx, p)
+		if err != nil {
+			return err
+		}
+		out = make([]Key, 0, len(rows))
+		for _, row := range rows {
+			presence, err := r.Catalogue().PresenceForKey(ctx, p, row.ID)
+			if err != nil {
+				return err
+			}
+			key, err := keyOf(row, presence)
+			if err != nil {
+				return err
+			}
+			out = append(out, key)
+		}
+		return nil
+	})
+	return out, revision, err
+}
+
+// ListPage is the bounded keyset read behind hikyo_inspect_configuration. It
+// pages the catalogue by the UNIQUE key name and resolves each page key's cell
+// with a point read; reveal is always false, so `config` plaintext appears and
+// a `secret` cell carries only its classification and set/absent presence.
+func (s *Values) ListPage(ctx context.Context, actor Actor, scope domain.Scope, afterName string, limit int) ([]ValueCell, error) {
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValueList, scope)
+	if err != nil {
+		return nil, err
+	}
+	var out []ValueCell
+	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		_, p, err := authorize(ctx, az, actor, authz.OpValueList, scope, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		keys, err := r.Catalogue().ListPage(ctx, p, afterName, limit)
+		if err != nil {
+			return err
+		}
+		out = make([]ValueCell, 0, len(keys))
+		for _, key := range keys {
+			cell := ValueCell{KeyID: key.ID, Name: key.Name, Classification: key.Classification}
+			entry, err := r.Values().Get(ctx, p, key.ID)
+			switch {
+			case errors.Is(err, domain.ErrNotFound):
+				// `absent`: not an error, not a fallback.
+			case err != nil:
+				return err
+			default:
+				cell.Set = true
+				cell.UpdatedAt = entry.UpdatedAt
+				cell.UpdatedBy = entry.UpdatedBy
+				// `config` plaintext rides `read`; `secret` plaintext is never
+				// opened on this reveal-false path.
+				if key.Classification == string(schema.Config) {
+					plain, err := openCell(sealer, entry)
+					if err != nil {
+						return err
+					}
+					cell.Value = plain
+					cell.Revealed = true
+				}
+			}
+			out = append(out, cell)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// PendingDraftsPage is the bounded keyset read behind hikyo_list_pending_changes.
+// The owner is the caller resolved inside the transaction, and the stable order
+// is the UNIQUE draft key_id; afterKeyID is "" for the first page. `config`
+// draft plaintext may appear; a `secret` or unset draft never carries material.
+func (s *Revisions) PendingDraftsPage(ctx context.Context, actor Actor, scope domain.Scope, afterKeyID string, limit int) ([]PendingDraft, error) {
+	sealer, err := sealerFor(ctx, s.DB, s.Keyring, actor, authz.OpValuePendingList, scope)
+	if err != nil {
+		return nil, err
+	}
+	var out []PendingDraft
+	err = tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		out = nil
+		caller, p, err := authorize(ctx, az, actor, authz.OpValuePendingList, scope, s.now())
+		if err != nil {
+			return err
+		}
+		changes, err := r.Pending().ListForOwnerInEnvironmentPage(ctx, p, string(caller.Principal), afterKeyID, limit)
+		if err != nil {
+			return err
+		}
+		out = make([]PendingDraft, 0, len(changes))
+		for _, change := range changes {
+			key, err := r.Catalogue().GetInProject(ctx, p, change.KeyID)
+			if err != nil {
+				return fmt.Errorf("service: pending change %s references key %s: %w", change.ID, change.KeyID, err)
+			}
+			draft := PendingDraft{
+				VersionID: change.ID, KeyID: change.KeyID, Name: key.Name,
+				Classification: key.Classification, Operation: string(change.Operation),
+				StagedFromRevision: change.StagedFromRevision, CreatedAt: change.CreatedAt,
+			}
+			// MaterialSecret is sticky across restores. A historically secret
+			// value must never become readable merely because the key is now
+			// config.
+			if change.Operation == store.PendingSet && key.Classification == string(schema.Config) && !change.MaterialSecret {
+				plain, err := sealer.OpenField(pendingAAD(
+					change.OrgID, change.ProjectID, change.EnvironmentID, change.KeyID, change.ID), change.Ciphertext)
+				if err != nil {
+					return fmt.Errorf("service: pending change %s: %w", change.ID, err)
+				}
+				draft.Revealed = true
+				draft.Value = string(plain)
+			}
+			out = append(out, draft)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// HistoryPage is the bounded keyset read behind hikyo_list_revisions. The stable
+// order is the UNIQUE revision, descending; beforeRevision is a sentinel above
+// the newest revision for the first page. It returns revision metadata only, no
+// historical values and no change token.
+func (s *Revisions) HistoryPage(ctx context.Context, actor Actor, scope domain.Scope, beforeRevision int64, limit int) ([]RevisionView, error) {
+	var out []RevisionView
+	err := tx.Read(ctx, s.DB, func(ctx context.Context, r store.ReadRepos, az *authz.TxAuthorizer) error {
+		out = nil
+		_, p, err := authorize(ctx, az, actor, authz.OpRevisionList, scope, s.now())
+		if err != nil {
+			return err
+		}
+		snapshots, err := r.Snapshots().ListPage(ctx, p, beforeRevision, limit)
+		if err != nil {
+			return err
+		}
+		for _, snapshot := range snapshots {
+			changes, err := r.Snapshots().Changes(ctx, p, snapshot.Revision)
+			if err != nil {
+				return err
+			}
+			out = append(out, RevisionView{
+				Revision: snapshot.Revision, SchemaRevision: snapshot.SchemaRevision,
+				PublishedBy: snapshot.PublishedBy, PublishedAt: snapshot.PublishedAt,
+				ChangedKeys:    changedKeys(changes),
+				PayloadPresent: snapshot.PayloadPresent(), CollectedPolicy: snapshot.CollectionPolicy(),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/store/catalogue.go
+++ b/internal/store/catalogue.go
@@ -122,6 +122,17 @@ const (
 type CatalogueReader interface {
 	Get(ctx context.Context, p authz.Proof, id string) (CatalogueKey, error)
 	List(ctx context.Context, p authz.Proof) ([]CatalogueKey, error)
+	// ListPage is the bounded keyset read (#629): one page of keys ordered by
+	// the UNIQUE name column, strictly past afterName ("" for the first page),
+	// fetching at most limit rows.
+	ListPage(ctx context.Context, p authz.Proof, afterName string, limit int) ([]CatalogueKey, error)
+	// GetInProject resolves one key by id under the key.list store authorization
+	// (StoreCatalogueList), so a page-bounded caller can attach a key's name and
+	// classification without a whole-catalogue read. ErrNotFound when absent.
+	GetInProject(ctx context.Context, p authz.Proof, id string) (CatalogueKey, error)
+	// PresenceForKey returns one key's explicit presence rows, so a bounded page
+	// resolves presence per page key instead of listing the project's rows.
+	PresenceForKey(ctx context.Context, p authz.Proof, keyID string) ([]KeyPresence, error)
 	// Count is the per-project key cap's input, read inside the same
 	// transaction as the insert it bounds.
 	Count(ctx context.Context, p authz.Proof) (int64, error)

--- a/internal/store/coordination.go
+++ b/internal/store/coordination.go
@@ -33,7 +33,20 @@ const (
 	IPBucket      = "ip"
 	MetaBucket    = "meta"
 	IssuerBucket  = "issuer"
+
+	// MCP admission is shared across replicas. One token is restored each
+	// second (60/minute), with at most 20 immediately available. In-flight
+	// calls are bounded independently by principal, organization, and instance.
+	MCPRateCapacity       = 20
+	MCPRateRefillInterval = time.Second
+	MCPPrincipalLimit     = 4
+	MCPOrganizationLimit  = 8
+	MCPInstanceLimit      = 64
 )
+
+// ErrMCPAdmissionLimited is the non-distinguishing shared rate/concurrency
+// refusal. The transport translates it to the uniform authenticated 429.
+var ErrMCPAdmissionLimited = errors.New("store: MCP admission limit reached")
 
 func isNoRows(err error) bool {
 	return errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows)
@@ -435,6 +448,161 @@ func (c *Coordination) BumpWindow(ctx context.Context, bucket, subject string, w
 		return 0, fmt.Errorf("store: bump admission window %s/%s: %w", bucket, subject, err)
 	}
 	return count, nil
+}
+
+// The MCP claim lock serializes only the short datastore admission decision.
+// Calls themselves run concurrently after commit and are represented by
+// expiring rows. A crashed replica therefore releases capacity automatically.
+const mcpAdmissionAdvisoryClass = 88
+
+// AcquireMCP atomically charges the principal token bucket and claims all
+// three concurrency dimensions. No rate token is consumed unless every
+// concurrency dimension has room. The PostgreSQL clock is authoritative;
+// SQLite is single-node and uses the process clock like Coordination.Now.
+func (c *Coordination) AcquireMCP(ctx context.Context, callID, principalID, orgID string, ttl time.Duration) error {
+	if callID == "" || principalID == "" || orgID == "" || ttl <= 0 {
+		return errors.New("store: invalid MCP admission claim")
+	}
+	switch c.db.engine {
+	case EnginePostgres:
+		return c.acquireMCPPostgres(ctx, callID, principalID, orgID, ttl)
+	case EngineSQLite:
+		return c.acquireMCPSQLite(ctx, callID, principalID, orgID, ttl)
+	default:
+		return fmt.Errorf("store: MCP admission claim on unknown engine %q", c.db.engine)
+	}
+}
+
+func (c *Coordination) acquireMCPPostgres(ctx context.Context, callID, principalID, orgID string, ttl time.Duration) error {
+	tx, err := c.db.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: MCP admission begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1, $2)`, coordinationAdvisoryNamespace, mcpAdmissionAdvisoryClass); err != nil {
+		return fmt.Errorf("store: MCP admission lock: %w", err)
+	}
+	var now time.Time
+	if err := tx.QueryRow(ctx, `SELECT now()`).Scan(&now); err != nil {
+		return fmt.Errorf("store: MCP admission clock: %w", err)
+	}
+	now = now.UTC()
+	if _, err := tx.Exec(ctx, `DELETE FROM mcp_inflight WHERE expires_at <= $1`, now); err != nil {
+		return fmt.Errorf("store: prune MCP claims: %w", err)
+	}
+	var principalCount, orgCount, instanceCount int64
+	if err := tx.QueryRow(ctx, `SELECT
+		COUNT(*) FILTER (WHERE principal_id = $1),
+		COUNT(*) FILTER (WHERE org_id = $2),
+		COUNT(*)
+		FROM mcp_inflight`, principalID, orgID).Scan(&principalCount, &orgCount, &instanceCount); err != nil {
+		return fmt.Errorf("store: count MCP claims: %w", err)
+	}
+	if principalCount >= MCPPrincipalLimit || orgCount >= MCPOrganizationLimit || instanceCount >= MCPInstanceLimit {
+		return ErrMCPAdmissionLimited
+	}
+
+	nextAt := now
+	err = tx.QueryRow(ctx, `SELECT next_at FROM mcp_rate_buckets WHERE principal_id = $1 FOR UPDATE`, principalID).Scan(&nextAt)
+	if err != nil && !isNoRows(err) {
+		return fmt.Errorf("store: read MCP rate bucket: %w", err)
+	}
+	if nextAt.After(now.Add(time.Duration(MCPRateCapacity-1) * MCPRateRefillInterval)) {
+		return ErrMCPAdmissionLimited
+	}
+	if nextAt.Before(now) {
+		nextAt = now
+	}
+	nextAt = nextAt.Add(MCPRateRefillInterval)
+	if _, err := tx.Exec(ctx, `INSERT INTO mcp_rate_buckets (principal_id, next_at) VALUES ($1, $2)
+		ON CONFLICT (principal_id) DO UPDATE SET next_at = EXCLUDED.next_at`, principalID, nextAt); err != nil {
+		return fmt.Errorf("store: update MCP rate bucket: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO mcp_inflight (call_id, principal_id, org_id, expires_at) VALUES ($1, $2, $3, $4)`,
+		callID, principalID, orgID, now.Add(ttl)); err != nil {
+		return fmt.Errorf("store: insert MCP claim: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("store: commit MCP admission: %w", err)
+	}
+	return nil
+}
+
+func (c *Coordination) acquireMCPSQLite(ctx context.Context, callID, principalID, orgID string, ttl time.Duration) error {
+	tx, err := c.db.sqWrite.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("store: MCP admission begin: %w", err)
+	}
+	defer tx.Rollback()
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM mcp_inflight WHERE expires_at <= ?`, fixedStamp(now)); err != nil {
+		return fmt.Errorf("store: prune MCP claims: %w", err)
+	}
+	var principalCount, orgCount, instanceCount int64
+	if err := tx.QueryRowContext(ctx, `SELECT
+		COALESCE(SUM(CASE WHEN principal_id = ? THEN 1 ELSE 0 END), 0),
+		COALESCE(SUM(CASE WHEN org_id = ? THEN 1 ELSE 0 END), 0),
+		COUNT(*)
+		FROM mcp_inflight`, principalID, orgID).Scan(&principalCount, &orgCount, &instanceCount); err != nil {
+		return fmt.Errorf("store: count MCP claims: %w", err)
+	}
+	if principalCount >= MCPPrincipalLimit || orgCount >= MCPOrganizationLimit || instanceCount >= MCPInstanceLimit {
+		return ErrMCPAdmissionLimited
+	}
+
+	nextAt := now
+	var nextRaw string
+	err = tx.QueryRowContext(ctx, `SELECT next_at FROM mcp_rate_buckets WHERE principal_id = ?`, principalID).Scan(&nextRaw)
+	switch {
+	case isNoRows(err):
+	case err != nil:
+		return fmt.Errorf("store: read MCP rate bucket: %w", err)
+	default:
+		nextAt, err = parseStamp(nextRaw)
+		if err != nil {
+			return fmt.Errorf("store: parse MCP rate bucket: %w", err)
+		}
+	}
+	if nextAt.After(now.Add(time.Duration(MCPRateCapacity-1) * MCPRateRefillInterval)) {
+		return ErrMCPAdmissionLimited
+	}
+	if nextAt.Before(now) {
+		nextAt = now
+	}
+	nextAt = nextAt.Add(MCPRateRefillInterval)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO mcp_rate_buckets (principal_id, next_at) VALUES (?, ?)
+		ON CONFLICT (principal_id) DO UPDATE SET next_at = excluded.next_at`, principalID, fixedStamp(nextAt)); err != nil {
+		return fmt.Errorf("store: update MCP rate bucket: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO mcp_inflight (call_id, principal_id, org_id, expires_at) VALUES (?, ?, ?, ?)`,
+		callID, principalID, orgID, fixedStamp(now.Add(ttl))); err != nil {
+		return fmt.Errorf("store: insert MCP claim: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit MCP admission: %w", err)
+	}
+	return nil
+}
+
+// ReleaseMCP releases one successful claim. A missing or already-expired id is
+// harmless. Callers still fail closed on datastore errors.
+func (c *Coordination) ReleaseMCP(ctx context.Context, callID string) error {
+	if callID == "" {
+		return errors.New("store: empty MCP admission call id")
+	}
+	var err error
+	switch c.db.engine {
+	case EnginePostgres:
+		_, err = c.db.pool.Exec(ctx, `DELETE FROM mcp_inflight WHERE call_id = $1`, callID)
+	case EngineSQLite:
+		_, err = c.db.sqWrite.ExecContext(ctx, `DELETE FROM mcp_inflight WHERE call_id = ?`, callID)
+	default:
+		return fmt.Errorf("store: MCP admission release on unknown engine %q", c.db.engine)
+	}
+	if err != nil {
+		return fmt.Errorf("store: release MCP claim: %w", err)
+	}
+	return nil
 }
 
 // AccountFailureState reports an account subject's consecutive-failure count,

--- a/internal/store/coordination_test.go
+++ b/internal/store/coordination_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -212,4 +213,110 @@ func runCoordinationInvariants(t *testing.T, db *store.DB) {
 			t.Fatalf("cleanup prune: %v", err)
 		}
 	})
+
+	t.Run("mcp_admission_is_shared_and_bounded", func(t *testing.T) {
+		const ttl = time.Minute
+		seedMCPSubject(t, db, "mcp-rate-principal", "mcp-rate-org")
+		leases := make([]string, 0, store.MCPPrincipalLimit)
+		for i := range store.MCPPrincipalLimit {
+			id := fmt.Sprintf("mcp-principal-call-%d", i)
+			if err := c.AcquireMCP(ctx, id, "mcp-rate-principal", "mcp-rate-org", ttl); err != nil {
+				t.Fatalf("principal claim %d: %v", i+1, err)
+			}
+			leases = append(leases, id)
+		}
+		if err := db.Coordination().AcquireMCP(ctx, "mcp-principal-overflow", "mcp-rate-principal", "mcp-rate-org", ttl); !errors.Is(err, store.ErrMCPAdmissionLimited) {
+			t.Fatalf("principal overflow = %v, want ErrMCPAdmissionLimited", err)
+		}
+		for _, id := range leases {
+			if err := c.ReleaseMCP(ctx, id); err != nil {
+				t.Fatalf("release %s: %v", id, err)
+			}
+		}
+
+		// The rejected concurrency claim did not consume a token: 16 more
+		// admitted calls fill the capacity after the 4 successful claims.
+		for i := store.MCPPrincipalLimit; i < store.MCPRateCapacity; i++ {
+			id := fmt.Sprintf("mcp-rate-call-%d", i)
+			if err := c.AcquireMCP(ctx, id, "mcp-rate-principal", "mcp-rate-org", ttl); err != nil {
+				t.Fatalf("rate fill %d: %v", i+1, err)
+			}
+			if err := c.ReleaseMCP(ctx, id); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := db.Coordination().AcquireMCP(ctx, "mcp-rate-overflow", "mcp-rate-principal", "mcp-rate-org", ttl); !errors.Is(err, store.ErrMCPAdmissionLimited) {
+			t.Fatalf("rate overflow = %v, want ErrMCPAdmissionLimited", err)
+		}
+
+		orgLeases := make([]string, 0, store.MCPOrganizationLimit)
+		for i := range store.MCPOrganizationLimit + 1 {
+			principal := fmt.Sprintf("mcp-org-principal-%d", i)
+			seedMCPSubject(t, db, principal, "mcp-shared-org")
+			id := fmt.Sprintf("mcp-org-call-%d", i)
+			err := db.Coordination().AcquireMCP(ctx, id, principal, "mcp-shared-org", ttl)
+			if i == store.MCPOrganizationLimit {
+				if !errors.Is(err, store.ErrMCPAdmissionLimited) {
+					t.Fatalf("org overflow = %v, want ErrMCPAdmissionLimited", err)
+				}
+				break
+			}
+			if err != nil {
+				t.Fatalf("org claim %d: %v", i+1, err)
+			}
+			orgLeases = append(orgLeases, id)
+		}
+		for _, id := range orgLeases {
+			if err := c.ReleaseMCP(ctx, id); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		instanceLeases := make([]string, 0, store.MCPInstanceLimit)
+		for i := range store.MCPInstanceLimit + 1 {
+			principal := fmt.Sprintf("mcp-instance-principal-%d", i)
+			org := fmt.Sprintf("mcp-instance-org-%d", i/store.MCPOrganizationLimit)
+			seedMCPSubject(t, db, principal, org)
+			id := fmt.Sprintf("mcp-instance-call-%d", i)
+			err := db.Coordination().AcquireMCP(ctx, id, principal, org, ttl)
+			if i == store.MCPInstanceLimit {
+				if !errors.Is(err, store.ErrMCPAdmissionLimited) {
+					t.Fatalf("instance overflow = %v, want ErrMCPAdmissionLimited", err)
+				}
+				break
+			}
+			if err != nil {
+				t.Fatalf("instance claim %d: %v", i+1, err)
+			}
+			instanceLeases = append(instanceLeases, id)
+		}
+		for _, id := range instanceLeases {
+			if err := c.ReleaseMCP(ctx, id); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
+func seedMCPSubject(t *testing.T, db *store.DB, principalID, orgID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	var err error
+	switch db.Engine() {
+	case store.EngineSQLite:
+		_, err = db.SQLiteWrite().ExecContext(t.Context(), `INSERT OR IGNORE INTO orgs (id, name, active, metadata, created_at) VALUES (?, ?, 1, '{}', ?)`, orgID, orgID, now)
+		if err == nil {
+			_, err = db.SQLiteWrite().ExecContext(t.Context(), `INSERT OR IGNORE INTO principals (id, kind, created_at) VALUES (?, 'machine', ?)`, principalID, now)
+		}
+	case store.EnginePostgres:
+		_, err = db.PG().Exec(t.Context(), `INSERT INTO orgs (id, name, active, metadata, created_at) VALUES ($1, $2, TRUE, '{}', $3) ON CONFLICT (id) DO NOTHING`, orgID, orgID, now)
+		if err == nil {
+			_, err = db.PG().Exec(t.Context(), `INSERT INTO principals (id, kind, created_at) VALUES ($1, 'machine', $2) ON CONFLICT (id) DO NOTHING`, principalID, now)
+		}
+	default:
+		err = fmt.Errorf("unknown engine %q", db.Engine())
+	}
+	if err != nil {
+		t.Fatalf("seed MCP subject %s/%s: %v", principalID, orgID, err)
+	}
 }

--- a/internal/store/migrate/upgrade_test.go
+++ b/internal/store/migrate/upgrade_test.go
@@ -48,7 +48,10 @@ func runMCPAuditOriginRollback(t *testing.T, cfg store.Config) {
 		t.Fatal(err)
 	}
 	if err := withProvider(ctx, cfg, func(provider *goose.Provider, _ *sql.DB) error {
-		_, err := provider.Down(ctx)
+		// Roll back through migration 42 specifically. Later migrations must not
+		// turn this targeted compatibility proof into a rollback of the latest
+		// unrelated schema change.
+		_, err := provider.DownTo(ctx, 41)
 		return err
 	}); err != nil {
 		t.Fatalf("rollback MCP audit origin migration: %v", err)

--- a/internal/store/migrations/postgres/00043_mcp_admission.sql
+++ b/internal/store/migrations/postgres/00043_mcp_admission.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- Shared MCP rate and concurrency state (#629). Claims are serialized briefly
+-- under one transaction-scoped advisory lock, then held as expiring rows so
+-- every serving replica observes the same 4/principal, 8/org, 64/instance
+-- limits. The rate row implements the 60/minute, capacity-20 token bucket.
+
+-- hikyo:table mcp_rate_buckets class=instance chain=-
+CREATE TABLE mcp_rate_buckets (
+    principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+    next_at      TIMESTAMPTZ NOT NULL
+);
+
+-- hikyo:table mcp_inflight class=instance chain=-
+CREATE TABLE mcp_inflight (
+    call_id      TEXT PRIMARY KEY,
+    principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+    org_id       TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+    expires_at   TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX mcp_inflight_principal ON mcp_inflight (principal_id);
+CREATE INDEX mcp_inflight_org ON mcp_inflight (org_id);
+CREATE INDEX mcp_inflight_expiry ON mcp_inflight (expires_at);
+
+-- +goose Down
+DROP TABLE mcp_inflight;
+DROP TABLE mcp_rate_buckets;

--- a/internal/store/migrations/sqlite/00043_mcp_admission.sql
+++ b/internal/store/migrations/sqlite/00043_mcp_admission.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- Shared MCP rate and concurrency state (#629). SQLite serves one node, but
+-- keeps the same durable coordination model as PostgreSQL so engine behavior
+-- and future migrations remain identical.
+
+-- hikyo:table mcp_rate_buckets class=instance chain=-
+CREATE TABLE mcp_rate_buckets (
+    principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+    next_at      TEXT NOT NULL
+);
+
+-- hikyo:table mcp_inflight class=instance chain=-
+CREATE TABLE mcp_inflight (
+    call_id      TEXT PRIMARY KEY,
+    principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+    org_id       TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+    expires_at   TEXT NOT NULL
+);
+
+CREATE INDEX mcp_inflight_principal ON mcp_inflight (principal_id);
+CREATE INDEX mcp_inflight_org ON mcp_inflight (org_id);
+CREATE INDEX mcp_inflight_expiry ON mcp_inflight (expires_at);
+
+-- +goose Down
+DROP TABLE mcp_inflight;
+DROP TABLE mcp_rate_buckets;

--- a/internal/store/pggen/catalogue.sql.go
+++ b/internal/store/pggen/catalogue.sql.go
@@ -326,6 +326,45 @@ func (q *Queries) GetKeyGroup(ctx context.Context, arg GetKeyGroupParams) (KeyGr
 	return i, err
 }
 
+const getKeyInProject = `-- name: GetKeyInProject :one
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = $1 AND project_id = $2
+  AND id = $3
+`
+
+type GetKeyInProjectParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	KeyID          string
+}
+
+// GetKeyInProject resolves one key by id under the key.list authorization
+// (StoreCatalogueList), so the MCP pending-change page can attach a page-bounded
+// key name and classification without a JOIN or a whole-catalogue read.
+func (q *Queries) GetKeyInProject(ctx context.Context, arg GetKeyInProjectParams) (Key, error) {
+	row := q.db.QueryRow(ctx, getKeyInProject, arg.ChainOrgID, arg.ChainProjectID, arg.KeyID)
+	var i Key
+	err := row.Scan(
+		&i.ID,
+		&i.OrgID,
+		&i.ProjectID,
+		&i.Name,
+		&i.FolderPath,
+		&i.Classification,
+		&i.Description,
+		&i.Deprecated,
+		&i.DeprecationNote,
+		&i.Declaration,
+		&i.RequiredMode,
+		&i.ForbiddenMode,
+		&i.GroupID,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getProjectSchemaRevision = `-- name: GetProjectSchemaRevision :one
 SELECT revision FROM project_schema_revisions
 WHERE org_id = $1 AND project_id = $2
@@ -501,6 +540,49 @@ func (q *Queries) ListKeyPresence(ctx context.Context, arg ListKeyPresenceParams
 	return items, nil
 }
 
+const listKeyPresenceForKey = `-- name: ListKeyPresenceForKey :many
+SELECT org_id, project_id, key_id, environment_id, rule
+FROM key_presence_environments
+WHERE org_id = $1 AND project_id = $2
+  AND key_id = $3
+ORDER BY rule, environment_id
+`
+
+type ListKeyPresenceForKeyParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	KeyID          string
+}
+
+// ListKeyPresenceForKey reads one key's explicit presence rules, so the MCP
+// definitions page resolves presence per page key instead of listing the whole
+// project's presence rows.
+func (q *Queries) ListKeyPresenceForKey(ctx context.Context, arg ListKeyPresenceForKeyParams) ([]KeyPresenceEnvironment, error) {
+	rows, err := q.db.Query(ctx, listKeyPresenceForKey, arg.ChainOrgID, arg.ChainProjectID, arg.KeyID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []KeyPresenceEnvironment
+	for rows.Next() {
+		var i KeyPresenceEnvironment
+		if err := rows.Scan(
+			&i.OrgID,
+			&i.ProjectID,
+			&i.KeyID,
+			&i.EnvironmentID,
+			&i.Rule,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listKeys = `-- name: ListKeys :many
 SELECT id, org_id, project_id, name, folder_path, classification, description,
        deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
@@ -515,6 +597,66 @@ type ListKeysParams struct {
 
 func (q *Queries) ListKeys(ctx context.Context, arg ListKeysParams) ([]Key, error) {
 	rows, err := q.db.Query(ctx, listKeys, arg.ChainOrgID, arg.ChainProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Key
+	for rows.Next() {
+		var i Key
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.Name,
+			&i.FolderPath,
+			&i.Classification,
+			&i.Description,
+			&i.Deprecated,
+			&i.DeprecationNote,
+			&i.Declaration,
+			&i.RequiredMode,
+			&i.ForbiddenMode,
+			&i.GroupID,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listKeysPage = `-- name: ListKeysPage :many
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = $1 AND project_id = $2
+  AND name > $3
+ORDER BY name LIMIT $4
+`
+
+type ListKeysPageParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	AfterName      string
+	PageLimit      int32
+}
+
+// ListKeysPage is the MCP-bounded keyset read (#629). name is UNIQUE per
+// project, so it is a stable single-column cursor: the statement fetches
+// strictly past the last returned name and never materializes the whole
+// catalogue to slice a limit afterwards.
+func (q *Queries) ListKeysPage(ctx context.Context, arg ListKeysPageParams) ([]Key, error) {
+	rows, err := q.db.Query(ctx, listKeysPage,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.AfterName,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/pggen/environments.sql.go
+++ b/internal/store/pggen/environments.sql.go
@@ -227,6 +227,125 @@ func (q *Queries) ListEnvironments(ctx context.Context, arg ListEnvironmentsPara
 	return items, nil
 }
 
+const listEnvironmentsPageAfterOrder = `-- name: ListEnvironmentsPageAfterOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = $1 AND project_id = $2
+  AND display_order > $3
+ORDER BY display_order, name LIMIT $4
+`
+
+type ListEnvironmentsPageAfterOrderParams struct {
+	ChainOrgID        string
+	ChainProjectID    string
+	AfterDisplayOrder int64
+	PageLimit         int32
+}
+
+type ListEnvironmentsPageAfterOrderRow struct {
+	ID           string
+	OrgID        string
+	ProjectID    string
+	Name         string
+	Note         string
+	CreatedAt    pgtype.Timestamptz
+	DisplayOrder int64
+}
+
+func (q *Queries) ListEnvironmentsPageAfterOrder(ctx context.Context, arg ListEnvironmentsPageAfterOrderParams) ([]ListEnvironmentsPageAfterOrderRow, error) {
+	rows, err := q.db.Query(ctx, listEnvironmentsPageAfterOrder,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.AfterDisplayOrder,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListEnvironmentsPageAfterOrderRow
+	for rows.Next() {
+		var i ListEnvironmentsPageAfterOrderRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Note,
+			&i.CreatedAt,
+			&i.DisplayOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEnvironmentsPageAtOrder = `-- name: ListEnvironmentsPageAtOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = $1 AND project_id = $2
+  AND display_order = $3 AND name > $4
+ORDER BY display_order, name LIMIT $5
+`
+
+type ListEnvironmentsPageAtOrderParams struct {
+	ChainOrgID        string
+	ChainProjectID    string
+	AfterDisplayOrder int64
+	AfterName         string
+	PageLimit         int32
+}
+
+type ListEnvironmentsPageAtOrderRow struct {
+	ID           string
+	OrgID        string
+	ProjectID    string
+	Name         string
+	Note         string
+	CreatedAt    pgtype.Timestamptz
+	DisplayOrder int64
+}
+
+// These two bounded reads compose List's display_order/name keyset without an
+// OR predicate the tenant-isolation analyzer cannot prove. The store reads the
+// remainder of the cursor's current order first, then later orders.
+func (q *Queries) ListEnvironmentsPageAtOrder(ctx context.Context, arg ListEnvironmentsPageAtOrderParams) ([]ListEnvironmentsPageAtOrderRow, error) {
+	rows, err := q.db.Query(ctx, listEnvironmentsPageAtOrder,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.AfterDisplayOrder,
+		arg.AfterName,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListEnvironmentsPageAtOrderRow
+	for rows.Next() {
+		var i ListEnvironmentsPageAtOrderRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Note,
+			&i.CreatedAt,
+			&i.DisplayOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const nextEnvironmentOrder = `-- name: NextEnvironmentOrder :one
 SELECT CAST(COALESCE(MAX(display_order) + 1, 0) AS BIGINT) FROM environments
 WHERE org_id = $1 AND project_id = $2

--- a/internal/store/pggen/models.go
+++ b/internal/store/pggen/models.go
@@ -642,6 +642,18 @@ type MasterKey struct {
 	CreatedAt    pgtype.Timestamptz
 }
 
+type McpInflight struct {
+	CallID      string
+	PrincipalID string
+	OrgID       string
+	ExpiresAt   pgtype.Timestamptz
+}
+
+type McpRateBucket struct {
+	PrincipalID string
+	NextAt      pgtype.Timestamptz
+}
+
 type OfflineRecord struct {
 	PrincipalID string
 	RecordID    string

--- a/internal/store/pggen/revisions.sql.go
+++ b/internal/store/pggen/revisions.sql.go
@@ -755,6 +755,75 @@ func (q *Queries) ListPendingChangesForOwnerInEnvironment(ctx context.Context, a
 	return items, nil
 }
 
+const listPendingChangesForOwnerInEnvironmentPage = `-- name: ListPendingChangesForOwnerInEnvironmentPage :many
+SELECT id, org_id, project_id, environment_id, key_id, owner_id,
+       operation, ciphertext, staged_from_revision, staged_from_entry, created_at, source, secret, material_secret
+FROM pending_changes
+WHERE org_id = $1 AND project_id = $2
+  AND environment_id = $3 AND owner_id = $4
+  AND key_id > $5
+ORDER BY key_id LIMIT $6
+`
+
+type ListPendingChangesForOwnerInEnvironmentPageParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	ChainEnvID     string
+	OwnerID        string
+	AfterKeyID     string
+	PageLimit      int32
+}
+
+// ListPendingMarkers is the matrix signal's read and the group-closure
+// collision check's read. It returns NO ciphertext: what another principal's
+// draft may disclose is write-presence and nothing else, and the cheapest way
+// to hold that rule is a statement that cannot carry the material.
+// ListPendingChangesForOwnerInEnvironmentPage is the MCP-bounded keyset read
+// (#629). (env, key, owner) is UNIQUE, so key_id is a stable single-column
+// cursor for one owner's drafts in one environment. No JOIN: the caller resolves
+// each page key's name and classification under the same key.list authorization.
+func (q *Queries) ListPendingChangesForOwnerInEnvironmentPage(ctx context.Context, arg ListPendingChangesForOwnerInEnvironmentPageParams) ([]PendingChange, error) {
+	rows, err := q.db.Query(ctx, listPendingChangesForOwnerInEnvironmentPage,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.ChainEnvID,
+		arg.OwnerID,
+		arg.AfterKeyID,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PendingChange
+	for rows.Next() {
+		var i PendingChange
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.EnvironmentID,
+			&i.KeyID,
+			&i.OwnerID,
+			&i.Operation,
+			&i.Ciphertext,
+			&i.StagedFromRevision,
+			&i.StagedFromEntry,
+			&i.CreatedAt,
+			&i.Source,
+			&i.Secret,
+			&i.MaterialSecret,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPendingForReencrypt = `-- name: ListPendingForReencrypt :many
 SELECT id, environment_id, key_id, ciphertext FROM pending_changes
 WHERE org_id = $1 AND project_id = $2
@@ -827,10 +896,6 @@ type ListPendingMarkersRow struct {
 	Operation     string
 }
 
-// ListPendingMarkers is the matrix signal's read and the group-closure
-// collision check's read. It returns NO ciphertext: what another principal's
-// draft may disclose is write-presence and nothing else, and the cheapest way
-// to hold that rule is a statement that cannot carry the material.
 func (q *Queries) ListPendingMarkers(ctx context.Context, arg ListPendingMarkersParams) ([]ListPendingMarkersRow, error) {
 	rows, err := q.db.Query(ctx, listPendingMarkers, arg.ChainOrgID, arg.ChainProjectID)
 	if err != nil {
@@ -1111,6 +1176,66 @@ type ListSnapshotsParams struct {
 
 func (q *Queries) ListSnapshots(ctx context.Context, arg ListSnapshotsParams) ([]Snapshot, error) {
 	rows, err := q.db.Query(ctx, listSnapshots, arg.ChainOrgID, arg.ChainProjectID, arg.ChainEnvID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Snapshot
+	for rows.Next() {
+		var i Snapshot
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.EnvironmentID,
+			&i.Revision,
+			&i.SchemaRevision,
+			&i.PublishedBy,
+			&i.PublishedAt,
+			&i.PayloadPresent,
+			&i.CollectedAt,
+			&i.CollectedPolicy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSnapshotsPage = `-- name: ListSnapshotsPage :many
+SELECT id, org_id, project_id, environment_id, revision, schema_revision,
+       published_by, published_at, payload_present, collected_at, collected_policy
+FROM snapshots
+WHERE org_id = $1 AND project_id = $2
+  AND environment_id = $3
+  AND revision < $4
+ORDER BY revision DESC LIMIT $5
+`
+
+type ListSnapshotsPageParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	ChainEnvID     string
+	BeforeRevision int64
+	PageLimit      int32
+}
+
+// ListSnapshotsPage is the MCP-bounded keyset read (#629). revision is UNIQUE
+// and monotonic per environment, so it is a stable single-column cursor in
+// descending order: the statement fetches strictly below the last returned
+// revision and never materializes the whole history to slice a limit afterwards.
+func (q *Queries) ListSnapshotsPage(ctx context.Context, arg ListSnapshotsPageParams) ([]Snapshot, error) {
+	rows, err := q.db.Query(ctx, listSnapshotsPage,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.ChainEnvID,
+		arg.BeforeRevision,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/queries/postgres/catalogue.sql
+++ b/internal/store/queries/postgres/catalogue.sql
@@ -57,6 +57,28 @@ SELECT id, org_id, project_id, name, folder_path, classification, description,
        group_id, created_at
 FROM keys WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id) ORDER BY name;
 
+-- ListKeysPage is the MCP-bounded keyset read (#629). name is UNIQUE per
+-- project, so it is a stable single-column cursor: the statement fetches
+-- strictly past the last returned name and never materializes the whole
+-- catalogue to slice a limit afterwards.
+-- name: ListKeysPage :many
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND name > sqlc.arg(after_name)
+ORDER BY name LIMIT sqlc.arg(page_limit);
+
+-- GetKeyInProject resolves one key by id under the key.list authorization
+-- (StoreCatalogueList), so the MCP pending-change page can attach a page-bounded
+-- key name and classification without a JOIN or a whole-catalogue read.
+-- name: GetKeyInProject :one
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND id = sqlc.arg(key_id);
+
 -- name: CountKeys :one
 SELECT COUNT(*) FROM keys
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id);
@@ -119,6 +141,16 @@ SELECT org_id, project_id, key_id, environment_id, rule
 FROM key_presence_environments
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
 ORDER BY key_id, rule, environment_id;
+
+-- ListKeyPresenceForKey reads one key's explicit presence rules, so the MCP
+-- definitions page resolves presence per page key instead of listing the whole
+-- project's presence rows.
+-- name: ListKeyPresenceForKey :many
+SELECT org_id, project_id, key_id, environment_id, rule
+FROM key_presence_environments
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND key_id = sqlc.arg(key_id)
+ORDER BY rule, environment_id;
 
 -- DeleteKeyPresence clears one key's explicit sets so a declaration save can
 -- rewrite them whole. Zero rows is the ordinary case (a key whose modes were

--- a/internal/store/queries/postgres/environments.sql
+++ b/internal/store/queries/postgres/environments.sql
@@ -14,6 +14,21 @@ WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id
 SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id) ORDER BY display_order, name;
 
+-- These two bounded reads compose List's display_order/name keyset without an
+-- OR predicate the tenant-isolation analyzer cannot prove. The store reads the
+-- remainder of the cursor's current order first, then later orders.
+-- name: ListEnvironmentsPageAtOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND display_order = sqlc.arg(after_display_order) AND name > sqlc.arg(after_name)
+ORDER BY display_order, name LIMIT sqlc.arg(page_limit);
+
+-- name: ListEnvironmentsPageAfterOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND display_order > sqlc.arg(after_display_order)
+ORDER BY display_order, name LIMIT sqlc.arg(page_limit);
+
 -- name: CountEnvironments :one
 SELECT COUNT(*) FROM environments WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id);
 
@@ -64,4 +79,3 @@ WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id
 -- name: ListEnvironmentProtection :many
 SELECT id, protected FROM environments
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id) ORDER BY id;
-

--- a/internal/store/queries/postgres/revisions.sql
+++ b/internal/store/queries/postgres/revisions.sql
@@ -80,6 +80,19 @@ ORDER BY key_id;
 -- collision check's read. It returns NO ciphertext: what another principal's
 -- draft may disclose is write-presence and nothing else, and the cheapest way
 -- to hold that rule is a statement that cannot carry the material.
+-- ListPendingChangesForOwnerInEnvironmentPage is the MCP-bounded keyset read
+-- (#629). (env, key, owner) is UNIQUE, so key_id is a stable single-column
+-- cursor for one owner's drafts in one environment. No JOIN: the caller resolves
+-- each page key's name and classification under the same key.list authorization.
+-- name: ListPendingChangesForOwnerInEnvironmentPage :many
+SELECT id, org_id, project_id, environment_id, key_id, owner_id,
+       operation, ciphertext, staged_from_revision, staged_from_entry, created_at, source, secret, material_secret
+FROM pending_changes
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND environment_id = sqlc.arg(chain_env_id) AND owner_id = sqlc.arg(owner_id)
+  AND key_id > sqlc.arg(after_key_id)
+ORDER BY key_id LIMIT sqlc.arg(page_limit);
+
 -- name: ListPendingMarkers :many
 SELECT id, environment_id, key_id, owner_id, operation
 FROM pending_changes
@@ -129,6 +142,19 @@ FROM snapshots
 WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
   AND environment_id = sqlc.arg(chain_env_id)
 ORDER BY revision DESC;
+
+-- ListSnapshotsPage is the MCP-bounded keyset read (#629). revision is UNIQUE
+-- and monotonic per environment, so it is a stable single-column cursor in
+-- descending order: the statement fetches strictly below the last returned
+-- revision and never materializes the whole history to slice a limit afterwards.
+-- name: ListSnapshotsPage :many
+SELECT id, org_id, project_id, environment_id, revision, schema_revision,
+       published_by, published_at, payload_present, collected_at, collected_policy
+FROM snapshots
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND environment_id = sqlc.arg(chain_env_id)
+  AND revision < sqlc.arg(before_revision)
+ORDER BY revision DESC LIMIT sqlc.arg(page_limit);
 
 -- name: DeleteSnapshotsForEnvironment :execrows
 DELETE FROM snapshots

--- a/internal/store/queries/sqlite/catalogue.sql
+++ b/internal/store/queries/sqlite/catalogue.sql
@@ -50,6 +50,28 @@ SELECT id, org_id, project_id, name, folder_path, classification, description,
        group_id, created_at
 FROM keys WHERE org_id = ? AND project_id = ? ORDER BY name;
 
+-- ListKeysPage is the MCP-bounded keyset read (#629). name is UNIQUE per
+-- project, so it is a stable single-column cursor: the statement fetches
+-- strictly past the last returned name and never materializes the whole
+-- catalogue to slice a limit afterwards.
+-- name: ListKeysPage :many
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND name > sqlc.arg(after_name)
+ORDER BY name LIMIT sqlc.arg(page_limit);
+
+-- GetKeyInProject resolves one key by id under the key.list authorization
+-- (StoreCatalogueList), so the MCP pending-change page can attach a page-bounded
+-- key name and classification without a JOIN or a whole-catalogue read.
+-- name: GetKeyInProject :one
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND id = sqlc.arg(key_id);
+
 -- name: CountKeys :one
 SELECT COUNT(*) FROM keys WHERE org_id = ? AND project_id = ?;
 
@@ -106,6 +128,16 @@ VALUES (?, ?, ?, ?, ?);
 SELECT org_id, project_id, key_id, environment_id, rule
 FROM key_presence_environments
 WHERE org_id = ? AND project_id = ? ORDER BY key_id, rule, environment_id;
+
+-- ListKeyPresenceForKey reads one key's explicit presence rules, so the MCP
+-- definitions page resolves presence per page key instead of listing the whole
+-- project's presence rows.
+-- name: ListKeyPresenceForKey :many
+SELECT org_id, project_id, key_id, environment_id, rule
+FROM key_presence_environments
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND key_id = sqlc.arg(key_id)
+ORDER BY rule, environment_id;
 
 -- DeleteKeyPresence clears one key's explicit sets so a declaration save can
 -- rewrite them whole. Zero rows is the ordinary case (a key whose modes were

--- a/internal/store/queries/sqlite/environments.sql
+++ b/internal/store/queries/sqlite/environments.sql
@@ -14,6 +14,21 @@ WHERE org_id = ? AND project_id = ? AND id = ?;
 SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
 WHERE org_id = ? AND project_id = ? ORDER BY display_order, name;
 
+-- These two bounded reads compose List's display_order/name keyset without an
+-- OR predicate the tenant-isolation analyzer cannot prove. The store reads the
+-- remainder of the cursor's current order first, then later orders.
+-- name: ListEnvironmentsPageAtOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND display_order = sqlc.arg(after_display_order) AND name > sqlc.arg(after_name)
+ORDER BY display_order, name LIMIT sqlc.arg(page_limit);
+
+-- name: ListEnvironmentsPageAfterOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND display_order > sqlc.arg(after_display_order)
+ORDER BY display_order, name LIMIT sqlc.arg(page_limit);
+
 -- name: CountEnvironments :one
 SELECT COUNT(*) FROM environments WHERE org_id = ? AND project_id = ?;
 

--- a/internal/store/queries/sqlite/revisions.sql
+++ b/internal/store/queries/sqlite/revisions.sql
@@ -67,6 +67,19 @@ ORDER BY key_id;
 -- collision check's read. It returns NO ciphertext: what another principal's
 -- draft may disclose is write-presence and nothing else, and the cheapest way
 -- to hold that rule is a statement that cannot carry the material.
+-- ListPendingChangesForOwnerInEnvironmentPage is the MCP-bounded keyset read
+-- (#629). (env, key, owner) is UNIQUE, so key_id is a stable single-column
+-- cursor for one owner's drafts in one environment. No JOIN: the caller resolves
+-- each page key's name and classification under the same key.list authorization.
+-- name: ListPendingChangesForOwnerInEnvironmentPage :many
+SELECT id, org_id, project_id, environment_id, key_id, owner_id,
+       operation, ciphertext, staged_from_revision, staged_from_entry, created_at, source, secret, material_secret
+FROM pending_changes
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND environment_id = sqlc.arg(chain_env_id) AND owner_id = sqlc.arg(owner_id)
+  AND key_id > sqlc.arg(after_key_id)
+ORDER BY key_id LIMIT sqlc.arg(page_limit);
+
 -- name: ListPendingMarkers :many
 SELECT id, environment_id, key_id, owner_id, operation
 FROM pending_changes
@@ -109,6 +122,19 @@ SELECT id, org_id, project_id, environment_id, revision, schema_revision,
 FROM snapshots
 WHERE org_id = ? AND project_id = ? AND environment_id = ?
 ORDER BY revision DESC;
+
+-- ListSnapshotsPage is the MCP-bounded keyset read (#629). revision is UNIQUE
+-- and monotonic per environment, so it is a stable single-column cursor in
+-- descending order: the statement fetches strictly below the last returned
+-- revision and never materializes the whole history to slice a limit afterwards.
+-- name: ListSnapshotsPage :many
+SELECT id, org_id, project_id, environment_id, revision, schema_revision,
+       published_by, published_at, payload_present, collected_at, collected_policy
+FROM snapshots
+WHERE org_id = sqlc.arg(chain_org_id) AND project_id = sqlc.arg(chain_project_id)
+  AND environment_id = sqlc.arg(chain_env_id)
+  AND revision < sqlc.arg(before_revision)
+ORDER BY revision DESC LIMIT sqlc.arg(page_limit);
 
 -- name: DeleteSnapshotsForEnvironment :execrows
 DELETE FROM snapshots

--- a/internal/store/repos_mcp_page.go
+++ b/internal/store/repos_mcp_page.go
@@ -1,0 +1,329 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/store/pggen"
+	"github.com/Hikyo-Org/hikyo/internal/store/sqlitegen"
+)
+
+// This file holds the bounded keyset page reads the MCP adapter needs (#629).
+// Each method verifies the SAME store authorization its unbounded sibling does,
+// so the existing operation proof authorizes it, and fetches strictly past the
+// caller's cursor with a LIMIT rather than materializing a whole collection.
+
+func (r sqliteEnvs) ListPage(ctx context.Context, p authz.Proof, afterDisplayOrder int64, afterName string, limit int) ([]Environment, error) {
+	chain, err := authz.Verify(p, authz.StoreEnvironmentsListPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListEnvironmentsPageAtOrder(ctx, sqlitegen.ListEnvironmentsPageAtOrderParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project),
+		AfterDisplayOrder: afterDisplayOrder, AfterName: afterName, PageLimit: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Environment, 0, limit)
+	appendRow := func(id, orgID, projectID, name, note, createdAt string, displayOrder int64) error {
+		created, err := parseTime("environment", id, createdAt)
+		if err != nil {
+			return err
+		}
+		out = append(out, Environment{ID: id, OrgID: orgID, ProjectID: projectID, Name: name, Note: note, DisplayOrder: displayOrder, CreatedAt: created})
+		return nil
+	}
+	for _, row := range rows {
+		if err := appendRow(row.ID, row.OrgID, row.ProjectID, row.Name, row.Note, row.CreatedAt, row.DisplayOrder); err != nil {
+			return nil, err
+		}
+	}
+	if len(out) < limit {
+		later, err := r.q.ListEnvironmentsPageAfterOrder(ctx, sqlitegen.ListEnvironmentsPageAfterOrderParams{
+			ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project),
+			AfterDisplayOrder: afterDisplayOrder, PageLimit: int64(limit - len(out)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range later {
+			if err := appendRow(row.ID, row.OrgID, row.ProjectID, row.Name, row.Note, row.CreatedAt, row.DisplayOrder); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+
+func (r pgEnvs) ListPage(ctx context.Context, p authz.Proof, afterDisplayOrder int64, afterName string, limit int) ([]Environment, error) {
+	chain, err := authz.Verify(p, authz.StoreEnvironmentsListPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListEnvironmentsPageAtOrder(ctx, pggen.ListEnvironmentsPageAtOrderParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project),
+		AfterDisplayOrder: afterDisplayOrder, AfterName: afterName, PageLimit: int32(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Environment, 0, limit)
+	appendRow := func(id, orgID, projectID, name, note string, createdAt time.Time, createdAtValid bool, displayOrder int64) error {
+		if !createdAtValid {
+			return fmt.Errorf("store: environment %s: null created_at", id)
+		}
+		out = append(out, Environment{ID: id, OrgID: orgID, ProjectID: projectID, Name: name, Note: note, DisplayOrder: displayOrder, CreatedAt: createdAt.UTC()})
+		return nil
+	}
+	for _, row := range rows {
+		if err := appendRow(row.ID, row.OrgID, row.ProjectID, row.Name, row.Note, row.CreatedAt.Time, row.CreatedAt.Valid, row.DisplayOrder); err != nil {
+			return nil, err
+		}
+	}
+	if len(out) < limit {
+		later, err := r.q.ListEnvironmentsPageAfterOrder(ctx, pggen.ListEnvironmentsPageAfterOrderParams{
+			ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project),
+			AfterDisplayOrder: afterDisplayOrder, PageLimit: int32(limit - len(out)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range later {
+			if err := appendRow(row.ID, row.OrgID, row.ProjectID, row.Name, row.Note, row.CreatedAt.Time, row.CreatedAt.Valid, row.DisplayOrder); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+
+func (r sqliteCatalogue) ListPage(ctx context.Context, p authz.Proof, afterName string, limit int) ([]CatalogueKey, error) {
+	chain, err := authz.Verify(p, authz.StoreCatalogueListPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListKeysPage(ctx, sqlitegen.ListKeysPageParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project),
+		AfterName: afterName, PageLimit: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CatalogueKey, 0, len(rows))
+	for _, row := range rows {
+		key, err := keyFromSQLite(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, key)
+	}
+	return out, nil
+}
+
+func (r pgCatalogue) ListPage(ctx context.Context, p authz.Proof, afterName string, limit int) ([]CatalogueKey, error) {
+	chain, err := authz.Verify(p, authz.StoreCatalogueListPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListKeysPage(ctx, pggen.ListKeysPageParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project),
+		AfterName: afterName, PageLimit: int32(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CatalogueKey, 0, len(rows))
+	for _, row := range rows {
+		key, err := keyFromPG(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, key)
+	}
+	return out, nil
+}
+
+func (r sqliteCatalogue) GetInProject(ctx context.Context, p authz.Proof, id string) (CatalogueKey, error) {
+	chain, err := authz.Verify(p, authz.StoreCatalogueGetInProject, r.tok)
+	if err != nil {
+		return CatalogueKey{}, err
+	}
+	row, err := r.q.GetKeyInProject(ctx, sqlitegen.GetKeyInProjectParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), KeyID: id,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return CatalogueKey{}, ErrNotFound
+	}
+	if err != nil {
+		return CatalogueKey{}, err
+	}
+	return keyFromSQLite(row)
+}
+
+func (r pgCatalogue) GetInProject(ctx context.Context, p authz.Proof, id string) (CatalogueKey, error) {
+	chain, err := authz.Verify(p, authz.StoreCatalogueGetInProject, r.tok)
+	if err != nil {
+		return CatalogueKey{}, err
+	}
+	row, err := r.q.GetKeyInProject(ctx, pggen.GetKeyInProjectParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), KeyID: id,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return CatalogueKey{}, ErrNotFound
+	}
+	if err != nil {
+		return CatalogueKey{}, err
+	}
+	return keyFromPG(row)
+}
+
+func (r sqliteCatalogue) PresenceForKey(ctx context.Context, p authz.Proof, keyID string) ([]KeyPresence, error) {
+	chain, err := authz.Verify(p, authz.StoreCataloguePresenceForKey, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListKeyPresenceForKey(ctx, sqlitegen.ListKeyPresenceForKeyParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), KeyID: keyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]KeyPresence, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, KeyPresence{KeyID: row.KeyID, EnvironmentID: row.EnvironmentID, Rule: row.Rule})
+	}
+	return out, nil
+}
+
+func (r pgCatalogue) PresenceForKey(ctx context.Context, p authz.Proof, keyID string) ([]KeyPresence, error) {
+	chain, err := authz.Verify(p, authz.StoreCataloguePresenceForKey, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListKeyPresenceForKey(ctx, pggen.ListKeyPresenceForKeyParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), KeyID: keyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]KeyPresence, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, KeyPresence{KeyID: row.KeyID, EnvironmentID: row.EnvironmentID, Rule: row.Rule})
+	}
+	return out, nil
+}
+
+func (r sqlitePending) ListForOwnerInEnvironmentPage(ctx context.Context, p authz.Proof, ownerID, afterKeyID string, limit int) ([]PendingChange, error) {
+	chain, err := authz.Verify(p, authz.StorePendingListForOwnerInEnvironmentPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	env, err := envOf(chain, authz.StorePendingListForOwnerInEnvironmentPage)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListPendingChangesForOwnerInEnvironmentPage(ctx, sqlitegen.ListPendingChangesForOwnerInEnvironmentPageParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), ChainEnvID: env,
+		OwnerID: ownerID, AfterKeyID: afterKeyID, PageLimit: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PendingChange, 0, len(rows))
+	for _, row := range rows {
+		change, err := pendingFromSQLite(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, change)
+	}
+	return out, nil
+}
+
+func (r pgPending) ListForOwnerInEnvironmentPage(ctx context.Context, p authz.Proof, ownerID, afterKeyID string, limit int) ([]PendingChange, error) {
+	chain, err := authz.Verify(p, authz.StorePendingListForOwnerInEnvironmentPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	env, err := envOf(chain, authz.StorePendingListForOwnerInEnvironmentPage)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListPendingChangesForOwnerInEnvironmentPage(ctx, pggen.ListPendingChangesForOwnerInEnvironmentPageParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), ChainEnvID: env,
+		OwnerID: ownerID, AfterKeyID: afterKeyID, PageLimit: int32(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PendingChange, 0, len(rows))
+	for _, row := range rows {
+		change, err := pendingFromPostgres(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, change)
+	}
+	return out, nil
+}
+
+func (r sqliteSnapshots) ListPage(ctx context.Context, p authz.Proof, beforeRevision int64, limit int) ([]Snapshot, error) {
+	chain, err := authz.Verify(p, authz.StoreSnapshotsListPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	env, err := envOf(chain, authz.StoreSnapshotsListPage)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListSnapshotsPage(ctx, sqlitegen.ListSnapshotsPageParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), ChainEnvID: env,
+		BeforeRevision: beforeRevision, PageLimit: int64(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Snapshot, 0, len(rows))
+	for _, row := range rows {
+		snap, err := revisionSnapshotFromSQLite(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}
+
+func (r pgSnapshots) ListPage(ctx context.Context, p authz.Proof, beforeRevision int64, limit int) ([]Snapshot, error) {
+	chain, err := authz.Verify(p, authz.StoreSnapshotsListPage, r.tok)
+	if err != nil {
+		return nil, err
+	}
+	env, err := envOf(chain, authz.StoreSnapshotsListPage)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListSnapshotsPage(ctx, pggen.ListSnapshotsPageParams{
+		ChainOrgID: string(chain.Org), ChainProjectID: string(chain.Project), ChainEnvID: env,
+		BeforeRevision: beforeRevision, PageLimit: int32(limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Snapshot, 0, len(rows))
+	for _, row := range rows {
+		snap, err := revisionSnapshotFromPG(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}

--- a/internal/store/revisions.go
+++ b/internal/store/revisions.go
@@ -192,6 +192,12 @@ type PendingReader interface {
 	// environment are both bound into its SQL predicate; no post-query filter
 	// is trusted with another principal's ciphertext.
 	ListForOwnerInEnvironment(ctx context.Context, p authz.Proof, ownerID string) ([]PendingChange, error)
+	// ListForOwnerInEnvironmentPage is the bounded keyset read (#629): one page
+	// of one owner's drafts in the proof's environment, ordered by the UNIQUE
+	// key_id column, strictly past afterKeyID ("" for the first page). Owner and
+	// environment are bound into the SQL predicate; no post-query filter is
+	// trusted with another principal's ciphertext.
+	ListForOwnerInEnvironmentPage(ctx context.Context, p authz.Proof, ownerID, afterKeyID string, limit int) ([]PendingChange, error)
 	// ListMarkers returns every principal's drafts in the proof's project,
 	// without material.
 	ListMarkers(ctx context.Context, p authz.Proof) ([]PendingMarker, error)
@@ -252,6 +258,11 @@ type SnapshotReader interface {
 	AtRevision(ctx context.Context, p authz.Proof, revision int64) (Snapshot, error)
 	// List returns the environment's revision history, newest first.
 	List(ctx context.Context, p authz.Proof) ([]Snapshot, error)
+	// ListPage is the bounded keyset read (#629): one page of revision history
+	// ordered by the UNIQUE revision column descending, strictly below
+	// beforeRevision (a sentinel above the newest for the first page), fetching
+	// at most limit rows.
+	ListPage(ctx context.Context, p authz.Proof, beforeRevision int64, limit int) ([]Snapshot, error)
 	// Entries returns one snapshot's resolved map, ordered by key name.
 	Entries(ctx context.Context, p authz.Proof, snapshot Snapshot) ([]SnapshotEntry, error)
 	// SecretValueOccurrenceIDs returns the payload-free sticky sensitivity

--- a/internal/store/sqlitegen/catalogue.sql.go
+++ b/internal/store/sqlitegen/catalogue.sql.go
@@ -315,6 +315,45 @@ func (q *Queries) GetKeyGroup(ctx context.Context, arg GetKeyGroupParams) (KeyGr
 	return i, err
 }
 
+const getKeyInProject = `-- name: GetKeyInProject :one
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = ?1 AND project_id = ?2
+  AND id = ?3
+`
+
+type GetKeyInProjectParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	KeyID          string
+}
+
+// GetKeyInProject resolves one key by id under the key.list authorization
+// (StoreCatalogueList), so the MCP pending-change page can attach a page-bounded
+// key name and classification without a JOIN or a whole-catalogue read.
+func (q *Queries) GetKeyInProject(ctx context.Context, arg GetKeyInProjectParams) (Key, error) {
+	row := q.db.QueryRowContext(ctx, getKeyInProject, arg.ChainOrgID, arg.ChainProjectID, arg.KeyID)
+	var i Key
+	err := row.Scan(
+		&i.ID,
+		&i.OrgID,
+		&i.ProjectID,
+		&i.Name,
+		&i.FolderPath,
+		&i.Classification,
+		&i.Description,
+		&i.Deprecated,
+		&i.DeprecationNote,
+		&i.Declaration,
+		&i.RequiredMode,
+		&i.ForbiddenMode,
+		&i.GroupID,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getProjectSchemaRevision = `-- name: GetProjectSchemaRevision :one
 SELECT revision FROM project_schema_revisions
 WHERE org_id = ? AND project_id = ?
@@ -495,6 +534,52 @@ func (q *Queries) ListKeyPresence(ctx context.Context, arg ListKeyPresenceParams
 	return items, nil
 }
 
+const listKeyPresenceForKey = `-- name: ListKeyPresenceForKey :many
+SELECT org_id, project_id, key_id, environment_id, rule
+FROM key_presence_environments
+WHERE org_id = ?1 AND project_id = ?2
+  AND key_id = ?3
+ORDER BY rule, environment_id
+`
+
+type ListKeyPresenceForKeyParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	KeyID          string
+}
+
+// ListKeyPresenceForKey reads one key's explicit presence rules, so the MCP
+// definitions page resolves presence per page key instead of listing the whole
+// project's presence rows.
+func (q *Queries) ListKeyPresenceForKey(ctx context.Context, arg ListKeyPresenceForKeyParams) ([]KeyPresenceEnvironment, error) {
+	rows, err := q.db.QueryContext(ctx, listKeyPresenceForKey, arg.ChainOrgID, arg.ChainProjectID, arg.KeyID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []KeyPresenceEnvironment
+	for rows.Next() {
+		var i KeyPresenceEnvironment
+		if err := rows.Scan(
+			&i.OrgID,
+			&i.ProjectID,
+			&i.KeyID,
+			&i.EnvironmentID,
+			&i.Rule,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listKeys = `-- name: ListKeys :many
 SELECT id, org_id, project_id, name, folder_path, classification, description,
        deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
@@ -509,6 +594,69 @@ type ListKeysParams struct {
 
 func (q *Queries) ListKeys(ctx context.Context, arg ListKeysParams) ([]Key, error) {
 	rows, err := q.db.QueryContext(ctx, listKeys, arg.OrgID, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Key
+	for rows.Next() {
+		var i Key
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.Name,
+			&i.FolderPath,
+			&i.Classification,
+			&i.Description,
+			&i.Deprecated,
+			&i.DeprecationNote,
+			&i.Declaration,
+			&i.RequiredMode,
+			&i.ForbiddenMode,
+			&i.GroupID,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listKeysPage = `-- name: ListKeysPage :many
+SELECT id, org_id, project_id, name, folder_path, classification, description,
+       deprecated, deprecation_note, declaration, required_mode, forbidden_mode,
+       group_id, created_at
+FROM keys WHERE org_id = ?1 AND project_id = ?2
+  AND name > ?3
+ORDER BY name LIMIT ?4
+`
+
+type ListKeysPageParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	AfterName      string
+	PageLimit      int64
+}
+
+// ListKeysPage is the MCP-bounded keyset read (#629). name is UNIQUE per
+// project, so it is a stable single-column cursor: the statement fetches
+// strictly past the last returned name and never materializes the whole
+// catalogue to slice a limit afterwards.
+func (q *Queries) ListKeysPage(ctx context.Context, arg ListKeysPageParams) ([]Key, error) {
+	rows, err := q.db.QueryContext(ctx, listKeysPage,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.AfterName,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlitegen/environments.sql.go
+++ b/internal/store/sqlitegen/environments.sql.go
@@ -232,6 +232,131 @@ func (q *Queries) ListEnvironments(ctx context.Context, arg ListEnvironmentsPara
 	return items, nil
 }
 
+const listEnvironmentsPageAfterOrder = `-- name: ListEnvironmentsPageAfterOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = ?1 AND project_id = ?2
+  AND display_order > ?3
+ORDER BY display_order, name LIMIT ?4
+`
+
+type ListEnvironmentsPageAfterOrderParams struct {
+	ChainOrgID        string
+	ChainProjectID    string
+	AfterDisplayOrder int64
+	PageLimit         int64
+}
+
+type ListEnvironmentsPageAfterOrderRow struct {
+	ID           string
+	OrgID        string
+	ProjectID    string
+	Name         string
+	Note         string
+	CreatedAt    string
+	DisplayOrder int64
+}
+
+func (q *Queries) ListEnvironmentsPageAfterOrder(ctx context.Context, arg ListEnvironmentsPageAfterOrderParams) ([]ListEnvironmentsPageAfterOrderRow, error) {
+	rows, err := q.db.QueryContext(ctx, listEnvironmentsPageAfterOrder,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.AfterDisplayOrder,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListEnvironmentsPageAfterOrderRow
+	for rows.Next() {
+		var i ListEnvironmentsPageAfterOrderRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Note,
+			&i.CreatedAt,
+			&i.DisplayOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEnvironmentsPageAtOrder = `-- name: ListEnvironmentsPageAtOrder :many
+SELECT id, org_id, project_id, name, note, created_at, display_order FROM environments
+WHERE org_id = ?1 AND project_id = ?2
+  AND display_order = ?3 AND name > ?4
+ORDER BY display_order, name LIMIT ?5
+`
+
+type ListEnvironmentsPageAtOrderParams struct {
+	ChainOrgID        string
+	ChainProjectID    string
+	AfterDisplayOrder int64
+	AfterName         string
+	PageLimit         int64
+}
+
+type ListEnvironmentsPageAtOrderRow struct {
+	ID           string
+	OrgID        string
+	ProjectID    string
+	Name         string
+	Note         string
+	CreatedAt    string
+	DisplayOrder int64
+}
+
+// These two bounded reads compose List's display_order/name keyset without an
+// OR predicate the tenant-isolation analyzer cannot prove. The store reads the
+// remainder of the cursor's current order first, then later orders.
+func (q *Queries) ListEnvironmentsPageAtOrder(ctx context.Context, arg ListEnvironmentsPageAtOrderParams) ([]ListEnvironmentsPageAtOrderRow, error) {
+	rows, err := q.db.QueryContext(ctx, listEnvironmentsPageAtOrder,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.AfterDisplayOrder,
+		arg.AfterName,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListEnvironmentsPageAtOrderRow
+	for rows.Next() {
+		var i ListEnvironmentsPageAtOrderRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Note,
+			&i.CreatedAt,
+			&i.DisplayOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const nextEnvironmentOrder = `-- name: NextEnvironmentOrder :one
 SELECT CAST(COALESCE(MAX(display_order) + 1, 0) AS INTEGER) FROM environments
 WHERE org_id = ? AND project_id = ?

--- a/internal/store/sqlitegen/models.go
+++ b/internal/store/sqlitegen/models.go
@@ -640,6 +640,18 @@ type MasterKey struct {
 	CreatedAt    string
 }
 
+type McpInflight struct {
+	CallID      string
+	PrincipalID string
+	OrgID       string
+	ExpiresAt   string
+}
+
+type McpRateBucket struct {
+	PrincipalID string
+	NextAt      string
+}
+
 type OfflineRecord struct {
 	PrincipalID string
 	RecordID    string

--- a/internal/store/sqlitegen/revisions.sql.go
+++ b/internal/store/sqlitegen/revisions.sql.go
@@ -716,6 +716,78 @@ func (q *Queries) ListPendingChangesForOwnerInEnvironment(ctx context.Context, a
 	return items, nil
 }
 
+const listPendingChangesForOwnerInEnvironmentPage = `-- name: ListPendingChangesForOwnerInEnvironmentPage :many
+SELECT id, org_id, project_id, environment_id, key_id, owner_id,
+       operation, ciphertext, staged_from_revision, staged_from_entry, created_at, source, secret, material_secret
+FROM pending_changes
+WHERE org_id = ?1 AND project_id = ?2
+  AND environment_id = ?3 AND owner_id = ?4
+  AND key_id > ?5
+ORDER BY key_id LIMIT ?6
+`
+
+type ListPendingChangesForOwnerInEnvironmentPageParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	ChainEnvID     string
+	OwnerID        string
+	AfterKeyID     string
+	PageLimit      int64
+}
+
+// ListPendingMarkers is the matrix signal's read and the group-closure
+// collision check's read. It returns NO ciphertext: what another principal's
+// draft may disclose is write-presence and nothing else, and the cheapest way
+// to hold that rule is a statement that cannot carry the material.
+// ListPendingChangesForOwnerInEnvironmentPage is the MCP-bounded keyset read
+// (#629). (env, key, owner) is UNIQUE, so key_id is a stable single-column
+// cursor for one owner's drafts in one environment. No JOIN: the caller resolves
+// each page key's name and classification under the same key.list authorization.
+func (q *Queries) ListPendingChangesForOwnerInEnvironmentPage(ctx context.Context, arg ListPendingChangesForOwnerInEnvironmentPageParams) ([]PendingChange, error) {
+	rows, err := q.db.QueryContext(ctx, listPendingChangesForOwnerInEnvironmentPage,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.ChainEnvID,
+		arg.OwnerID,
+		arg.AfterKeyID,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PendingChange
+	for rows.Next() {
+		var i PendingChange
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.EnvironmentID,
+			&i.KeyID,
+			&i.OwnerID,
+			&i.Operation,
+			&i.Ciphertext,
+			&i.StagedFromRevision,
+			&i.StagedFromEntry,
+			&i.CreatedAt,
+			&i.Source,
+			&i.Secret,
+			&i.MaterialSecret,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPendingForReencrypt = `-- name: ListPendingForReencrypt :many
 SELECT id, environment_id, key_id, ciphertext FROM pending_changes
 WHERE org_id = ? AND project_id = ? AND id > ?
@@ -790,10 +862,6 @@ type ListPendingMarkersRow struct {
 	Operation     string
 }
 
-// ListPendingMarkers is the matrix signal's read and the group-closure
-// collision check's read. It returns NO ciphertext: what another principal's
-// draft may disclose is write-presence and nothing else, and the cheapest way
-// to hold that rule is a statement that cannot carry the material.
 func (q *Queries) ListPendingMarkers(ctx context.Context, arg ListPendingMarkersParams) ([]ListPendingMarkersRow, error) {
 	rows, err := q.db.QueryContext(ctx, listPendingMarkers, arg.OrgID, arg.ProjectID)
 	if err != nil {
@@ -1086,6 +1154,69 @@ type ListSnapshotsParams struct {
 
 func (q *Queries) ListSnapshots(ctx context.Context, arg ListSnapshotsParams) ([]Snapshot, error) {
 	rows, err := q.db.QueryContext(ctx, listSnapshots, arg.OrgID, arg.ProjectID, arg.EnvironmentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Snapshot
+	for rows.Next() {
+		var i Snapshot
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrgID,
+			&i.ProjectID,
+			&i.EnvironmentID,
+			&i.Revision,
+			&i.SchemaRevision,
+			&i.PublishedBy,
+			&i.PublishedAt,
+			&i.PayloadPresent,
+			&i.CollectedAt,
+			&i.CollectedPolicy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSnapshotsPage = `-- name: ListSnapshotsPage :many
+SELECT id, org_id, project_id, environment_id, revision, schema_revision,
+       published_by, published_at, payload_present, collected_at, collected_policy
+FROM snapshots
+WHERE org_id = ?1 AND project_id = ?2
+  AND environment_id = ?3
+  AND revision < ?4
+ORDER BY revision DESC LIMIT ?5
+`
+
+type ListSnapshotsPageParams struct {
+	ChainOrgID     string
+	ChainProjectID string
+	ChainEnvID     string
+	BeforeRevision int64
+	PageLimit      int64
+}
+
+// ListSnapshotsPage is the MCP-bounded keyset read (#629). revision is UNIQUE
+// and monotonic per environment, so it is a stable single-column cursor in
+// descending order: the statement fetches strictly below the last returned
+// revision and never materializes the whole history to slice a limit afterwards.
+func (q *Queries) ListSnapshotsPage(ctx context.Context, arg ListSnapshotsPageParams) ([]Snapshot, error) {
+	rows, err := q.db.QueryContext(ctx, listSnapshotsPage,
+		arg.ChainOrgID,
+		arg.ChainProjectID,
+		arg.ChainEnvID,
+		arg.BeforeRevision,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -218,6 +218,11 @@ type EnvironmentReader interface {
 	Get(ctx context.Context, p authz.Proof) (Environment, error)
 	// List returns the project's environments in display order.
 	List(ctx context.Context, p authz.Proof) ([]Environment, error)
+	// ListPage is the bounded keyset read (#629): one page of environments in
+	// List's display-order/name order, strictly past the supplied tuple (-1/""
+	// for the first page), fetching at most limit rows. It never materializes
+	// the whole project to slice a limit afterwards.
+	ListPage(ctx context.Context, p authz.Proof, afterDisplayOrder int64, afterName string, limit int) ([]Environment, error)
 	// Count is the environment-count cap's input, read inside the same
 	// transaction as the insert it bounds.
 	Count(ctx context.Context, p authz.Proof) (int64, error)


### PR DESCRIPTION
## Summary

- expose the five approved read-only MCP configuration tools
- enforce keyset pagination, cursor-chain bounds, and exact encoded response limits
- coordinate rate and concurrency admission across replicas
- keep cursors portable across replicas and token-key rotation

## Verification

- go test ./... -count=1 (4604 passed across 74 packages)
- go build ./...
- go vet ./...
- go test -race ./internal/mcpserver -count=1 (50 passed)
- DCO and cryptographic signature checks

Closes #629