### PR TITLE
fix(ci): gofmt the Postgres host-param test table

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,9 +145,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
-		"postgres:///hikyo", // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
+		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {


### PR DESCRIPTION
## Summary

\`validation / generated\` fails on main since #676: \`gofmt -l\` lists \`internal/config/config_test.go\` (comment alignment in the host-param DSN table). Surfaced on the #681 merge-ref run; the branch never touched the file. This is the \`gofmt -w\` output, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)