### PR TITLE
fix(docs): patch vulnerable fast-uri build dependency

### DIFF
--- a/docs/handoff/dependency-security-pre-1.0.md
+++ b/docs/handoff/dependency-security-pre-1.0.md
@@ -1,0 +1,25 @@
+# Pre-1.0 docs dependency security handoff
+
+Base: `f4175a5d`. Branch: `fix/one-zero-dependency-security`. No commit or push; parent owns review, signed delivery and merge on green.
+
+## Change
+
+`docs/site/pnpm-lock.yaml` moves the sole `fast-uri` resolution from 3.1.5 to 3.1.7 through existing Ajv 8.20.0. No manifest, override, direct dependency, major version, or unrelated package version changes.
+
+Live GitHub alerts #9-12 name GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf and GHSA-jqff-g426-hqxp, first patched in 3.1.6. Upstream [3.1.7](https://github.com/fastify/fast-uri/releases/tag/v3.1.7) additionally fixes GHSA-qw65-cvwx-89v3 and GHSA-58mr-gqgx-xq4g. Staying on the compatible v3 release line is recommended.
+
+The package manager generated the update with `pnpm update fast-uri --depth 100 --lockfile-only`. It also refreshed unrelated optional-peer metadata. Only its three unmodified fast-uri hunks were retained: package version/integrity, Ajv dependency edge, and snapshot. No integrity hash was authored or modified by hand. Frozen installation subsequently passed against that exact minimal lockfile.
+
+## Evidence
+
+- Pinned Node 26.7.0, pnpm 11.24.0.
+- Frozen install passes and peer check reports no issues.
+- `pnpm why fast-uri` finds exactly one version, 3.1.7; routes are Workbox build and Astro checker development dependencies through Ajv.
+- `pnpm audit --json` reports zero vulnerabilities across 955 total dependencies at all severities. JSON: `/tmp/hikyo-dependency-audit.json`.
+- Canonical `scripts/ci/verify-docs.sh` passed with `POSTHOG_REQUIRED=true` and repository public analytics variables; 39-page static build, 98-file precache, required analytics, browser offline navigation and all policy/fallback fixtures passed; details in the [HTML report](../reports/1.0/dependency-security.html). Log: `/tmp/hikyo-dependency-docs.log`.
+
+This fixes a known vulnerable build dependency. The dependency graph is not proof of an exploitable Go-server request path. GitHub alert closure remains a post-merge check.
+
+## Next parent action
+
+Review the four-line lockfile diff and validation report. Include these files in the signed 1.0 readiness PR, merge only after exact-head CI passes, then query Dependabot to confirm alerts #9-12 closed on the default branch.

--- a/docs/reports/1.0/dependency-security.html
+++ b/docs/reports/1.0/dependency-security.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>1.0 dependency security decisions</title>
+<style>body{font:16px/1.6 system-ui;max-width:1000px;margin:40px auto;padding:0 24px;background:#101820;color:#eaf1f5}h1,h2{color:#a8dfbf}table{border-collapse:collapse;width:100%}td,th{border:1px solid #53606a;padding:12px;text-align:left}code{color:#ffc985}a{color:#9bd9ff}</style>
+<h1>1.0 dependency security: docs toolchain</h1>
+<p>Base: <code>f4175a5d</code>. Decision owner: Codex under explicit unattended production-readiness authorization. Four open high-severity Dependabot alerts, #9 through #12, identify <code>fast-uri@3.1.5</code> in <code>docs/site/pnpm-lock.yaml</code>.</p>
+<h2>Decision record</h2>
+<table>
+<tr><th>Question</th><th>Options</th><th>Recommended choice and why</th></tr>
+<tr><td>Address before 1.0?</td><td>Defer because docs-only; update the vulnerable transitive dependency.</td><td>Update. Enterprise self-hosting readiness includes a maintained build toolchain. The observed dependency path is docs development/build tooling through Ajv, not evidence of a remotely exploitable Go server.</td></tr>
+<tr><td>Which version?</td><td>First patched 3.1.6; current compatible 3.1.7; major upgrade to 4.x.</td><td>3.1.7. It satisfies existing Ajv constraints, fixes the four reported advisories, and the upstream security release fixes two additional high-severity parser issues. No major upgrade or direct dependency was needed.</td></tr>
+<tr><td>Keep unrelated lockfile churn?</td><td>Keep pnpm's optional-peer metadata refresh; retain only generated package, dependency edge and snapshot changes.</td><td>Retain the three exact pnpm-generated fast-uri hunks. Four lines change. No integrity hash was invented or edited; the npm registry reports the same integrity. Frozen installation and peer validation prove the retained graph is installable.</td></tr>
+</table>
+<h2>Primary evidence</h2>
+<table>
+<tr><th>Advisory</th><th>Issue addressed</th></tr>
+<tr><td><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-5jgf-p345-68v8">GHSA-5jgf-p345-68v8</a></td><td>Scheme-relative IDN host canonicalization.</td></tr>
+<tr><td><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc">GHSA-f65p-4m7j-42xc</a></td><td>Malformed IPv6 host normalization.</td></tr>
+<tr><td><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-fph4-wmhf-6fwf">GHSA-fph4-wmhf-6fwf</a></td><td>Repeated hostname percent-decoding.</td></tr>
+<tr><td><a href="https://github.com/fastify/fast-uri/security/advisories/GHSA-jqff-g426-hqxp">GHSA-jqff-g426-hqxp</a></td><td>Percent-encoded scheme normalization.</td></tr>
+</table>
+<p>The four advisories identify 3.1.6 as the first patched v3 release. The <a href="https://github.com/fastify/fast-uri/releases/tag/v3.1.7">upstream 3.1.7 release</a> adds fixes for GHSA-qw65-cvwx-89v3 and GHSA-58mr-gqgx-xq4g. Current registry integrity: <code>sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==</code>.</p>
+<h2>Verification</h2>
+<p>Node 26.7.0 and pinned pnpm 11.24.0. Frozen install passes; peer check reports no issues; <code>pnpm audit --json</code> reports zero vulnerabilities at every severity across 955 total dependencies. <code>pnpm why fast-uri</code> finds one version, 3.1.7, through Ajv 8.20.0 in Workbox and Astro's checker toolchain.</p>
+<p id="docs-verification">Canonical <code>scripts/ci/verify-docs.sh</code> passed with <code>POSTHOG_REQUIRED=true</code> and repository-configured public analytics variables. Astro check: 18 files, zero errors, warnings or hints. Static build generated 39 pages and precached 98 files. OSS policy, PWA manifest/assets, required PostHog events, real-browser offline navigation, governance/disclosure/package-manager fixtures, live-docs fixture and fallback-channel fixture all passed. Log: <code>/tmp/hikyo-dependency-docs.log</code>.</p>
+<p>Parent owns signed commit, review, exact-head CI and merge. Dependabot alert closure must be confirmed after the lockfile reaches the default branch; this report does not claim remote alerts are already closed.</p>
+</html>

--- a/docs/site/pnpm-lock.yaml
+++ b/docs/site/pnpm-lock.yaml
@@ -2714,8 +2714,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6796,7 +6796,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7428,7 +7428,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
Updates the docs build dependency fast-uri from 3.1.5 to 3.1.7, resolving four open high-severity dependency alerts and two additional upstream fixes. Only the existing Ajv dependency resolution changes.

Validation: frozen installation, zero-vulnerability audit, and the complete docs verification pipeline passed, including offline browser navigation and analytics policy checks. The HTML decision report and reproducible handoff are committed.
