### PR TITLE
Fix post-merge MCP conformance CI #630

### DIFF
--- a/scripts/ci/install-corepack.sh
+++ b/scripts/ci/install-corepack.sh
@@ -12,3 +12,38 @@ if [ "$actual" != "$corepack_version" ]; then
 	printf 'Corepack bootstrap: got %s, want %s\n' "$actual" "$corepack_version" >&2
 	exit 1
 fi
+
+repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
+package_manager=
+for manifest in \
+	web/package.json \
+	clients/ts/package.json \
+	docs/site/package.json \
+	scripts/mcp-conformance/package.json
+do
+	declared=$(node -p 'require(process.argv[1]).packageManager' \
+		"$repo_root/$manifest")
+	case "$declared" in
+		pnpm@*) ;;
+		*)
+			printf 'Corepack bootstrap: %s must pin pnpm, got %s\n' \
+				"$manifest" "$declared" >&2
+			exit 1
+			;;
+	esac
+	if [ -z "$package_manager" ]; then
+		package_manager=$declared
+	elif [ "$declared" != "$package_manager" ]; then
+		printf 'Corepack bootstrap: package manager mismatch: %s has %s, want %s\n' \
+			"$manifest" "$declared" "$package_manager" >&2
+		exit 1
+	fi
+done
+
+corepack install --global "$package_manager"
+actual=$(pnpm --version)
+expected=${package_manager#pnpm@}
+if [ "$actual" != "$expected" ]; then
+	printf 'pnpm bootstrap: got %s, want %s\n' "$actual" "$expected" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- derive one pinned pnpm version from every committed JavaScript package manifest
- fail closed if package manager declarations drift
- activate that exact pnpm during the shared Corepack bootstrap

## Verification
- exact CI sequence with Node 26.7.0 and a clean Corepack home
- `shellcheck scripts/ci/install-corepack.sh`
- `sh -n scripts/ci/install-corepack.sh`
- signature and DCO checks

Repairs the post-merge main CI failure on `f4175a5` from #639.