### PR TITLE
fix(release): verify sharded Rekor nightly proofs

### DIFF
--- a/docs/handoff/20260906-nightly-signing.md
+++ b/docs/handoff/20260906-nightly-signing.md
@@ -71,3 +71,28 @@ recovery authorization; ordinary nightlies under the same policy do not. Private
 project keys stay off Actions. Runtime installation still follows the manual
 backup/drill and full-stop writer procedure. Review/merge, bootstrap activation
 and deployment are separate from local validation.
+
+## First production signing and shard-index repair
+
+PR #687 merged as `bd4b5b3e0b16c36d4e063001c455f97fb64bfda8`; all 45 PR
+checks and all 39 main CI jobs passed. The first signed nightly run
+[34049690497](https://github.com/Hikyo-Org/Hikyo/actions/runs/34049690497)
+built all packages and signed through GitHub OIDC, then correctly stopped before
+publication when the runtime verifier rejected an invalid index comparison.
+
+Rekor v1 signs a global index in the SET but uses a shard-local index for its
+Merkle proof. The actual entry has global index `2742136979` and proof index
+`2620232717`, with the pinned log key and checkpoint origin. The equality check
+was removed; the maintained verifier still authenticates both indexes against
+the same entry body, along with the signature and checkpoint. See
+[Sigstore's sharding documentation](https://docs.sigstore.dev/logging/sharding/).
+
+The test fixture now signs unequal global/local indexes. It reproduced the
+production refusal before the fix, then passed, including independent tampering
+of either index. Relevant trust, bundle, self-update, nightly and assembler
+packages passed, as did the focused race test. Review returned CLEAN. A local
+probe recovered the actual public Rekor entry and verified its exact OIDC
+identity/commit, SCT, SET, checkpoint, inclusion proof and signature over manifest
+SHA-256 `830c059cf9275ec8d14cf344ec0d5a161e21709aab861133f51abc1262060cbb`.
+The corrected verifier still requires a new green merge and successful nightly
+run before publication is established.

--- a/internal/releasetrust/nightly.go
+++ b/internal/releasetrust/nightly.go
@@ -188,9 +188,13 @@ func verifyNightlyEnvelope(policy NightlyPolicy, trustedRoot, rawBundle, artifac
 	if err := checkpoint.UnmarshalText([]byte(proof.GetCheckpoint().GetEnvelope())); err != nil {
 		return err
 	}
-	if hex.EncodeToString(entries[0].GetLogId().GetKeyId()) != string(policy.RekorLogID) || checkpoint.Origin != policy.CheckpointOrigin || proof.GetTreeSize() < 1 || checkpoint.Size != uint64(proof.GetTreeSize()) || proof.GetLogIndex() != entries[0].GetLogIndex() {
-		return errors.New("nightly checkpoint identity/tree size or entry index differs from pinned evidence")
+	if hex.EncodeToString(entries[0].GetLogId().GetKeyId()) != string(policy.RekorLogID) || checkpoint.Origin != policy.CheckpointOrigin || proof.GetTreeSize() < 1 || checkpoint.Size != uint64(proof.GetTreeSize()) {
+		return errors.New("nightly checkpoint identity or tree size differs from pinned evidence")
 	}
+	// Rekor v1's SET authenticates a global index, but its Merkle proof uses
+	// a shard-local index. They need not match. The maintained verifier below
+	// verifies both against this entry's same canonicalized body, including
+	// the signed global index and the proof's local index and checkpoint.
 	san, err := verify.NewSANMatcher(workflowURI, "")
 	if err != nil {
 		return err

--- a/internal/releasetrust/nightly_test.go
+++ b/internal/releasetrust/nightly_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
-	f, m, _ := testfixture.Nightly(t, []byte("signed compatibility fixture"), false)
+	f, m, proof := testfixture.Nightly(t, []byte("signed compatibility fixture"), false)
+	entry := proof.VerificationMaterial.TlogEntries[0]
+	if entry.LogIndex == entry.InclusionProof.LogIndex {
+		t.Fatal("fixture must exercise a sharded Rekor log")
+	}
 	release, err := releasetrust.VerifyNightly(f.Snapshot(t), m)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +24,7 @@ func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
 	if release.Identity().Profile != releaseidentity.NightlyV1 {
 		t.Fatal("nightly authorized stable identity")
 	}
-	for _, name := range []string{"unsigned", "wrong commit", "missing promise", "missing proof", "bad checkpoint", "wrong tree size", "wrong entry index", "missing asset", "extra asset", "substitution", "wrong root", "policy revoked", "wrong issuer", "wrong repository", "wrong owner", "wrong workflow", "wrong ref", "wrong log", "wrong checkpoint origin", "manifest revoked", "required SCT missing", "SCT choice omitted"} {
+	for _, name := range []string{"unsigned", "wrong commit", "missing promise", "missing proof", "bad checkpoint", "wrong tree size", "wrong entry index", "wrong global index", "missing asset", "extra asset", "substitution", "wrong root", "policy revoked", "wrong issuer", "wrong repository", "wrong owner", "wrong workflow", "wrong ref", "wrong log", "wrong checkpoint origin", "manifest revoked", "required SCT missing", "SCT choice omitted"} {
 		t.Run(name, func(t *testing.T) {
 			f, m, pb := testfixture.Nightly(t, []byte("signed compatibility fixture"), name == "wrong commit")
 			switch name {
@@ -36,6 +40,8 @@ func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
 				pb.VerificationMaterial.TlogEntries[0].InclusionProof.TreeSize++
 			case "wrong entry index":
 				pb.VerificationMaterial.TlogEntries[0].InclusionProof.LogIndex++
+			case "wrong global index":
+				pb.VerificationMaterial.TlogEntries[0].LogIndex++
 			case "missing asset":
 				delete(m.Artifacts, "checksums.txt")
 			case "extra asset":
@@ -77,7 +83,7 @@ func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
 				m.Policy = testfixture.JSON(t, policy)
 				f.Catalog.NightlyPolicies = []releaseidentity.Digest{releaseidentity.Hash(m.Policy)}
 			}
-			if name == "missing promise" || name == "missing proof" || name == "bad checkpoint" || name == "wrong tree size" || name == "wrong entry index" {
+			if name == "missing promise" || name == "missing proof" || name == "bad checkpoint" || name == "wrong tree size" || name == "wrong entry index" || name == "wrong global index" {
 				var err error
 				m.Bundle, err = protojson.Marshal(pb)
 				if err != nil {

--- a/internal/releasetrust/testfixture/nightly.go
+++ b/internal/releasetrust/testfixture/nightly.go
@@ -178,6 +178,10 @@ func NightlyWithPayloads(t testing.TB, compatibility []byte, wrongCommit bool, p
 		}
 		tlogEntry.KindVersion = &protorekor.KindVersion{Kind: body.Kind, Version: body.APIVersion}
 		tlogEntry.LogId.KeyId = rekorIDBytes
+		// Rekor v1 signs the global (virtual) index in its SET, while the
+		// inclusion proof below uses the index within the current shard.
+		// Model a nonempty previous shard so tests cannot conflate the two.
+		tlogEntry.LogIndex = 121904262
 		payload := JSON(t, tlog.RekorPayload{LogID: string(rekorID), IntegratedTime: integrated.Unix(), LogIndex: tlogEntry.LogIndex, Body: base64.StdEncoding.EncodeToString(tlogEntry.CanonicalizedBody)})
 		canonical, err := jsoncanonicalizer.Transform(payload)
 		if err != nil {


### PR DESCRIPTION
The first real signed nightly stopped before publication because verification required Rekor's global SET index to equal its shard-local inclusion-proof index. The actual entry used 2742136979 and 2620232717, respectively.

Remove that invalid comparison while retaining pinned log/checkpoint identity, tree size, complete evidence, and the maintained Sigstore verifier's authentication of both indexes against the same entry body. The cryptographic fixture now exercises unequal indexes and rejects independent tampering of either one.

Validation: the regression reproduced before the fix; relevant trust, bundle, self-update, nightly and assembler packages pass, plus the focused race test. Review CLEAN. Independently recovered the failed run's public Rekor entry and verified its OIDC identity, exact commit, SCT, SET, checkpoint, inclusion proof and manifest signature. First run: https://github.com/Hikyo-Org/Hikyo/actions/runs/34049690497. Upstream index semantics: https://docs.sigstore.dev/logging/sharding/.
