### PR TITLE
fix(ci): repair advisory formatting and consent expiry

### DIFF
--- a/docs/handoff/advisory-main-format.md
+++ b/docs/handoff/advisory-main-format.md
@@ -1,0 +1,19 @@
+# Advisory integration CI repair
+
+Main commit `3700a0ef24af59cfb4d3d159b4eda147a74b0e77` already contains the
+SCIM paging, workspace consent, browser secret lifetime, and human OIDC
+transport remediations delivered through the combined HTTP advisory branch.
+The four original private PRs are superseded by that integration.
+
+The `generated` job in main run `33991135025` failed its Format step on
+`internal/config/config_test.go`. The shell's standalone gofmt accepted the
+file, but the repository's Go 1.27 toolchain formatter required different
+alignment for three trailing comments. Apply the formatter from
+`$(go env GOROOT)/bin/gofmt`, matching the existing CI check. No test logic or
+runtime behavior changes.
+
+Validation: repository-wide formatting and SQLC, OpenAPI, scanning, and CRD
+generation freshness pass. Config race tests pass. The existing integrated
+web source passes typechecking, all 801 unit tests, production build, and all
+20 TypeScript client tests. The remaining advisory-specific local checks and
+exact-head hosted CI are tracked by the delivery session.

--- a/docs/handoff/advisory-main-format.md
+++ b/docs/handoff/advisory-main-format.md
@@ -1,4 +1,4 @@
-# Advisory integration CI repair
+# Advisory integration CI repairs
 
 Main commit `3700a0ef24af59cfb4d3d159b4eda147a74b0e77` already contains the
 SCIM paging, workspace consent, browser secret lifetime, and human OIDC
@@ -10,7 +10,16 @@ The `generated` job in main run `33991135025` failed its Format step on
 file, but the repository's Go 1.27 toolchain formatter required different
 alignment for three trailing comments. Apply the formatter from
 `$(go env GOROOT)/bin/gofmt`, matching the existing CI check. No test logic or
-runtime behavior changes.
+runtime behavior changes from this formatting correction.
+
+The same main run also failed `TestWorkspaceConsentOriginAndLiveness` on both
+databases. `StartHandoff` returned its nanosecond deadline while the stored
+deadline, subsequently returned by `ShowHandoff`, had microsecond precision.
+macOS clock precision hid the mismatch during earlier local validation.
+Canonicalize the deadline with the existing `store.CanonTime` before both
+persisting and returning it. The test now injects a noncanonical nanosecond
+clock on every platform and retains exact equality and expiry rejection.
+The deterministic regression failed on both databases before this repair.
 
 Validation: repository-wide formatting and SQLC, OpenAPI, scanning, and CRD
 generation freshness pass. Config race tests pass. The existing integrated

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,9 +145,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
-		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
+		"postgres:///hikyo", // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {

--- a/internal/isolation/workspace_consent_test.go
+++ b/internal/isolation/workspace_consent_test.go
@@ -15,7 +15,9 @@ func TestWorkspaceConsentOriginAndLiveness(t *testing.T) {
 	forEngines(t, func(t *testing.T, db *store.DB) {
 		ctx := t.Context()
 		ws := stepUpWorkspace(t, db)
-		now := time.Now().UTC()
+		// Exercise sub-microsecond clocks even on hosts whose clock resolution
+		// already matches the persisted timestamp precision.
+		now := time.Now().UTC().Truncate(time.Microsecond).Add(time.Nanosecond)
 		ws.Now = func() time.Time { return now }
 		approver := service.Bearer(seedSessionFactors(t, db, root, `["password","totp"]`))
 		origins := []string{"https://first.example:8443", "https://second.example", "https://xn--bcher-kva.example"}
@@ -43,7 +45,7 @@ func TestWorkspaceConsentOriginAndLiveness(t *testing.T) {
 					t.Fatalf("recipient=%q want stored%q", view.RequestingOrigin, origin)
 				}
 				if !view.ExpiresAt.Equal(started.ExpiresAt) {
-					t.Fatal("summary expiry differs from transaction")
+					t.Fatalf("summary expiry %s differs from transaction %s", view.ExpiresAt.Format(time.RFC3339Nano), started.ExpiresAt.Format(time.RFC3339Nano))
 				}
 				code, redirect, err := ws.ApproveHandoff(ctx, approver, started.State)
 				if err != nil {

--- a/internal/service/workspace.go
+++ b/internal/service/workspace.go
@@ -731,7 +731,8 @@ func (s *Workspace) StartHandoff(ctx context.Context, req HandoffRequest) (Hando
 		return HandoffStart{}, err
 	}
 	now := s.now()
-	expires := now.Add(remotefetch.HandoffExpiry)
+	// Return the same deadline that both stores persist and consent displays.
+	expires := store.CanonTime(now.Add(remotefetch.HandoffExpiry))
 	err = tx.Write(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
 		allowed, err := az.WorkspaceOriginAllowed(ctx, canonical)
 		if err != nil {


### PR DESCRIPTION
The advisory integration left two failures on main: Go 1.27 formatting and a consent expiry mismatch exposed by Linux clock precision.

`StartHandoff` now canonicalizes its deadline with the existing `store.CanonTime` before persistence and response, so `ShowHandoff` returns the exact same expiry on SQLite and PostgreSQL. The regression injects sub-microsecond time on every platform and retains exact equality, expiry refusal and single-use approval/redemption checks. Three test comment alignments also use the pinned Go formatter.

Validation: the deterministic consent regression failed on both databases before the fix; the complete focused workspace, two-instance and handoff-policy race suite passes on both databases after it. Repository-wide Go formatting and SQLC/OpenAPI/scanning/CRD freshness pass. Integrated web source passes typecheck, 801 unit tests and production build; all 20 client tests pass.
