### PR TITLE
fix(ci): separate expensive race suites across runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1212,6 +1212,7 @@ jobs:
       - changes
     if: ${{ fromJSON(needs.changes.outputs.plan).race }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -1268,7 +1269,10 @@ jobs:
             echo "race: shard $RACE_SHARD has no packages" >&2
             exit 1
           fi
-          xargs go test -race -vet=off -count=1 <"$packages"
+          # Authenticated boot fixtures repeat real, durable migrations. The
+          # 10-minute Go default limits the whole package, not each test.
+          # Bound package contention and cumulative race runtime separately.
+          xargs go test -race -p 2 -timeout=20m -vet=off -count=1 <"$packages"
       - name: Save race Go cache (main push only)
         if: >-
           success() && steps.race-go-cache.outputs.cache-hit != 'true' &&

--- a/scripts/ci/analysis-shards-go/main.go
+++ b/scripts/ci/analysis-shards-go/main.go
@@ -49,8 +49,10 @@ type options struct {
 
 var preferredShards = map[string]map[string]int{
 	"race": {
+		// Each repeatedly boots the authenticated database fixture. Keep the
+		// largest suites on separate runners instead of contending on shard 0.
 		"internal/app":           0,
-		"internal/service":       0,
+		"internal/service":       1,
 		"internal/lint":          1,
 		"internal/store/migrate": 1,
 		"internal/conformance":   2,

--- a/scripts/ci/analysis-shards_test.sh
+++ b/scripts/ci/analysis-shards_test.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$fixture_dir"' EXIT HUP INT TERM
 
 mkdir -p \
 	"$fixture_dir/extra" \
+	"$fixture_dir/internal/app" \
 	"$fixture_dir/internal/crypto" \
 	"$fixture_dir/internal/isolation" \
 	"$fixture_dir/internal/service" \
@@ -16,7 +17,7 @@ mkdir -p \
 
 printf '%s\n' 'module example.com/shards' 'go 1.27.0' >"$fixture_dir/go.mod"
 
-for package in extra internal/crypto internal/isolation internal/service internal/store; do
+for package in extra internal/app internal/crypto internal/isolation internal/service internal/store; do
 	package_name=${package##*/}
 	printf 'package %s\n' "$package_name" >"$fixture_dir/$package/$package_name.go"
 done
@@ -100,11 +101,21 @@ fi
 cut -f2 "$race_actual" | sort >"$fixture_dir/race-packages"
 cat >"$fixture_dir/race-expected" <<'EOF'
 example.com/shards/extra
+example.com/shards/internal/app
 example.com/shards/internal/crypto
 example.com/shards/internal/service
 example.com/shards/internal/store
 EOF
 cmp "$fixture_dir/race-expected" "$fixture_dir/race-packages"
+
+# The cumulative app/service race timeout came from co-locating the largest
+# authenticated datastore fixtures. Keep all three on independent runners.
+heavy_shards=$(awk -F '\t' '$2 ~ /^example.com\/shards\/internal\/(app|service|store)$/ { print $1 }' \
+	"$race_actual" | sort -u | wc -l | tr -d ' ')
+[ "$heavy_shards" -eq 3 ] || {
+	printf 'analysis shard fixture failed: heavy race packages share a runner\n' >&2
+	exit 1
+}
 
 cut -f2- "$fuzz_actual" | sort >"$fixture_dir/fuzz-targets"
 cat >"$fixture_dir/fuzz-expected" <<'EOF'


### PR DESCRIPTION
PR #666 exposed cumulative race-suite timeouts: `internal/app` and `internal/service` shared one runner and each reached Go’s default 10-minute package deadline while still progressing through real migration fixtures. Separate app, service and store across the existing three runners, bound package concurrency to two, and set an explicit 20-minute package deadline within a 30-minute job cap. Every race package and required shard remains enabled.

Validation: complete/disjoint shard inventory fixture, trusted-CI boundary fixture, changed-path classifier fixture, actionlint, ShellCheck, formatting and independent review passed. This small repair must land first because pull requests consume the trusted base workflow and planner.
