### PR TITLE
test(app): close maintenance client connections before shutdown

### DIFF
--- a/internal/app/maintenance_test.go
+++ b/internal/app/maintenance_test.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestRestoreRequiredRestartExposesOnlyOperationalHealth(t *testing.T) {
@@ -27,20 +29,38 @@ func TestRestoreRequiredRestartExposesOnlyOperationalHealth(t *testing.T) {
 		t.Fatal("maintenance boot acquired a tenant-serving resource")
 	}
 	ctx, cancel := context.WithCancel(t.Context())
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 	done := make(chan error, 1)
 	go func() { done <- srv.ServeWithReady(ctx, nil) }()
 	t.Cleanup(func() {
+		// An unused transport dial is StateNew to net/http and can consume
+		// the entire server drain window. Release this fixture's connections
+		// before testing server shutdown, including any spare keep-alive dial.
+		transport.CloseIdleConnections()
 		cancel()
-		if err := <-done; err != nil {
-			t.Error(err)
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Error(err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("maintenance server did not finish bounded shutdown")
 		}
 	})
 	for path, want := range map[string]int{"/healthz": 200, "/readyz": 503, "/metrics": 503, "/api/v1/meta": 404, "/mcp": 404, "/": 404} {
-		resp, err := http.Get("http://" + srv.OperationalAddr + path)
+		resp, err := client.Get("http://" + srv.OperationalAddr + path)
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp.Body.Close()
+		_, readErr := io.Copy(io.Discard, resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
 		if resp.StatusCode != want {
 			t.Errorf("%s: got %d, want %d", path, resp.StatusCode, want)
 		}


### PR DESCRIPTION
The maintenance restart test intermittently exhausted the server’s five-second shutdown grace because the shared HTTP transport retained a spare connection that had never served a request. The original test reproduced the post-merge CI failure under race instrumentation; a controlled transport probe confirmed the unused-connection path.

Give the fixture its own HTTP client, drain and close every response, and close idle connections before cancelling the server. Keep all health, readiness, tenant-route and resource-exclusion assertions, require successful shutdown, and bound both client requests and cleanup. Production shutdown behavior is unchanged.

Validation: focused repeated race checks, existing graceful/forced shutdown regression checks, go vet, formatting, diff checks and independent review.
