### PR TITLE
fix(ha): fence approval sweeps against stale leadership #616

### DIFF
--- a/docs/handoff/616-approval-acceptance.md
+++ b/docs/handoff/616-approval-acceptance.md
@@ -1,0 +1,104 @@
+# Handoff: #616 approval acceptance and scheduler write fencing
+
+Issue: <https://github.com/Hikyo-Org/Hikyo/issues/616>.
+Base: `e114b56e2423a0996fa266fafbb59b561712d35d`.
+Implementation: Codex. Parent 1.0 work owns combined review, signed commit, PR,
+exact-head CI, and merge. No deployment claim is made by this handoff.
+
+## Result
+
+The approval expiry scheduler previously fenced claim and renewal, but only
+cancelled jobs after a heartbeat noticed leadership loss. Expiry itself did not
+check a fence. A paused worker could resume after another node acquired the
+lease and mutate requests before cancellation reached it.
+
+The scheduler now carries its lease name, owner, and fence in its term context.
+Every attempt at the common write boundary validates and locks that live lease
+inside the same database transaction as its work. The lock lasts through commit;
+takeover cannot slip between a lease check and tenant mutation. A stale snapshot
+retries against the current fence. PostgreSQL checks `clock_timestamp()` so a
+transaction's old start time cannot revive an expired lease. SQLite uses its
+process clock and existing `BEGIN IMMEDIATE` admission.
+
+`store.ErrSingletonLeaseLost` refuses expired and superseded terms, including a
+restart that reuses the node owner name. Ordinary user requests and single-node
+schedulers have no lease context and retain their existing transaction contract.
+No migration, tenant permission, or public API changes were needed.
+
+This guard applies to scheduler work using `tx.Write`, `tx.WriteResult`, or
+`tx.WriteSerialized`; it does not claim to fence arbitrary external effects or
+proof-free coordination methods. Approval expiry and its audit event already
+share this write boundary and now share its lease guard.
+
+## Acceptance evidence
+
+`internal/isolation/approval_acceptance_test.go` opens independent connection
+pools and independent keyrings on the same datastore. Both SQLite and PostgreSQL
+run every test. SQLite parity is writer-concurrency evidence, not support for
+multi-node SQLite deployments.
+
+- `TestApprovalVoteRetryAcrossNodes`: concurrent duplicate vote delivery remains
+  one vote, one audit, and below a two-person quorum. Two distinct voters race a
+  fresh request to quorum; response-loss retry on another replica stays
+  idempotent. Racing merges produce one commit, one conflict, and one merge audit.
+- `TestApprovalTargetMovementInvalidation`: a different approved request moves
+  the target environment. Two attempts to merge the old approved request fail
+  closed, persist `env_advanced`, emit one `approval.invalidated`, and leave
+  value/draft/revision row counts unchanged.
+- `TestApprovalExpirySchedulerTakeover`: real scheduler terms on separate nodes
+  advance the stored fence. The old context deliberately retains its lease while
+  suppressing cancellation, proving stale work is refused independently of
+  heartbeat timing. The successor expires the first node's request exactly once,
+  including concurrent stale delivery and a repeated sweep.
+- `TestApprovalFenceSerializesTakeover`: a takeover is blocked until an admitted
+  transaction completes; the previous fence then fails closed.
+- `TestApprovalExpiryRejectsExpiredAndReusedOwner`: an expired lease fails even
+  before a successor exists, and a new generation under the same node name does
+  not revive the old term.
+
+## Owner dispositions under delegated judgment
+
+The user explicitly authorized recommended choices without questions in the
+1.0 release task. The complete question/options/choice record is in
+[`docs/reports/1.0/approval-acceptance.html`](../reports/1.0/approval-acceptance.html).
+
+1. **Environment policy scope accepted.** Project defaults cover all project
+   environments. Folders remain organizational and have no authorization scope,
+   as already declared in the MVP boundary amendment.
+2. **Requester-only merge and bypass accepted.** Ordinary publish materializes
+   only the caller's drafts. Being a named bypasser does not confer ownership
+   of another user's staged change. Cross-owner publish needs its own ownership
+   contract before expanding this surface.
+3. **Lazy invalidation accepted.** Policy drift commits invalidation and audit
+   before refusing the next vote or merge. A queue entry may display its prior
+   status until an action checks it, but cannot authorize a stale publish.
+4. **`read@env` request inspection accepted.** The response exposes request and
+   vote metadata, not secret value fields. Voting, ceremony binding, merge, and
+   bypass retain their independent publish, eligibility, and ceremony checks.
+
+The immutable #151 handoff is not edited. Its migration number is corrected
+here: approvals shipped in `00041_change_approvals.sql`, not 00040. Release-wide
+ledger disposition belongs to the parent 1.0 inventory.
+
+## Local validation
+
+All commands used `GOMAXPROCS=2` and `-p 1`. The PostgreSQL base was a newly
+created scratch database `hikyo_616`; the harness used its own
+`hikyo_616_isolation` database. Existing application databases were not reset.
+
+```sh
+go test -p 1 ./internal/isolation \
+  -run '^Test(Approval|Approvals|ConcurrentApproval|ProtectedApproval)' -count=1
+go test -p 1 ./internal/store/tx ./internal/app \
+  -run 'Test(Retry|Scheduler)' -count=1
+go test -p 1 ./internal/isolation -run '^TestInvariant(07|08|09)' -count=1
+go test -race -p 1 ./internal/isolation \
+  -run '^TestApproval(VoteRetryAcrossNodes|TargetMovementInvalidation|ExpirySchedulerTakeover|FenceSerializesTakeover|ExpiryRejectsExpiredAndReusedOwner)$' -count=3
+go vet ./internal/store/tx ./internal/app ./internal/isolation
+```
+
+Results: approval suite passed (30 top-level and engine subtests), scheduler and
+retry tests passed (15 tests), proof/predicate/driver/result confinement passed
+(5 tests). The five new acceptance tests passed three repetitions under the race
+detector on both engines (45 top-level and engine subtests). Scoped vet and
+`git diff --check` passed. Final release verification belongs to the parent PR.

--- a/docs/reports/1.0/approval-acceptance.html
+++ b/docs/reports/1.0/approval-acceptance.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hikyo 1.0: approval acceptance decisions</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; line-height: 1.6; }
+    body { max-width: 72rem; margin: 3rem auto; padding: 0 1.25rem; }
+    h1, h2 { line-height: 1.2; } h2 { margin-top: 2.5rem; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { text-align: left; vertical-align: top; border: 1px solid #8888; padding: .8rem; }
+    th { background: #8882; } code { overflow-wrap: anywhere; }
+    .status { border-left: .3rem solid #278f75; padding: .7rem 1rem; background: #278f7512; }
+    @media (max-width: 42rem) { table, tbody, tr, td, th { display: block; } thead { display: none; } tr { margin-bottom: 1rem; } }
+  </style>
+</head>
+<body>
+  <h1>Approval acceptance for 1.0</h1>
+  <p>Decision date: 2026-09-05. Scope: <a href="https://github.com/Hikyo-Org/Hikyo/issues/616">#616</a>, following
+    <a href="../../handoff/151-change-approvals.md">#151's immutable handoff</a> and
+    <a href="../../adr/mvp-boundary.md">C-APV</a>. Base: <code>e114b56e2423a0996fa266fafbb59b561712d35d</code>.</p>
+  <p class="status">Required for 1.0: approvals already protect production publishing. A stale scheduler leader must not mutate
+    requests after takeover, and reviewed changes must fail closed when their target moves. Implementation and local validation passed;
+    parent release work owns review, CI, PR, and merge.</p>
+
+  <h2>Finding and fix</h2>
+  <p>The scheduler previously fenced lease claim and renewal, then relied on heartbeat cancellation to stop jobs. The expiry transaction
+    did not inspect the lease. A paused leader could resume after takeover and expire requests before its next heartbeat observed the loss.</p>
+  <p>The scheduler now attaches its lease name, owner, and monotonic fence to every leadership-term context. Each write transaction checks
+    and locks the matching, unexpired lease row before executing its closure. The lock remains through commit, so takeover cannot interleave
+    between validation and a tenant mutation. Retries recheck the fence. PostgreSQL uses its current datastore clock; SQLite uses its process clock.
+    Request state and audit remain in one transaction. Ordinary requests and single-node jobs carry no lease context.</p>
+  <p>This guard covers all scheduler jobs that use the common write boundary, including approval expiry. It adds no tenant permissions,
+    bypass path, schema migration, or public API. SQLite's separate-pool test is concurrency parity evidence; HA deployment still requires PostgreSQL.</p>
+
+  <h2>Delegated decisions</h2>
+  <p>The user authorized recommended choices without questions. These are the questions, alternatives, and choices that would otherwise
+    have required disposition. They can be revisited without reconstructing this session.</p>
+  <table>
+    <thead><tr><th>Question</th><th>Options</th><th>Choice and reason</th></tr></thead>
+    <tbody>
+      <tr><td>Should 1.0 introduce folder-scoped approval policies?</td><td>A. Keep environment policies and project-wide defaults.<br>B. Add folder authority.</td>
+        <td><strong>A, accepted.</strong> The locked boundary already names folders as organizational, outside authorization. Environment scopes match actual publish targets.
+          Folder authority would introduce a new security domain, not close an acceptance gap.</td></tr>
+      <tr><td>Can a designated approver or bypasser publish another user's request?</td><td>A. Keep requester-only merge and bypass.<br>B. Add cross-owner draft publishing.</td>
+        <td><strong>A, accepted.</strong> The existing publish path materializes only the caller's staged drafts. The requester must separately hold publish authority;
+          emergency bypass also requires policy membership, a current ceremony, and a reason. Cross-owner publishing requires an independently specified ownership model.</td></tr>
+      <tr><td>Must policy updates eagerly rewrite every pending request?</td><td>A. Keep lazy, fail-closed invalidation.<br>B. Fan policy writes out to environment request rows.</td>
+        <td><strong>A, accepted.</strong> A pinned policy mismatch commits invalidation and its audit before refusing a vote or merge. A stale queue row can remain visible
+          until an action checks it, but cannot authorize publishing. This preserves scoped policy and environment authority.</td></tr>
+      <tr><td>Should reading a request require publish permission?</td><td>A. Retain <code>read@env</code>.<br>B. Require <code>publish@env</code>.</td>
+        <td><strong>A, accepted.</strong> The queue contains request, key identifier, and vote metadata, with no value plaintext. Environment readers may inspect it;
+          voting, ceremonies, merge, and bypass still enforce their own publish and eligibility checks. Read stays audited-none under the existing read contract.</td></tr>
+      <tr><td>How should stale scheduler writes be stopped?</td><td>A. Validate and lock the fence inside the mutation transaction.<br>B. Check the lease before starting work.<br>C. Rely on heartbeat cancellation.</td>
+        <td><strong>A, implemented.</strong> B has a check-to-write race; C leaves a pause/resume window. A serializes takeover with the actual commit and refuses expired,
+          superseded, and reused-owner terms without depending on cancellation.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Acceptance evidence</h2>
+  <p>New tests live in <a href="../../../internal/isolation/approval_acceptance_test.go"><code>internal/isolation/approval_acceptance_test.go</code></a>.
+    All run on SQLite and PostgreSQL using independently opened pools and independently loaded keyrings under the same root key.</p>
+  <table>
+    <thead><tr><th>Test</th><th>Contract checked</th></tr></thead>
+    <tbody>
+      <tr><td><code>TestApprovalVoteRetryAcrossNodes</code></td><td>Duplicate concurrent vote delivery does not reach a two-person quorum or duplicate audit.
+        Distinct voters reach quorum; a retry on another replica stays idempotent. Racing merge delivery produces one committed merge and one refusal.</td></tr>
+      <tr><td><code>TestApprovalTargetMovementInvalidation</code></td><td>A separately approved publish advances the same environment. Merging the older approved request
+        twice refuses, persists <code>env_advanced</code>, emits one <code>approval.invalidated</code>, and does not change value, draft, or revision row counts.</td></tr>
+      <tr><td><code>TestApprovalExpirySchedulerTakeover</code></td><td>Real scheduler terms advance the persisted fence across independent nodes. An uncancelled old term
+        cannot expire a request created on the first node. The successor expires it once despite concurrent stale delivery and a retry.</td></tr>
+      <tr><td><code>TestApprovalFenceSerializesTakeover</code></td><td>A takeover waits for an admitted transaction to commit. The prior fence is refused afterwards,
+        proving the guard is held through the mutation boundary.</td></tr>
+      <tr><td><code>TestApprovalExpiryRejectsExpiredAndReusedOwner</code></td><td>An expired lease fails even with no successor. Reusing a node name does not revive
+        its old fence; only the new generation can expire and audit the request.</td></tr>
+    </tbody>
+  </table>
+  <p id="validation">Local validation passed: the complete approval suite on both engines (30 top-level and engine subtests), scheduler and transaction retry
+    tests (15), and proof/predicate/driver/result confinement invariants (5). All five new acceptance tests also passed three repetitions under the Go
+    race detector on both engines (45 top-level and engine subtests). Scoped <code>go vet</code> and <code>git diff --check</code> passed.
+    The initial fixture-only peer root-key mismatch was corrected by loading independent keyrings under the same retained root.
+    The scratch PostgreSQL base was <code>hikyo_616</code>; the isolation harness reset only <code>hikyo_616_isolation</code>.</p>
+
+  <h2>Evidence hygiene</h2>
+  <p>The original handoff remains unchanged. Its migration reference is corrected here: approval tables shipped in
+    <code>00041_change_approvals.sql</code>, not 00040. A new <a href="../../handoff/616-approval-acceptance.md">#616 handoff</a>
+    records this work. The release-wide status ledger belongs to the parent 1.0 inventory; this focused change does not independently expand that ledger.</p>
+</body>
+</html>

--- a/internal/app/scheduler.go
+++ b/internal/app/scheduler.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"sync/atomic"
 	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/store"
 )
 
 const (
@@ -60,7 +62,9 @@ type Scheduler struct {
 	// behaviour, unchanged). When set, jobs run only while this node holds the
 	// scheduler lease, so every singleton executes at most once across the
 	// cluster and a stale leader that loses the lease has its in-flight jobs
-	// cancelled.
+	// cancelled. Its term identity also travels in the job context: tx.Write
+	// locks and validates that fence before mutation, so a paused leader cannot
+	// commit after takeover even before cancellation reaches it.
 	Lease     LeaseManager
 	NodeID    string
 	LeaseTTL  time.Duration
@@ -277,7 +281,7 @@ func (s *Scheduler) runHA(ctx context.Context) {
 					expiresAt = expires
 					s.leader.Store(true)
 					s.logger().Info("scheduler acquired leadership", "node", s.NodeID, "fence", fence)
-					termCtx, cancel := context.WithCancel(ctx)
+					termCtx, cancel := context.WithCancel(store.WithSingletonLease(ctx, schedulerLeaseName, s.NodeID, fence))
 					termCancel = cancel
 					termDone = make(chan struct{})
 					done := termDone

--- a/internal/isolation/approval_acceptance_test.go
+++ b/internal/isolation/approval_acceptance_test.go
@@ -1,0 +1,401 @@
+package isolation
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/app"
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/schema"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+// approvalPeer opens independent connection pools on the SAME datastore. The
+// SQLite leg exercises independent writers, not HA deployment support; real HA
+// deployments require PostgreSQL. No process-local service state is shared.
+func approvalPeer(t *testing.T, db *store.DB) *store.DB {
+	t.Helper()
+	cfg := store.Config{Engine: db.Engine()}
+	if db.Engine() == store.EnginePostgres {
+		cfg.DSN = db.PG().Config().ConnString()
+	} else {
+		var sequence int
+		var name string
+		if err := db.SQLiteRead().QueryRowContext(t.Context(), "PRAGMA database_list").Scan(&sequence, &name, &cfg.Path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	peer, err := store.Open(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { peer.Close() })
+	root, err := (probeRootSource{db: db}).Current(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadAndRegisterKeyring(t, peer, root)
+	return peer
+}
+
+type approvalNode struct {
+	approvals *service.Approvals
+	revisions *service.Revisions
+	values    *service.Values
+}
+
+func newApprovalNode(t *testing.T, db *store.DB) approvalNode {
+	t.Helper()
+	kr, auth := probeKeyring(t, db), authService(t, db)
+	return approvalNode{
+		approvals: &service.Approvals{DB: db, Auth: auth, Keyring: kr},
+		revisions: &service.Revisions{DB: db, Auth: auth, Keyring: kr},
+		values:    &service.Values{DB: db, Auth: auth, Keyring: kr},
+	}
+}
+
+// Both keys exist before any request pins its target, so later tests move only
+// the value revision, not the schema or policy.
+func approvalAcceptanceFixture(t *testing.T, db *store.DB, quorum int) (approvalNode, approvalNode, domain.Scope) {
+	t.Helper()
+	ctx := t.Context()
+	a, b := newApprovalNode(t, db), newApprovalNode(t, approvalPeer(t, db))
+	project := domain.Scope{Org: orgA, Project: prjA1}
+	env, err := (&service.Environments{DB: db, Keyring: a.approvals.Keyring}).Create(ctx, service.LocalPrincipal(alice), project, "approval-acceptance", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := domain.Scope{Org: orgA, Project: prjA1, Env: domain.EnvID(env.ID)}
+	for _, name := range []string{"ACCEPTANCE_A", "ACCEPTANCE_B"} {
+		if _, err := (&service.Keys{DB: db, Keyring: a.approvals.Keyring}).Create(ctx, service.LocalPrincipal(alice), project, service.KeySpec{
+			Name: name, Classification: string(schema.Config),
+			Declaration: schema.Declaration{Rule: &schema.Rule{Type: schema.TypeString}},
+			Presence:    schema.DefaultPresenceRules(),
+		}, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := (&service.Grants{DB: db}).Create(ctx, service.LocalPrincipal(orgAdmin), service.GrantSpec{
+		Target: bob, Capability: domain.CapPublish, Scope: domain.Scope{Org: orgA},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.approvals.CreatePolicy(ctx, service.LocalPrincipal(orgAdmin), project, service.ApprovalPolicyInput{
+		EnvironmentID: env.ID, MinApprovals: quorum, RequestTTLSeconds: 3600, Enabled: true,
+		Approvers: []service.ApprovalApproverSpec{
+			{Kind: "principal", SubjectID: string(custodian)},
+			{Kind: "principal", SubjectID: string(bob)},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return a, b, scope
+}
+
+func (n approvalNode) request(t *testing.T, scope domain.Scope, key string) string {
+	t.Helper()
+	staged, err := n.values.Set(t.Context(), service.LocalPrincipal(alice), scope, key, "reviewed-value", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := n.revisions.PublishPlanned(t.Context(), service.LocalPrincipal(alice), scope,
+		service.PublishRequest{VersionIDs: []string{staged.VersionID}})
+	if err != nil || result.CreatedApprovalRequest == nil {
+		t.Fatalf("create request: result=%+v err=%v", result, err)
+	}
+	return result.CreatedApprovalRequest.ID
+}
+
+func approvalAuditCount(t *testing.T, db *store.DB, request, event string) int64 {
+	t.Helper()
+	return queryInt(t, db, "SELECT COUNT(*) FROM audit_tenant_events WHERE object_id = '"+request+"' AND type = '"+event+"'")
+}
+
+// A transport retry may arrive on another replica, concurrently with the first
+// delivery or after its response was lost. Both must return the same decision,
+// with one vote row and one audit event. Two independent voters then race the
+// final quorum, followed by duplicate merge delivery on both replicas.
+func TestApprovalVoteRetryAcrossNodes(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		a, b, scope := approvalAcceptanceFixture(t, db, 2)
+		request := a.request(t, scope, "ACCEPTANCE_A")
+		runVotes := func(actors []domain.PrincipalID) {
+			t.Helper()
+			start := make(chan struct{})
+			results := make(chan error, 2)
+			for i, node := range []approvalNode{a, b} {
+				go func() {
+					<-start
+					_, err := node.approvals.Vote(t.Context(), service.LocalPrincipal(actors[i]), scope, request, "approve")
+					results <- err
+				}()
+			}
+			close(start)
+			for range 2 {
+				if err := <-results; err != nil {
+					t.Fatalf("cross-node vote delivery: %v", err)
+				}
+			}
+		}
+		runVotes([]domain.PrincipalID{custodian, custodian})
+		if state := requestState(t, db, request); state != "open" {
+			t.Fatalf("duplicate voter reached quorum: state=%s", state)
+		}
+		if got := approvalAuditCount(t, db, request, "approval.voted"); got != 1 {
+			t.Fatalf("duplicate vote audit events=%d, want 1", got)
+		}
+		// A second request lets two distinct voters race from zero votes, on
+		// independent pools, rather than racing one retry against a new vote.
+		request = a.request(t, scope, "ACCEPTANCE_B")
+		runVotes([]domain.PrincipalID{custodian, bob})
+		if state := requestState(t, db, request); state != "approved" {
+			t.Fatalf("distinct voters did not reach quorum: state=%s", state)
+		}
+		if got := queryInt(t, db, "SELECT COUNT(*) FROM approval_votes WHERE request_id = '"+request+"'"); got != 2 {
+			t.Fatalf("vote rows=%d, want 2", got)
+		}
+		if got := approvalAuditCount(t, db, request, "approval.voted"); got != 2 {
+			t.Fatalf("vote audit events=%d, want 2", got)
+		}
+		if _, err := b.approvals.Vote(t.Context(), service.LocalPrincipal(custodian), scope, request, "approve"); err != nil {
+			t.Fatalf("retry after quorum on the other node: %v", err)
+		}
+		if got := approvalAuditCount(t, db, request, "approval.voted"); got != 2 {
+			t.Fatalf("quorum retry duplicated audit: events=%d, want 2", got)
+		}
+		start, results := make(chan struct{}), make(chan error, 2)
+		for _, node := range []approvalNode{a, b} {
+			go func() {
+				<-start
+				_, err := node.revisions.PublishPlanned(t.Context(), service.LocalPrincipal(alice), scope,
+					service.PublishRequest{ApprovalRequestID: request})
+				results <- err
+			}()
+		}
+		close(start)
+		commits, conflicts := 0, 0
+		for range 2 {
+			switch err := <-results; {
+			case err == nil:
+				commits++
+			case errors.Is(err, domain.ErrConflict):
+				conflicts++
+			default:
+				t.Fatalf("cross-node merge delivery: %v", err)
+			}
+		}
+		if commits != 1 || conflicts != 1 || approvalAuditCount(t, db, request, "approval.merged") != 1 {
+			t.Fatalf("duplicate merge: commits=%d conflicts=%d, want exactly one of each and one audit", commits, conflicts)
+		}
+	})
+}
+
+func TestApprovalTargetMovementInvalidation(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		a, b, scope := approvalAcceptanceFixture(t, db, 1)
+		stale := a.request(t, scope, "ACCEPTANCE_A")
+		advance := b.request(t, scope, "ACCEPTANCE_B")
+		for _, request := range []string{stale, advance} {
+			if _, err := b.approvals.Vote(t.Context(), service.LocalPrincipal(custodian), scope, request, "approve"); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := b.revisions.PublishPlanned(t.Context(), service.LocalPrincipal(alice), scope,
+			service.PublishRequest{ApprovalRequestID: advance}); err != nil {
+			t.Fatalf("advance target through an approved publish: %v", err)
+		}
+		before := rowCounts(t, db)
+		for range 2 {
+			if _, err := a.revisions.PublishPlanned(t.Context(), service.LocalPrincipal(alice), scope,
+				service.PublishRequest{ApprovalRequestID: stale}); !errors.Is(err, domain.ErrConflict) {
+				t.Fatalf("merge after target movement=%v, want conflict", err)
+			}
+		}
+		if state := requestState(t, db, stale); state != "invalidated" {
+			t.Fatalf("stale state=%s, want invalidated", state)
+		}
+		if cause := queryString(t, db, "SELECT invalidated_cause FROM approval_requests WHERE id = '"+stale+"'"); cause != "env_advanced" {
+			t.Fatalf("invalidation cause=%s, want env_advanced", cause)
+		}
+		if got := approvalAuditCount(t, db, stale, "approval.invalidated"); got != 1 {
+			t.Fatalf("invalidation audit events=%d, want 1", got)
+		}
+		for table, count := range before {
+			if got := queryInt(t, db, "SELECT COUNT(*) FROM "+table); got != count {
+				t.Errorf("stale merge changed %s: %d -> %d", table, count, got)
+			}
+		}
+	})
+}
+
+func TestApprovalExpirySchedulerTakeover(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		a, b, scope := approvalAcceptanceFixture(t, db, 1)
+		request := a.request(t, scope, "ACCEPTANCE_A")
+		future := time.Now().UTC().Add(2 * time.Hour)
+		a.approvals.Now = func() time.Time { return future }
+		b.approvals.Now = func() time.Time { return future }
+		startNode := func(node approvalNode, name string) (context.Context, func()) {
+			t.Helper()
+			terms := make(chan context.Context, 1)
+			scheduler := &app.Scheduler{
+				Lease: node.approvals.DB.Coordination(), NodeID: name, LeaseTTL: time.Minute,
+				Heartbeat: 20 * time.Millisecond, Interval: time.Hour,
+				Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				Jobs: []app.ScheduledJob{{Name: "approval_expiry_sweep", Run: func(ctx context.Context) error {
+					// Retain the real term identity while deliberately suppressing
+					// cancellation, modeling a paused worker before its next write.
+					select {
+					case terms <- context.WithoutCancel(ctx):
+					default:
+					}
+					return nil
+				}}},
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			done := make(chan struct{})
+			go func() { defer close(done); scheduler.Run(ctx) }()
+			var once sync.Once
+			stop := func() { once.Do(func() { cancel(); <-done }) }
+			t.Cleanup(stop)
+			select {
+			case term := <-terms:
+				return term, stop
+			case <-time.After(5 * time.Second):
+				t.Fatal("scheduler did not acquire leadership")
+				return nil, stop
+			}
+		}
+		oldTerm, stopA := startNode(a, "approval-node-a")
+		oldFence := queryInt(t, db, "SELECT fence_token FROM singleton_leases WHERE name = 'scheduler'")
+		stopA()
+		newTerm, _ := startNode(b, "approval-node-b")
+		if fence := queryInt(t, db, "SELECT fence_token FROM singleton_leases WHERE name = 'scheduler'"); fence <= oldFence {
+			t.Fatalf("takeover fence=%d, want > %d", fence, oldFence)
+		}
+		if err := a.approvals.ExpireDue(oldTerm); !errors.Is(err, store.ErrSingletonLeaseLost) {
+			t.Fatalf("uncancelled stale leader expiry=%v, want lease lost", err)
+		}
+		if state := requestState(t, db, request); state != "open" || approvalAuditCount(t, db, request, "approval.expired") != 0 {
+			t.Fatalf("stale leader changed request: state=%s", state)
+		}
+		start, results := make(chan struct{}), make(chan error, 2)
+		for _, work := range []struct {
+			node approvalNode
+			ctx  context.Context
+		}{{a, oldTerm}, {b, newTerm}} {
+			go func() { <-start; results <- work.node.approvals.ExpireDue(work.ctx) }()
+		}
+		close(start)
+		for range 2 {
+			if err := <-results; err != nil && !errors.Is(err, store.ErrSingletonLeaseLost) {
+				t.Fatalf("raced expiry: %v", err)
+			}
+		}
+		if err := b.approvals.ExpireDue(newTerm); err != nil {
+			t.Fatalf("takeover retry: %v", err)
+		}
+		if state := requestState(t, db, request); state != "expired" || approvalAuditCount(t, db, request, "approval.expired") != 1 {
+			t.Fatalf("takeover expiry/retry: state=%s, want expired and one audit", state)
+		}
+	})
+}
+
+// A fence guard must hold its row lock through the SAME transaction as the
+// tenant mutation. A preflight lookup alone would let takeover slip between
+// validation and commit. ClaimLease uses a future instant to deterministically
+// model expiry while the old transaction is paused, without waiting a TTL.
+func TestApprovalFenceSerializesTakeover(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		a, b, _ := approvalAcceptanceFixture(t, db, 1)
+		now := time.Now().UTC()
+		fence, held, err := db.Coordination().ClaimLease(t.Context(), "approval-fence-test", "node-a", now, now.Add(time.Minute))
+		if err != nil || !held {
+			t.Fatalf("claim: held=%v err=%v", held, err)
+		}
+		term := store.WithSingletonLease(t.Context(), "approval-fence-test", "node-a", fence)
+		entered, release, writeDone := make(chan struct{}), make(chan struct{}), make(chan error, 1)
+		var releaseOnce sync.Once
+		releaseWrite := func() { releaseOnce.Do(func() { close(release) }) }
+		t.Cleanup(releaseWrite)
+		go func() {
+			writeDone <- tx.Write(term, a.approvals.DB, func(context.Context, store.Repos, *authz.TxAuthorizer) error {
+				close(entered)
+				<-release
+				return nil
+			})
+		}()
+		select {
+		case <-entered:
+		case err := <-writeDone:
+			t.Fatalf("fenced write did not start: %v", err)
+		}
+		takeover := make(chan error, 1)
+		go func() {
+			newFence, held, err := b.approvals.DB.Coordination().ClaimLease(t.Context(), "approval-fence-test", "node-b", now.Add(2*time.Minute), now.Add(3*time.Minute))
+			if err == nil && (!held || newFence <= fence) {
+				err = errors.New("takeover did not advance the fence")
+			}
+			takeover <- err
+		}()
+		select {
+		case err := <-takeover:
+			t.Fatalf("takeover escaped the in-flight transaction lock: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		releaseWrite()
+		if err := <-writeDone; err != nil {
+			t.Fatal(err)
+		}
+		if err := <-takeover; err != nil {
+			t.Fatal(err)
+		}
+		if err := a.approvals.ExpireDue(term); !errors.Is(err, store.ErrSingletonLeaseLost) {
+			t.Fatalf("old term after takeover=%v, want lease lost", err)
+		}
+	})
+}
+
+func TestApprovalExpiryRejectsExpiredAndReusedOwner(t *testing.T) {
+	forEngines(t, func(t *testing.T, db *store.DB) {
+		a, b, scope := approvalAcceptanceFixture(t, db, 1)
+		request := a.request(t, scope, "ACCEPTANCE_A")
+		future := time.Now().UTC().Add(2 * time.Hour)
+		a.approvals.Now = func() time.Time { return future }
+		b.approvals.Now = func() time.Time { return future }
+		now := time.Now().UTC()
+		oldFence, held, err := db.Coordination().ClaimLease(t.Context(), "scheduler", "restarted-node", now.Add(-time.Hour), now.Add(-time.Minute))
+		if err != nil || !held {
+			t.Fatalf("seed expired lease: held=%v err=%v", held, err)
+		}
+		oldTerm := store.WithSingletonLease(t.Context(), "scheduler", "restarted-node", oldFence)
+		if err := a.approvals.ExpireDue(oldTerm); !errors.Is(err, store.ErrSingletonLeaseLost) {
+			t.Fatalf("expired lease without successor=%v, want lease lost", err)
+		}
+		newFence, held, err := b.approvals.DB.Coordination().ClaimLease(t.Context(), "scheduler", "restarted-node", now, now.Add(time.Minute))
+		if err != nil || !held || newFence <= oldFence {
+			t.Fatalf("reused owner claim: held=%v fence=%d err=%v", held, newFence, err)
+		}
+		if err := a.approvals.ExpireDue(oldTerm); !errors.Is(err, store.ErrSingletonLeaseLost) {
+			t.Fatalf("same owner with old fence=%v, want lease lost", err)
+		}
+		if state := requestState(t, db, request); state != "open" || approvalAuditCount(t, db, request, "approval.expired") != 0 {
+			t.Fatalf("expired/superseded term changed request: state=%s", state)
+		}
+		newTerm := store.WithSingletonLease(t.Context(), "scheduler", "restarted-node", newFence)
+		if err := b.approvals.ExpireDue(newTerm); err != nil {
+			t.Fatal(err)
+		}
+		if state := requestState(t, db, request); state != "expired" || approvalAuditCount(t, db, request, "approval.expired") != 1 {
+			t.Fatalf("new term did not expire exactly once: state=%s", state)
+		}
+	})
+}

--- a/internal/service/approvals.go
+++ b/internal/service/approvals.go
@@ -533,7 +533,9 @@ func (s *Approvals) Vote(ctx context.Context, actor Actor, scope domain.Scope, r
 
 // ExpireDue is one bounded scheduler batch. It resolves up to 100 active
 // requests past expiry and emits a per-request event under scoped scheduler
-// authority. Repeated calls drain a backlog with committed progress.
+// authority. Repeated calls drain a backlog with committed progress. Under HA,
+// tx.WriteResult validates the scheduler context's lease in this transaction,
+// fencing expiry and its audit event together against stale leadership terms.
 func (s *Approvals) ExpireDue(ctx context.Context) error {
 	now := store.CanonTime(s.now())
 	_, err := tx.WriteResult(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) (int, error) {

--- a/internal/store/coordination_fence.go
+++ b/internal/store/coordination_fence.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrSingletonLeaseLost refuses work from an expired or superseded leadership
+// term, even if the scheduler has not yet observed its failed heartbeat.
+var ErrSingletonLeaseLost = errors.New("store: singleton lease lost")
+
+type singletonLeaseKey struct{}
+
+type singletonLease struct {
+	name  string
+	owner string
+	fence int64
+}
+
+// WithSingletonLease binds scheduler work to one leadership term. tx.Write
+// checks this identity inside every attempt, using the same transaction as the
+// job's writes. It is infrastructure identity, never tenant authorization.
+// Ordinary requests and single-node jobs do not carry a singleton lease.
+func WithSingletonLease(ctx context.Context, name, owner string, fence int64) context.Context {
+	return context.WithValue(ctx, singletonLeaseKey{}, singletonLease{name: name, owner: owner, fence: fence})
+}
+
+// GuardPGSingletonLease locks a live matching lease through transaction commit.
+// A takeover cannot pass the lock while admitted work is committing. After a
+// takeover, an old SERIALIZABLE snapshot retries and checks the new fence.
+// clock_timestamp, rather than the transaction's start time, also refuses a
+// term that expired while this transaction waited for the lease row.
+func GuardPGSingletonLease(ctx context.Context, transaction pgx.Tx) error {
+	lease, present := ctx.Value(singletonLeaseKey{}).(singletonLease)
+	if !present {
+		return nil
+	}
+	result, err := transaction.Exec(ctx, `UPDATE singleton_leases SET fence_token = fence_token
+		WHERE name = $1 AND owner = $2 AND fence_token = $3 AND expires_at > clock_timestamp()`,
+		lease.name, lease.owner, lease.fence)
+	if err != nil {
+		return fmt.Errorf("store: guard singleton lease: %w", err)
+	}
+	if result.RowsAffected() != 1 {
+		return ErrSingletonLeaseLost
+	}
+	return nil
+}
+
+// GuardSQLiteSingletonLease is the SQLite counterpart. BEGIN IMMEDIATE holds
+// write admission through commit; SQLite's process clock is authoritative.
+func GuardSQLiteSingletonLease(ctx context.Context, transaction *sql.Tx) error {
+	lease, present := ctx.Value(singletonLeaseKey{}).(singletonLease)
+	if !present {
+		return nil
+	}
+	result, err := transaction.ExecContext(ctx, `UPDATE singleton_leases SET fence_token = fence_token
+		WHERE name = ? AND owner = ? AND fence_token = ? AND expires_at > ?`,
+		lease.name, lease.owner, lease.fence, fixedStamp(time.Now().UTC()))
+	if err != nil {
+		return fmt.Errorf("store: guard singleton lease: %w", err)
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("store: guard singleton lease result: %w", err)
+	}
+	if count != 1 {
+		return ErrSingletonLeaseLost
+	}
+	return nil
+}

--- a/internal/store/tx/tx.go
+++ b/internal/store/tx/tx.go
@@ -179,6 +179,10 @@ func writeOnce(ctx context.Context, db *store.DB, fn WriteFn) error {
 	if err != nil {
 		return err
 	}
+	if err := store.GuardSQLiteSingletonLease(ctx, sqtx); err != nil {
+		_ = sqtx.Rollback()
+		return err
+	}
 	az := authz.NewTxAuthorizer(authn.NewSQLite(sqtx), tok)
 	err = fn(ctx, store.SQLiteTxRepos(sqtx, tok), az)
 	if err != nil {
@@ -204,6 +208,10 @@ func writePostgresOnce(ctx context.Context, db *store.DB, beginner postgresBegin
 func runPostgresTransaction(ctx context.Context, beginner postgresBeginner, tok *authz.TxToken, fn WriteFn) (*authz.TxAuthorizer, error) {
 	pgtx, err := beginner.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
 	if err != nil {
+		return nil, err
+	}
+	if err := store.GuardPGSingletonLease(ctx, pgtx); err != nil {
+		_ = pgtx.Rollback(ctx)
 		return nil, err
 	}
 	az := authz.NewTxAuthorizer(authn.NewPG(pgtx), tok)


### PR DESCRIPTION
An HA scheduler could continue expiring approval requests after another node took over, until its heartbeat detected the lost lease. Bind each scheduled transaction to its exact live lease and hold that lease row through commit, so an uncancelled stale leader cannot mutate requests or audit events.

Add both-engine acceptance with independent connection pools/keyrings for takeover, stale and expired terms, lock-through-commit, vote retry/races, merge retry, and target movement invalidation. Preserve environment-scoped policies, requester-owned publication, lazy fail-closed invalidation and read-scoped inspection; the report records the recommended dispositions and reasons.

Validation: full approval scenarios on SQLite/PostgreSQL; new acceptance race tests three times; scheduler/retry and boundary invariants; scoped vet. Parent independently reran approval, scheduler, transaction/retry and boundary checks. Standards and spec reviews clean. No UI or API contract change.

Evidence: `docs/reports/1.0/approval-acceptance.html` and `docs/handoff/616-approval-acceptance.md`.

Closes #616.
