### PR TITLE
fix(web): distinguish folders from linked keys

### DIFF
--- a/docs/handoff/folders-linked-keys.md
+++ b/docs/handoff/folders-linked-keys.md
@@ -1,0 +1,7 @@
+# Folders and linked keys
+
+Folders now determine matrix and sidebar placement even when a key belongs to a key group. Key groups appear as Linked keys, with a separate per-key relationship label and publishing/presence explanations in the editors. Server semantics and API field names remain unchanged.
+
+Regression coverage: a linked key stays under its folder; browser lifecycle selectors use the new terminology. Delivery proceeds through a signed PR and exact-head CI.
+
+Validation: Node 26.7.0 typecheck and production build passed; 684 web unit tests passed, followed by 9 catalogue tests after the error-copy adjustment. Linking/unlinking and catalogue lifecycle browser flows passed on desktop and mobile (2 each). Mobile screenshot is in the ignored web/test-results directory.

--- a/web/e2e/flows/matrix.spec.ts
+++ b/web/e2e/flows/matrix.spec.ts
@@ -609,6 +609,7 @@ const zCreatedKey = z.object({ id: z.string() });
 const CANARY = 'AKIAIOSFODNN7EXAMPLE';
 const zKeyRead = z.object({
   name: z.string(),
+  folder_path: z.string(),
   group_id: z.string(),
   declaration: z.object({
     rule: z
@@ -756,13 +757,20 @@ test.describe('catalogue declaration detail', () => {
     const keyPath = `/api/v1/orgs/${seed.org}/projects/${seed.project}/keys/${keyId}`;
     try {
       await page.goto(`/orgs/${seed.org}/projects/${seed.project}/matrix/keys/${keyId}`);
-      const groupSelect = page.getByLabel('Key group');
+      const groupSelect = page.getByLabel('Linked-key set');
       await groupSelect.selectOption(group.id);
-      await expect(page.getByRole('status').filter({ hasText: 'Group updated.' })).toBeVisible();
-      expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).group_id).toBe(group.id);
+      await expect(page.getByRole('status').filter({ hasText: 'Linked keys updated.' })).toBeVisible();
+      const linkedKey = await fixtureApiCall(token, 'GET', keyPath, zKeyRead);
+      expect(linkedKey.group_id).toBe(group.id);
+      await page.goto(MATRIX_PATH);
+      await expect(page.locator('.matrix__linked-keys').filter({ hasText: `catgrp-${testInfo.project.name}` })).toBeVisible();
+      await expect(page.locator('.matrix__group-toggle').filter({ hasText: `catgrp-${testInfo.project.name}` })).toHaveCount(0);
+      await expect(page.locator('.matrix__group-toggle').filter({ hasText: linkedKey.folder_path || 'No folder' })).toBeVisible();
+      await page.screenshot({ path: testInfo.outputPath('folders-linked-keys.png'), fullPage: true });
+      await page.goto(`/orgs/${seed.org}/projects/${seed.project}/matrix/keys/${keyId}`);
 
       await groupSelect.selectOption('');
-      await expect(page.getByRole('status').filter({ hasText: 'Group updated.' })).toBeVisible();
+      await expect(page.getByRole('status').filter({ hasText: 'Linked keys updated.' })).toBeVisible();
       expect((await fixtureApiCall(token, 'GET', keyPath, zKeyRead)).group_id).toBe('');
     } finally {
       await fixtureApiCall(
@@ -779,17 +787,17 @@ test.describe('catalogue declaration detail', () => {
     const folderPath = `catflow-${suffix}`;
     const groupName = `catflow ${suffix}`;
     await page.goto(MATRIX_PATH);
-    await page.getByRole('button', { name: 'Folders & groups' }).click();
+    await page.getByRole('button', { name: 'Folders & linked keys' }).click();
     const dialog = page.locator('dialog.catalogue-manage');
-    await expect(dialog.getByRole('heading', { name: 'Folders & groups' })).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Folders & linked keys' })).toBeVisible();
 
     await dialog.getByLabel('New folder path').fill(folderPath);
     await dialog.getByRole('button', { name: 'Add folder' }).click();
     await expect(dialog.getByText(`Folder ${folderPath} created.`)).toBeVisible();
 
-    await dialog.getByLabel('New group name').fill(groupName);
-    await dialog.getByRole('button', { name: 'Add group' }).click();
-    await expect(dialog.getByText(`Group ${groupName} created.`)).toBeVisible();
+    await dialog.getByLabel('New linked-key set name').fill(groupName);
+    await dialog.getByRole('button', { name: 'Add linked-key set' }).click();
+    await expect(dialog.getByText(`Linked-key set ${groupName} created.`)).toBeVisible();
 
     // Clean up through the same lifecycle controls; a row is addressed by its
     // input's accessible name (its identity lives in an input value).
@@ -801,7 +809,7 @@ test.describe('catalogue declaration detail', () => {
       .click();
     await expect(folderInput).toHaveCount(0);
 
-    const groupInput = dialog.getByLabel(`Name for group ${groupName}`);
+    const groupInput = dialog.getByLabel(`Name for linked-key set ${groupName}`);
     await groupInput.locator('xpath=ancestor::li').getByRole('button', { name: 'Delete' }).click();
     await groupInput
       .locator('xpath=ancestor::li')

--- a/web/src/api/catalogue.test.ts
+++ b/web/src/api/catalogue.test.ts
@@ -92,7 +92,7 @@ describe('catalogueRefusalText', () => {
     expect(catalogueRefusalText(new ApiError(403, 'x'), 'delete the folder')).toContain(
       'permission to delete the folder',
     );
-    expect(catalogueRefusalText(new ApiError(404, 'x'), 'rename the group')).toContain(
+    expect(catalogueRefusalText(new ApiError(404, 'x'), 'rename the linked-key set')).toContain(
       'no longer exists',
     );
     expect(catalogueRefusalText(new ApiError(409, 'x'), 'update the rules')).toContain(

--- a/web/src/api/catalogue.ts
+++ b/web/src/api/catalogue.ts
@@ -68,13 +68,13 @@ export function scanFindings(error: unknown): readonly RefusalFinding[] | null {
 
 export type CatalogueAction =
   | 'update the rules'
-  | 'change the group'
+  | 'change the linked keys'
   | 'create the folder'
   | 'rename the folder'
   | 'delete the folder'
-  | 'create the group'
-  | 'rename the group'
-  | 'delete the group';
+  | 'create the linked-key set'
+  | 'rename the linked-key set'
+  | 'delete the linked-key set';
 
 /**
  * catalogueRefusalText renders a catalogue-write refusal in the caller's own

--- a/web/src/routes/CatalogueManageDialog.tsx
+++ b/web/src/routes/CatalogueManageDialog.tsx
@@ -67,13 +67,13 @@ export function CatalogueManageDialog({
     <dialog className="matrix-editor catalogue-manage" ref={dialog} onClose={onClose}>
       <div className="matrix-editor__head">
         <div>
-          <h2>Folders &amp; groups</h2>
-          <p>Organise the catalogue: folders are namespace labels, groups couple related keys.</p>
+          <h2>Folders &amp; linked keys</h2>
+          <p>Folders organise keys by path. Linked keys enforce publishing and presence rules.</p>
         </div>
         <button
           type="button"
           className="btn matrix-editor__close"
-          aria-label="Close folders and groups"
+          aria-label="Close folders and linked keys"
           onClick={onClose}
         >
           ✕
@@ -84,6 +84,7 @@ export function CatalogueManageDialog({
 
       <section className="catalogue-manage__section" aria-labelledby="catalogue-folders">
         <h3 id="catalogue-folders">Folders</h3>
+        <p>Organise keys without changing how they publish or which values must be set.</p>
         {folders.isPending ? <p role="status">Loading folders…</p> : null}
         {folders.isError ? <Alert>Folders could not be read.</Alert> : null}
         {folders.data !== undefined && folders.data.items.length === 0 ? (
@@ -100,12 +101,13 @@ export function CatalogueManageDialog({
       </section>
 
       <section className="catalogue-manage__section" aria-labelledby="catalogue-groups">
-        <h3 id="catalogue-groups">Key groups</h3>
-        {groups.isPending ? <p role="status">Loading groups…</p> : null}
-        {groups.isError ? <Alert>Key groups could not be read.</Alert> : null}
+        <h3 id="catalogue-groups">Linked keys</h3>
+        <p>Pending changes publish together. All linked keys must be set together in each environment.</p>
+        {groups.isPending ? <p role="status">Loading linked keys…</p> : null}
+        {groups.isError ? <Alert>Linked keys could not be read.</Alert> : null}
         {groups.data !== undefined && groups.data.items.length === 0 ? (
           <p role="status" className="catalogue-manage__empty">
-            No groups yet. Create one, then add keys to it from each key’s detail page.
+            No linked keys yet. Create a set, then link keys from each key’s detail page.
           </p>
         ) : null}
         <ul className="catalogue-manage__list">
@@ -291,7 +293,7 @@ function FolderRow({
 
 function CreateKeyGroup({ refData }: { refData: MatrixRef }) {
   const create = useCreateKeyGroup(refData);
-  const write = useNameWrite('create the group');
+  const write = useNameWrite('create the linked-key set');
   const id = useId();
   const [name, setName] = useState('');
   const trimmed = name.trim();
@@ -309,12 +311,12 @@ function CreateKeyGroup({ refData }: { refData: MatrixRef }) {
                 { onSuccess: () => resolve(), onError: (error) => reject(error) },
               ),
             ).then(() => setName('')),
-          `Group ${trimmed} created.`,
+          `Linked-key set ${trimmed} created.`,
         );
       }}
     >
       <label className="visually-hidden" htmlFor={id}>
-        New group name
+        New linked-key set name
       </label>
       <input
         id={id}
@@ -324,14 +326,14 @@ function CreateKeyGroup({ refData }: { refData: MatrixRef }) {
         onChange={(event) => setName(event.currentTarget.value)}
       />
       <button type="submit" className="btn btn--primary" disabled={create.isPending || trimmed === ''}>
-        Add group
+        Add linked-key set
       </button>
       {write.refusal === null ? null : <Alert>{write.refusal}</Alert>}
       {write.done === null ? null : <Done>{write.done}</Done>}
       {write.scanBlock === null ? null : (
         <ScanBlockDialog
-          title="Group name blocked by secret scanning"
-          intro="A group name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
+          title="Linked-key set name blocked by secret scanning"
+          intro="A linked-key set name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
           findings={write.scanBlock.findings}
           onOverride={write.scanBlock.onOverride}
           onClose={write.closeScanBlock}
@@ -352,7 +354,7 @@ function GroupRow({
 }) {
   const rename = useRenameKeyGroup(refData, group.id);
   const remove = useDeleteKeyGroup(refData, group.id);
-  const write = useNameWrite('rename the group');
+  const write = useNameWrite('rename the linked-key set');
   const [name, setName] = useState(group.name);
   const [confirming, setConfirming] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -362,14 +364,14 @@ function GroupRow({
     <li className="catalogue-manage__row">
       <div className="catalogue-manage__row-main">
         <input
-          aria-label={`Name for group ${group.name}`}
+          aria-label={`Name for linked-key set ${group.name}`}
           value={name}
           disabled={readOnly || busy}
           onChange={(event) => setName(event.currentTarget.value)}
         />
         <span className="catalogue-manage__meta">
           {String(group.members.length)} {group.members.length === 1 ? 'key' : 'keys'}
-          {group.inert ? <span className="catalogue-manage__inert"> · inert</span> : null}
+          {group.inert ? <span className="catalogue-manage__inert"> · needs at least two keys</span> : null}
         </span>
         <button
           type="button"
@@ -384,7 +386,7 @@ function GroupRow({
                     { onSuccess: () => resolve(), onError: (error) => reject(error) },
                   ),
                 ),
-              `Group renamed to ${trimmed}.`,
+              `Linked-key set renamed to ${trimmed}.`,
             )
           }
         >
@@ -398,7 +400,7 @@ function GroupRow({
             onClick={() => {
               setDeleteError(null);
               remove.mutate(undefined, {
-                onError: (error) => setDeleteError(catalogueRefusalText(error, 'delete the group')),
+                onError: (error) => setDeleteError(catalogueRefusalText(error, 'delete the linked-key set')),
               });
             }}
           >
@@ -420,8 +422,8 @@ function GroupRow({
       {write.done === null ? null : <Done>{write.done}</Done>}
       {write.scanBlock === null ? null : (
         <ScanBlockDialog
-          title="Group name blocked by secret scanning"
-          intro="A group name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
+          title="Linked-key set name blocked by secret scanning"
+          intro="A linked-key set name is exported to Git and treated as public. This one was refused because it looks like it carries secret material."
           findings={write.scanBlock.findings}
           onOverride={write.scanBlock.onOverride}
           onClose={write.closeScanBlock}

--- a/web/src/routes/KeyDeclarationDetail.tsx
+++ b/web/src/routes/KeyDeclarationDetail.tsx
@@ -253,7 +253,7 @@ function KeyDeclarationBody({
           value={record.classification === 'secret' ? '🔒 secret' : 'config'}
         />
         <Fact term="Folder" value={record.folder_path === '' ? '(none)' : record.folder_path} mono />
-        <Fact term="Group" value={record.group_id === '' ? '(ungrouped)' : record.group_id} mono />
+        <Fact term="Linked keys" value={record.group_id === '' ? 'None' : record.group_id} mono />
         <Fact
           term="Description"
           value={record.description === '' ? '(none)' : record.description}
@@ -1717,9 +1717,10 @@ function GroupEditor({
 
   return (
     <section className="key-detail__section" aria-labelledby={`${id}-group`}>
-      <h3 id={`${id}-group`}>Group membership</h3>
+      <h3 id={`${id}-group`}>Linked keys</h3>
+      <p>Pending changes publish together. All linked keys must be set together in each environment.</p>
       <label className="field">
-        <span>Key group</span>
+        <span>Linked-key set</span>
         <select
           value={record.group_id}
           disabled={setGroup.isPending || !groups.isSuccess}
@@ -1731,12 +1732,12 @@ function GroupEditor({
               { groupId },
               {
                 onSuccess: () => setDone(true),
-                onError: (error) => setRefusal(catalogueRefusalText(error, 'change the group')),
+                onError: (error) => setRefusal(catalogueRefusalText(error, 'change the linked keys')),
               },
             );
           }}
         >
-          <option value="">(no group)</option>
+          <option value="">No linked keys</option>
           {(groups.data?.items ?? []).map((group) => (
             <option key={group.id} value={group.id}>
               {group.name}
@@ -1744,9 +1745,9 @@ function GroupEditor({
           ))}
         </select>
       </label>
-      {groups.isError ? <Alert>The project’s key groups could not be read.</Alert> : null}
+      {groups.isError ? <Alert>The project’s linked keys could not be read.</Alert> : null}
       {refusal === null ? null : <Alert>{refusal}</Alert>}
-      {done ? <Done>Group updated.</Done> : null}
+      {done ? <Done>Linked keys updated.</Done> : null}
     </section>
   );
 }

--- a/web/src/routes/Matrix.git-managed.test.tsx
+++ b/web/src/routes/Matrix.git-managed.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderForm } from '../testkit/renderForm.tsx';
 import { Matrix } from './Matrix.tsx';
 
-const mocks = vi.hoisted(() => ({ source: 'db' as 'db' | 'git' }));
+const mocks = vi.hoisted(() => ({ source: 'db' as 'db' | 'git', groupId: '' }));
 
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: ({ count }: { readonly count: number }) => ({
@@ -58,7 +58,7 @@ vi.mock('../api/matrix.ts', async (importActual) => {
             deprecation_note: '',
             declaration: { rule: { type: 'string', allow_empty: true } },
             presence: { required_in: { mode: 'none' }, forbidden_in: { mode: 'none' } },
-            group_id: '',
+            group_id: mocks.groupId,
             created_at: '2026-08-24T08:00:00Z',
           }],
           count: 1,
@@ -66,7 +66,7 @@ vi.mock('../api/matrix.ts', async (importActual) => {
         isPending: false,
         isError: false,
       },
-      groups: { data: { items: [], count: 0 }, isPending: false, isError: false },
+      groups: { data: { items: [{ id: 'linked_a', name: 'Database credentials' }], count: 1 }, isPending: false, isError: false },
       environmentRows: [{
         environmentId: 'env_a',
         environment,
@@ -103,6 +103,7 @@ vi.mock('./useProtectedPublishCeremony.ts', () => ({
 
 afterEach(() => {
   mocks.source = 'db';
+  mocks.groupId = '';
 });
 
 function render() {
@@ -144,4 +145,20 @@ describe('Matrix declaration availability by definitions source', () => {
     ).toBe(true);
     await view.unmount();
   });
+});
+
+it('keeps linked keys in their folder and shows their relationship separately', async () => {
+  mocks.groupId = 'linked_a';
+  const view = await render();
+  const sections = [...view.container.querySelectorAll('.matrix__group-toggle')];
+  expect(sections).toHaveLength(1);
+  expect(sections[0]?.textContent).toContain('app');
+  expect(sections[0]?.textContent).not.toContain('Database credentials');
+  expect(view.container.querySelector('.matrix__linked-keys')?.textContent).toContain(
+    'Linked keys: Database credentials',
+  );
+  expect(view.container.querySelector('.matrix__linked-keys')?.getAttribute('title')).toContain(
+    'Pending changes publish together',
+  );
+  await view.unmount();
 });

--- a/web/src/routes/Matrix.tsx
+++ b/web/src/routes/Matrix.tsx
@@ -393,7 +393,7 @@ export function Matrix({
     () => new Set(keysForMatrixFilter(stateKeys, problems, filter).map((key) => key.id)),
     [filter, problems, stateKeys],
   );
-  const displayGroupList = useMemo(() => displayGroups(keys, keyGroups), [keyGroups, keys]);
+  const displayGroupList = useMemo(() => displayGroups(keys), [keys]);
   const groups = useMemo(
     () => displayGroupList.map((group) => ({
       ...group,
@@ -914,7 +914,7 @@ export function Matrix({
         {/* #493: folder & key-group lifecycle. Project-scoped organisation in its
             own dialog, reachable here and from the empty state. */}
         <button type="button" className="btn matrix__manage" onClick={() => setManageOpen(true)}>
-          Folders &amp; groups
+          Folders &amp; linked keys
         </button>
         {/* env-matrix 31 / #492: the header's primary declare action. Git-managed
             projects disable it and say why — value actions still work. */}
@@ -1025,7 +1025,7 @@ export function Matrix({
                     Declare first key
                   </button>
                   <button type="button" className="btn" onClick={() => setManageOpen(true)}>
-                    Folders &amp; groups
+                    Folders &amp; linked keys
                   </button>
                 </div>
               )}
@@ -1192,10 +1192,7 @@ export function Matrix({
                                   className="matrix__add-key"
                                   onClick={() => {
                                     setCreateError(null);
-                                    // Prefill the actual folder_path, not the
-                                    // display name — an explicit key-group's name
-                                    // can differ from its folder, and the
-                                    // ungrouped pseudo-group has none (→ blank).
+                                    // New keys inherit this section's folder.
                                     setCreate({ folder: group.keys[0]?.folder_path || null });
                                   }}
                                 >
@@ -1233,6 +1230,15 @@ export function Matrix({
                             {key.classification === 'secret' ? <span aria-hidden="true">🔒 </span> : null}
                             {key.name}
                           </Link>
+                          {key.group_id === '' ? null : (
+                            <span
+                              className="matrix__linked-keys"
+                              title="Pending changes publish together. All linked keys must be set together in each environment."
+                            >
+                              <span aria-hidden="true">🔗 </span>
+                              Linked keys: {keyGroups.find((group) => group.id === key.group_id)?.name ?? key.group_id}
+                            </span>
+                          )}
                           <span className="matrix__required">{requiredLabel(key, environments)}</span>
                         </th>
                         {visibleEnvironments.map((environment) => {
@@ -1691,15 +1697,10 @@ function matrixPresence(key: MatrixKey): MatrixPresence {
 }
 
 function displayGroupID(key: MatrixKey): string {
-  if (key.group_id !== '') return `group:${key.group_id}`;
-  return `folder:${key.folder_path === '' ? 'ungrouped' : key.folder_path}`;
+  return `folder:${key.folder_path}`;
 }
 
-function displayGroups(
-  keys: readonly MatrixKey[],
-  groups: readonly { readonly id: string; readonly name: string }[],
-): readonly DisplayGroup[] {
-  const names = new Map(groups.map((group) => [`group:${group.id}`, group.name]));
+function displayGroups(keys: readonly MatrixKey[]): readonly DisplayGroup[] {
   const result = new Map<string, MatrixKey[]>();
   for (const key of keys) {
     const id = displayGroupID(key);
@@ -1709,7 +1710,7 @@ function displayGroups(
   }
   return [...result].map(([id, members]) => ({
     id,
-    name: names.get(id) ?? (members[0]?.folder_path || 'ungrouped'),
+    name: members[0]?.folder_path || 'No folder',
     keys: members,
   }));
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -5780,3 +5780,10 @@ select {
 .definitions-bundle__body .remote__facts dd { overflow-wrap: anywhere; min-width: 0; }
 .definitions-bundle__body input[type="file"] { width: 100%; min-width: 0; max-width: 100%; }
 .definitions-bundle__delete { display: flex; align-items: center; gap: .75rem; min-height: 44px; }
+
+.matrix__linked-keys {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 400;
+  white-space: normal;
+}


### PR DESCRIPTION
Folder placement previously disappeared when a key joined a group, making both concepts behave like competing folders. The matrix and sidebar now always organise keys by folder, while group membership appears separately as Linked keys with a link icon and an explanation of publishing and presence rules.

Updates catalogue management, key detail, refusal messages, and browser selectors without changing server semantics or API fields.

Validation: typecheck and production build passed; 684 web unit tests passed, plus the 9 catalogue tests after the final copy adjustment. Linking/unlinking and folder/linked-key lifecycle flows passed on desktop and mobile (2 tests each); mobile screenshot inspected. DCO and cryptographic signature checks passed.
