### PR TITLE
fix(release): authorize legacy bridges to signed nightly

### DIFF
--- a/docs/handoff/20260906-nightly-signing.md
+++ b/docs/handoff/20260906-nightly-signing.md
@@ -60,14 +60,15 @@ Mac; public files now exist in `release/trust`. Both default `nightly preflight`
 and `verify-bundle.sh --trust-only` pass. Private keys remain outside the checkout
 with passphrases in macOS Keychain. See the exact provenance and fingerprints in
 [the bootstrap record](../../release/trust/BOOTSTRAP.md). This was explicitly not
-an offline ceremony. Actual GitHub OIDC signing/publication and a live installation
-remain unverified pending review/merge and a successful nightly run. After the first signed
-target exists, its exact legacy bridge statements need a second offline recovery
-authorization and advancing catalog before old populated databases can upgrade.
+an offline ceremony. Actual GitHub OIDC signing/publication and packaged fresh
+startup are now verified as recorded below. The first target's legacy bridge
+statements and advancing catalog were signed under the same local nightly
+exception. A live existing-database upgrade remains a separate operator action.
 
 The workflow uses Rekor v1 signed integrated-time and inclusion/checkpoint
-evidence. Policy changes, log/root rotation and legacy bridges require offline
-recovery authorization; ordinary nightlies under the same policy do not. Private
+evidence. Policy changes, log/root rotation and legacy bridges require recovery
+authorization, normally offline; this operator's nightly custody exception is
+recorded explicitly. Ordinary nightlies under the same policy need no ceremony. Private
 project keys stay off Actions. Runtime installation still follows the manual
 backup/drill and full-stop writer procedure. Review/merge, bootstrap activation
 and deployment are separate from local validation.
@@ -94,5 +95,30 @@ packages passed, as did the focused race test. Review returned CLEAN. A local
 probe recovered the actual public Rekor entry and verified its exact OIDC
 identity/commit, SCT, SET, checkpoint, inclusion proof and signature over manifest
 SHA-256 `830c059cf9275ec8d14cf344ec0d5a161e21709aab861133f51abc1262060cbb`.
-The corrected verifier still requires a new green merge and successful nightly
-run before publication is established.
+PR #689 subsequently merged as `52c8b012f1fa45634572d7266c6ab7d3a9d5eed8`,
+with 30 passing PR checks and all 39 main CI jobs passing. Retry
+[34053156703](https://github.com/Hikyo-Org/Hikyo/actions/runs/34053156703)
+published immutable `v0.0.1-nightly.20260906.26.g52c8b012`. Actual OIDC verification
+and packaged fresh production startup/restart passed on both engines. All 22
+published assets were downloaded and independently verified on the operator's
+Mac. Manifest: `e54e0bdb3b9298e234070d27ad75680ed0a6abf75c59aff3815a8c1c30e9d0ee`.
+
+## Existing-database bridge activation
+
+Two exact legacy44-to-nightly26/migration49 statements and catalog sequence 2
+were prepared, reviewed CLEAN and signed using the approved encrypted local
+nightly recovery key. All 43 source migration-file hashes per engine match the
+operator's recovered September 5 commit. The actual signed runtime bundle loads,
+both engine routes require a maintenance bridge and operator attestation, and
+wrong source schemas, absent bridges and catalog rollback refuse. See
+[the public bridge record](../../release/trust/BRIDGES.md).
+
+Local public artifacts are retained beneath
+`~/Library/Application Support/hikyo/nightly-bootstrap/`: the complete release
+in `verified-nightlies/v0.0.1-nightly.20260906.26.g52c8b012`, assembled public
+runtime bundle in `runtime-bundle-20260906.26`, verification output in
+`legacy-bridge-verification.txt` and verified catalog floor in
+`bridge-verification-floor.json`. `verify-legacy-bridges.go` retains the probe;
+run a temporary copy inside this Go module to permit its internal imports.
+No live installation was modified. Its first upgrade still needs actual
+database inspection, its own backup/drill proof and a full legacy writer stop.

--- a/release/trust/BOOTSTRAP.md
+++ b/release/trust/BOOTSTRAP.md
@@ -29,15 +29,21 @@ owner numeric IDs were checked against GitHub. Production SCT verification is
 enabled. Cosign v3.1.3 was checked against both its upstream checksum asset and
 GitHub's release-asset SHA-256.
 
-Recovery-signed metadata sequence 1 and catalog sequence 1 authorize the nightly
-policy. There are no approved stable releases or legacy bridges. The metadata's
+Recovery-signed metadata sequence 1 and initial catalog sequence 1 authorize the
+nightly policy. Catalog sequence 2 additionally authorizes the two exact
+[legacy bridges](BRIDGES.md) into the first published signed nightly. There are
+no approved stable releases. The metadata's
 `pending_release` of `1.0.0` is the schema-required unsigned bootstrap placeholder;
 it is not a release approval. This root remains technically capable of
 authorizing stable releases. Its online/local custody must be considered before
 future stable activation; it must never be described as an offline-generated root.
 
 Local verification passed `nightly preflight` and `verify-bundle.sh --trust-only`.
-Public files are prepared in the checkout. GitHub publication and the first
-actual OIDC-signed nightly require the changes to be reviewed and merged. After
-that target exists, exact legacy bridge statements still need recovery
-authorization before populated pre-ledger databases can upgrade.
+PRs #687 and #689 activated the public bootstrap and corrected Rekor shard-index
+verification. The first actual OIDC-signed nightly,
+`v0.0.1-nightly.20260906.26.g52c8b012`, passed independent verification of every
+published asset and packaged production startup/restart on both engines.
+Its legacy bridge statements and catalog sequence 2 were subsequently signed
+with the same encrypted local recovery key under the approved nightly custody
+exception. They require separate installation backup/drill evidence and a full
+writer stop; signing these public documents does not upgrade a running server.

--- a/release/trust/BRIDGES.md
+++ b/release/trust/BRIDGES.md
@@ -1,0 +1,47 @@
+# First signed nightly legacy bridges
+
+Catalog sequence 2 authorizes one maintenance bridge per engine from the reviewed
+`legacy/v1` schema through migration 44 into
+[`v0.0.1-nightly.20260906.26.g52c8b012`](https://github.com/Hikyo-Org/Hikyo/releases/tag/v0.0.1-nightly.20260906.26.g52c8b012),
+whose target migrations run through 49. This is an exact source-schema route,
+not an assertion that an unsigned source binary was a signed release.
+
+| Engine | Recovery-signed statement SHA-256 |
+| --- | --- |
+| SQLite | `afb19f55f6e8fc47f7946653b5c9ec558cb4d5215c52edf43653e59fd6920b63` |
+| PostgreSQL | `e0a262775b4d9dfccbc81de2d97879b6102f00d7fc4f5a16a835f342d3d65705` |
+
+Both statements pin target manifest
+`e54e0bdb3b9298e234070d27ad75680ed0a6abf75c59aff3815a8c1c30e9d0ee`,
+compatibility declaration
+`61a0216151eb90101433824dd18c095e34ed910a7cc24733e45dc38343380671`,
+commit `52c8b012f1fa45634572d7266c6ab7d3a9d5eed8` and the existing nightly policy.
+The exact 43 source migration-file hashes for each engine were independently
+compared with recovered nightly commit
+`907e2f41fccc40bb8287025763b56e38c533eb37`. Source and target schema digests also
+match the authenticated published compatibility declaration.
+
+The [release run](https://github.com/Hikyo-Org/Hikyo/actions/runs/34053156703)
+verified the complete OIDC-signed inventory and actual packaged production
+startup/restart on both engines before immutable publication. The complete
+22-asset download was independently verified afterward. This first signed
+nightly had no authenticated signed predecessor, so the previous-signed-nightly
+upgrade job had no source release to exercise.
+
+The operator's encrypted local recovery key signed these exact statements and
+the advancing catalog on 2026-09-06 under the approved online/local nightly
+exception documented in [the bootstrap record](BOOTSTRAP.md). Private key
+material and passwords remain outside Git and Actions. Stable metadata and the
+authorized nightly policy remain unchanged.
+
+The runtime bundle loader verified both signatures and catalog 1 to 2
+advancement. Both engine plans require a single maintenance bridge and local
+operator attestation. Verification refused missing bridges, different source
+schemas and rollback to catalog 1. These checks establish project authorization
+of the exact route; the installation must still inspect its own database,
+complete its backup/drill and stop every legacy writer before upgrading.
+
+Use the [signed-nightly assembly procedure](../../docs/operations/signed-nightlies.md)
+and [manual verified upgrade procedure](../../docs/operations/manual-upgrades.md).
+An older binary-only self-updater cannot supply the required runtime bundle and
+installation evidence for this first hop.

--- a/release/trust/bridges/afb19f55f6e8fc47f7946653b5c9ec558cb4d5215c52edf43653e59fd6920b63/statement.json
+++ b/release/trust/bridges/afb19f55f6e8fc47f7946653b5c9ec558cb4d5215c52edf43653e59fd6920b63/statement.json
@@ -1,0 +1,390 @@
+{
+  "schema": "hikyo.dev/legacy-nightly-bridge/v1",
+  "source_genesis": "legacy/v1",
+  "target": {
+    "profile": "nightly/v1",
+    "version": "0.0.1-nightly.20260906.26.g52c8b012",
+    "sequence": 26,
+    "commit": "52c8b012f1fa45634572d7266c6ab7d3a9d5eed8",
+    "compatibility_sha256": "61a0216151eb90101433824dd18c095e34ed910a7cc24733e45dc38343380671",
+    "manifest_sha256": "e54e0bdb3b9298e234070d27ad75680ed0a6abf75c59aff3815a8c1c30e9d0ee"
+  },
+  "target_policy_sha256": "afaeb19fc0299f700234a74aa0817f77ce0833853b327a9d9d9d126d25d5b04f",
+  "source_migrations": {
+    "engine": "sqlite",
+    "entries": [
+      {
+        "version": 1,
+        "sha256": "a258e03e6629842534446228a0c97e920dbc5138a523966b38d9d2824c7c83a5"
+      },
+      {
+        "version": 2,
+        "sha256": "8a972f7c07db1c06b586639c58037801687365162c7425ab1e0d8a23be245b98"
+      },
+      {
+        "version": 3,
+        "sha256": "7c887b0eea60bc55de2b80f612611b07e9b2f19aec3b86e4a91920e06bb1aa2b"
+      },
+      {
+        "version": 4,
+        "sha256": "e1fa91c5246617c71476d98474d8f309529bff9bc168607733e5b408445a1cd0"
+      },
+      {
+        "version": 5,
+        "sha256": "12971648a303f1bce1cf2664a3dd665df4c6689ea0c9b8f7d86755197a31f1ae"
+      },
+      {
+        "version": 6,
+        "sha256": "1a33505a83b68304720ed7505dfc2837f56f1f9d94ad45dd6d82764cdb29fb81"
+      },
+      {
+        "version": 7,
+        "sha256": "5fb7445c0336767bb3f98249af9ab5fe98772def1b05cb6bec8227fb1d629c25"
+      },
+      {
+        "version": 8,
+        "sha256": "ce09d89bf22bb0c7ef3728233387946d43ccef3b650c68a40cf46a7817aa160d"
+      },
+      {
+        "version": 9,
+        "sha256": "8e74a2dc77ad859fb998494025a2029d92467d1add94d5c09251d759810e0702"
+      },
+      {
+        "version": 10,
+        "sha256": "0581e791807c8e857898ed7d384ece22ffc3c9984df21894e702cd3b0ba9ae27"
+      },
+      {
+        "version": 12,
+        "sha256": "ba09a3cd071c5d7f03570d4e788f2cf6bd183a4f9b6e18fc94b91bb27bff1fca"
+      },
+      {
+        "version": 13,
+        "sha256": "56e87cc8df6d13f58517c3560fa6a4f615cab73ef0daf05fc6b327e4194216cf"
+      },
+      {
+        "version": 14,
+        "sha256": "8825ebd39414784e513ee3021d327cfc29e2f4476677e0ea3829db12389fa1c4"
+      },
+      {
+        "version": 15,
+        "sha256": "4183a4f3ad01435d2d6aa454e828fab06cd8640884b00cc0ca6f362594ec2c5b"
+      },
+      {
+        "version": 16,
+        "sha256": "4df279b1dce69fa804dfcafb256703886c2d51267be53b283837fca9d4e20514"
+      },
+      {
+        "version": 17,
+        "sha256": "3fb87f20bf50b07b3fd828beab74dc1accb3ee80ca94874620823675445bb3b3"
+      },
+      {
+        "version": 18,
+        "sha256": "ba0d04ea3050164609f0bbdcb7a9b8367a7ebadeb7098aa4b5e55abbc3d46220"
+      },
+      {
+        "version": 19,
+        "sha256": "4ff2268cd45c69c240816ffd3b6c5c3105d4dfbc30ccaaa4e3d2fe7a53b0000d"
+      },
+      {
+        "version": 20,
+        "sha256": "0f54f407554c931e07d959d1d74faf93159e7091efebfa0d5bef957e8787d0f7"
+      },
+      {
+        "version": 21,
+        "sha256": "de7c52b5209716d1f04b309b315513f1fac667b6b314050d3bb65a94ff074751"
+      },
+      {
+        "version": 22,
+        "sha256": "76d55bfbf1d21ff7fb4b652b9b99158736edf31de1e32026b6db1d2ccdd0b089"
+      },
+      {
+        "version": 23,
+        "sha256": "dc1dce92f21715e28d101ec11eecca792bedae5e84ce3bbbacad93f95cd90881"
+      },
+      {
+        "version": 24,
+        "sha256": "0032d55fc0c011405a132fec66046465cd6c3f915f5353901da81c03e9ad03db"
+      },
+      {
+        "version": 25,
+        "sha256": "2574240b72f524995ef72939e51d650504c90007137c95d72059041dd174084f"
+      },
+      {
+        "version": 26,
+        "sha256": "775d656d23b787671ef57669406692b5eeee0d523dc881348e6870a9a8640556"
+      },
+      {
+        "version": 27,
+        "sha256": "1108c999639b761631e8758e4a41b11b75a256a19d477f7c9bc6a0ff59492f8a"
+      },
+      {
+        "version": 28,
+        "sha256": "f491b62072b061d4e9cb3f1ba04b60fa3161f8f771fd2473cd87e64a4add4a8e"
+      },
+      {
+        "version": 29,
+        "sha256": "3604e36e0f364d0b35b83efa84fce7ffc7824c89a42907007d3c96ad5acec7ef"
+      },
+      {
+        "version": 30,
+        "sha256": "16cb01dffedd4092921cfe3acbd28612c349f91bcb9aa098e81ef975aa3b4244"
+      },
+      {
+        "version": 31,
+        "sha256": "6e291c5062737a0efae91b48613ebc4e30cc921b18eab0881ad017a439377aff"
+      },
+      {
+        "version": 32,
+        "sha256": "ef40693b6969b32057831b1d6c514de7a97565d559d7d001ad1e2b2d41e04f01"
+      },
+      {
+        "version": 33,
+        "sha256": "f97f4be349068f31af9d849c565dc6e3fc2bbcdd4c6768608b9fdde0f15aeb43"
+      },
+      {
+        "version": 34,
+        "sha256": "9e60a005c55edae55d8d63ac8a50232942e47b3a43ec0d7c1ee70d9bfd5eb231"
+      },
+      {
+        "version": 35,
+        "sha256": "4e2b77a689bc51073781cb91fca34e54e739187a4590d761525b362979a7fbc2"
+      },
+      {
+        "version": 36,
+        "sha256": "7ec6c54d5e930605bdc67c70ff394099a595592897e333b77f63e772fb9a64ac"
+      },
+      {
+        "version": 37,
+        "sha256": "66e9f331137c9e61b8c43d1248d4620a4a80578db34cfebb04acae28adbbafb9"
+      },
+      {
+        "version": 38,
+        "sha256": "7d50f4118d6fb6ac82b071ca07bfaec42245fd7062057265afc3ffe0365d78cd"
+      },
+      {
+        "version": 39,
+        "sha256": "0f698059bafa79f45e5d1abc8883a0c8069636ca2c7e028b8620251f2006a08d"
+      },
+      {
+        "version": 40,
+        "sha256": "19bc28956cceadc6e5002090244c0264d2da04f6c9cf5c1d62ff977dedcc6a48"
+      },
+      {
+        "version": 41,
+        "sha256": "1da77f8ba83309b7c56b28e851c48f4751d395010d5fac9a00302eda8df2e8ca"
+      },
+      {
+        "version": 42,
+        "sha256": "74c26fd55b6bc5d401e7def96af853e2bf75ec52471835b0427dc56f26c471a2"
+      },
+      {
+        "version": 43,
+        "sha256": "68b240a05de225800396d31c546e0a78266288e20874fabbb4d2f7aa65b6c434"
+      },
+      {
+        "version": 44,
+        "sha256": "037667151a0d0be70fc1be5a6bcc63f2a38446e913cb6c34786605a69b847353"
+      }
+    ]
+  },
+  "target_migrations": {
+    "engine": "sqlite",
+    "entries": [
+      {
+        "version": 1,
+        "sha256": "a258e03e6629842534446228a0c97e920dbc5138a523966b38d9d2824c7c83a5"
+      },
+      {
+        "version": 2,
+        "sha256": "8a972f7c07db1c06b586639c58037801687365162c7425ab1e0d8a23be245b98"
+      },
+      {
+        "version": 3,
+        "sha256": "7c887b0eea60bc55de2b80f612611b07e9b2f19aec3b86e4a91920e06bb1aa2b"
+      },
+      {
+        "version": 4,
+        "sha256": "e1fa91c5246617c71476d98474d8f309529bff9bc168607733e5b408445a1cd0"
+      },
+      {
+        "version": 5,
+        "sha256": "12971648a303f1bce1cf2664a3dd665df4c6689ea0c9b8f7d86755197a31f1ae"
+      },
+      {
+        "version": 6,
+        "sha256": "1a33505a83b68304720ed7505dfc2837f56f1f9d94ad45dd6d82764cdb29fb81"
+      },
+      {
+        "version": 7,
+        "sha256": "5fb7445c0336767bb3f98249af9ab5fe98772def1b05cb6bec8227fb1d629c25"
+      },
+      {
+        "version": 8,
+        "sha256": "ce09d89bf22bb0c7ef3728233387946d43ccef3b650c68a40cf46a7817aa160d"
+      },
+      {
+        "version": 9,
+        "sha256": "8e74a2dc77ad859fb998494025a2029d92467d1add94d5c09251d759810e0702"
+      },
+      {
+        "version": 10,
+        "sha256": "0581e791807c8e857898ed7d384ece22ffc3c9984df21894e702cd3b0ba9ae27"
+      },
+      {
+        "version": 12,
+        "sha256": "ba09a3cd071c5d7f03570d4e788f2cf6bd183a4f9b6e18fc94b91bb27bff1fca"
+      },
+      {
+        "version": 13,
+        "sha256": "56e87cc8df6d13f58517c3560fa6a4f615cab73ef0daf05fc6b327e4194216cf"
+      },
+      {
+        "version": 14,
+        "sha256": "8825ebd39414784e513ee3021d327cfc29e2f4476677e0ea3829db12389fa1c4"
+      },
+      {
+        "version": 15,
+        "sha256": "4183a4f3ad01435d2d6aa454e828fab06cd8640884b00cc0ca6f362594ec2c5b"
+      },
+      {
+        "version": 16,
+        "sha256": "4df279b1dce69fa804dfcafb256703886c2d51267be53b283837fca9d4e20514"
+      },
+      {
+        "version": 17,
+        "sha256": "3fb87f20bf50b07b3fd828beab74dc1accb3ee80ca94874620823675445bb3b3"
+      },
+      {
+        "version": 18,
+        "sha256": "ba0d04ea3050164609f0bbdcb7a9b8367a7ebadeb7098aa4b5e55abbc3d46220"
+      },
+      {
+        "version": 19,
+        "sha256": "4ff2268cd45c69c240816ffd3b6c5c3105d4dfbc30ccaaa4e3d2fe7a53b0000d"
+      },
+      {
+        "version": 20,
+        "sha256": "0f54f407554c931e07d959d1d74faf93159e7091efebfa0d5bef957e8787d0f7"
+      },
+      {
+        "version": 21,
+        "sha256": "de7c52b5209716d1f04b309b315513f1fac667b6b314050d3bb65a94ff074751"
+      },
+      {
+        "version": 22,
+        "sha256": "76d55bfbf1d21ff7fb4b652b9b99158736edf31de1e32026b6db1d2ccdd0b089"
+      },
+      {
+        "version": 23,
+        "sha256": "dc1dce92f21715e28d101ec11eecca792bedae5e84ce3bbbacad93f95cd90881"
+      },
+      {
+        "version": 24,
+        "sha256": "0032d55fc0c011405a132fec66046465cd6c3f915f5353901da81c03e9ad03db"
+      },
+      {
+        "version": 25,
+        "sha256": "2574240b72f524995ef72939e51d650504c90007137c95d72059041dd174084f"
+      },
+      {
+        "version": 26,
+        "sha256": "775d656d23b787671ef57669406692b5eeee0d523dc881348e6870a9a8640556"
+      },
+      {
+        "version": 27,
+        "sha256": "1108c999639b761631e8758e4a41b11b75a256a19d477f7c9bc6a0ff59492f8a"
+      },
+      {
+        "version": 28,
+        "sha256": "f491b62072b061d4e9cb3f1ba04b60fa3161f8f771fd2473cd87e64a4add4a8e"
+      },
+      {
+        "version": 29,
+        "sha256": "3604e36e0f364d0b35b83efa84fce7ffc7824c89a42907007d3c96ad5acec7ef"
+      },
+      {
+        "version": 30,
+        "sha256": "16cb01dffedd4092921cfe3acbd28612c349f91bcb9aa098e81ef975aa3b4244"
+      },
+      {
+        "version": 31,
+        "sha256": "6e291c5062737a0efae91b48613ebc4e30cc921b18eab0881ad017a439377aff"
+      },
+      {
+        "version": 32,
+        "sha256": "ef40693b6969b32057831b1d6c514de7a97565d559d7d001ad1e2b2d41e04f01"
+      },
+      {
+        "version": 33,
+        "sha256": "f97f4be349068f31af9d849c565dc6e3fc2bbcdd4c6768608b9fdde0f15aeb43"
+      },
+      {
+        "version": 34,
+        "sha256": "9e60a005c55edae55d8d63ac8a50232942e47b3a43ec0d7c1ee70d9bfd5eb231"
+      },
+      {
+        "version": 35,
+        "sha256": "4e2b77a689bc51073781cb91fca34e54e739187a4590d761525b362979a7fbc2"
+      },
+      {
+        "version": 36,
+        "sha256": "7ec6c54d5e930605bdc67c70ff394099a595592897e333b77f63e772fb9a64ac"
+      },
+      {
+        "version": 37,
+        "sha256": "66e9f331137c9e61b8c43d1248d4620a4a80578db34cfebb04acae28adbbafb9"
+      },
+      {
+        "version": 38,
+        "sha256": "7d50f4118d6fb6ac82b071ca07bfaec42245fd7062057265afc3ffe0365d78cd"
+      },
+      {
+        "version": 39,
+        "sha256": "0f698059bafa79f45e5d1abc8883a0c8069636ca2c7e028b8620251f2006a08d"
+      },
+      {
+        "version": 40,
+        "sha256": "19bc28956cceadc6e5002090244c0264d2da04f6c9cf5c1d62ff977dedcc6a48"
+      },
+      {
+        "version": 41,
+        "sha256": "1da77f8ba83309b7c56b28e851c48f4751d395010d5fac9a00302eda8df2e8ca"
+      },
+      {
+        "version": 42,
+        "sha256": "74c26fd55b6bc5d401e7def96af853e2bf75ec52471835b0427dc56f26c471a2"
+      },
+      {
+        "version": 43,
+        "sha256": "68b240a05de225800396d31c546e0a78266288e20874fabbb4d2f7aa65b6c434"
+      },
+      {
+        "version": 44,
+        "sha256": "037667151a0d0be70fc1be5a6bcc63f2a38446e913cb6c34786605a69b847353"
+      },
+      {
+        "version": 45,
+        "sha256": "62ea7d5cc6d1799f0227089064361e10a7f075c6eba9024a8f723093d4871958"
+      },
+      {
+        "version": 46,
+        "sha256": "ad6f3635d6110276dd8dc2a5e6c7118f18ac84ffcaec96eb79a2d9566828be92"
+      },
+      {
+        "version": 47,
+        "sha256": "a8c540b69397505957e080c0d1d2703bdbe7269f0b5e84f2966d2572a079fd86"
+      },
+      {
+        "version": 48,
+        "sha256": "0f9683ec35d6350637752bee17ce891902cc3f69c1f445d70a716b6f7b0738b5"
+      },
+      {
+        "version": 49,
+        "sha256": "2a112cc0a7cbcf1a0f691c23ddd51f71e12ba34b4a0829ddd9d2a32e2aae0188"
+      }
+    ]
+  },
+  "source_schema_sha256": "6e68554a3faf93566d806781648ddf71d2310246e9644af51ee91c165ba5d2fa",
+  "target_schema_sha256": "dec6600ac942f234502d12173e9a56629acce798f267571c92bc5386c912a049",
+  "mode": "maintenance"
+}

--- a/release/trust/bridges/afb19f55f6e8fc47f7946653b5c9ec558cb4d5215c52edf43653e59fd6920b63/statement.sigstore.json
+++ b/release/trust/bridges/afb19f55f6e8fc47f7946653b5c9ec558cb4d5215c52edf43653e59fd6920b63/statement.sigstore.json
@@ -1,0 +1,1 @@
+{"base64Signature":"MEUCIQCOi8wsrbOnGdwxohi3/fNkM56iy6RFF7f/hANBCmey+gIgPaBoFYdCKys+w3NQMgjJedrWcaW8sppjHaRITMaAZRc="}

--- a/release/trust/bridges/e0a262775b4d9dfccbc81de2d97879b6102f00d7fc4f5a16a835f342d3d65705/statement.json
+++ b/release/trust/bridges/e0a262775b4d9dfccbc81de2d97879b6102f00d7fc4f5a16a835f342d3d65705/statement.json
@@ -1,0 +1,390 @@
+{
+  "schema": "hikyo.dev/legacy-nightly-bridge/v1",
+  "source_genesis": "legacy/v1",
+  "target": {
+    "profile": "nightly/v1",
+    "version": "0.0.1-nightly.20260906.26.g52c8b012",
+    "sequence": 26,
+    "commit": "52c8b012f1fa45634572d7266c6ab7d3a9d5eed8",
+    "compatibility_sha256": "61a0216151eb90101433824dd18c095e34ed910a7cc24733e45dc38343380671",
+    "manifest_sha256": "e54e0bdb3b9298e234070d27ad75680ed0a6abf75c59aff3815a8c1c30e9d0ee"
+  },
+  "target_policy_sha256": "afaeb19fc0299f700234a74aa0817f77ce0833853b327a9d9d9d126d25d5b04f",
+  "source_migrations": {
+    "engine": "postgres",
+    "entries": [
+      {
+        "version": 1,
+        "sha256": "eea5885c5ec812068112fd813cbeb4bb3d7397afcb380454edf09a46002a0ecd"
+      },
+      {
+        "version": 2,
+        "sha256": "a97b48e0075aa82b7365c79e1052a458eb2bcbb99cdf55a9ff8a8a596ffef5b5"
+      },
+      {
+        "version": 3,
+        "sha256": "e20df54b31080470757f6202fc4fe04130b9e98421f5f2f3696dd902a3b51792"
+      },
+      {
+        "version": 4,
+        "sha256": "dbfaa89e853eb4cb500937f5d64718b4ebc7aed56c093622308752db3cdec5c5"
+      },
+      {
+        "version": 5,
+        "sha256": "cd3db9fc9edf5669cca3875621d3e9530d3d8e41c7842125ec8e35f6562035df"
+      },
+      {
+        "version": 6,
+        "sha256": "8a8162d7d2bd03004463a886e268194cfb13ced057f0239089acabf1433a31c1"
+      },
+      {
+        "version": 7,
+        "sha256": "024471a575be90c0b85a70b4b56e7e8eb9dacfddfdaedefe1d3edbeae577e899"
+      },
+      {
+        "version": 8,
+        "sha256": "241723301173f5105c753652904b460a17a0866cb9c3c183a8a3acc7a4148db0"
+      },
+      {
+        "version": 9,
+        "sha256": "3a34f86fb17dc51c10c7276891921721010458b9589891be90d627b21be9f32f"
+      },
+      {
+        "version": 10,
+        "sha256": "87762947acaf730d97f6700c8f5552a983fb748b87afbeaf3ee085e8175654df"
+      },
+      {
+        "version": 11,
+        "sha256": "925ed4f50194a35e9eac9683b6e3cd44eb7c3737bc577e2b5488b7011dcad4b4"
+      },
+      {
+        "version": 12,
+        "sha256": "4bcbe15ad62c442cc718bd2ce75a65227330b8f9cf762827328297d0d5755a3d"
+      },
+      {
+        "version": 13,
+        "sha256": "62c86518bc6bc863450203975267da6b83fa80ffe63823a13881ac1b5dacdf5f"
+      },
+      {
+        "version": 14,
+        "sha256": "9e442fb01d2accaa55b4169f7ad144a04f101cd46c665d665bb256e0f01e6c2c"
+      },
+      {
+        "version": 15,
+        "sha256": "9d6308eb036c516ce50bae4fd15e4500e2d49db3783333f98f811882151ab89a"
+      },
+      {
+        "version": 16,
+        "sha256": "7327299939f6147df486d833a25bd699b6b833dbd537cae3c5364a500b83a2d5"
+      },
+      {
+        "version": 17,
+        "sha256": "b6789c8f61db3c56893d5e3c764d7387b51b4947a3e32b771809da49886be20d"
+      },
+      {
+        "version": 18,
+        "sha256": "756228fa797c0e123033e99dc0a4cd294a7ace8f1a4d637cb77350b2bfe857ca"
+      },
+      {
+        "version": 19,
+        "sha256": "2a1a3d5876c4bb38cb6c043aa74a6627d43ac7d6b72a4055ba648b7aa1345357"
+      },
+      {
+        "version": 20,
+        "sha256": "e5fd3263688891ef0b3348d85ba66d6837ccf9babeeaec88b085d1037a4062ae"
+      },
+      {
+        "version": 21,
+        "sha256": "697052c2938e531828332ffc142a5944db170346bc64faf726b9a60f00c2bc02"
+      },
+      {
+        "version": 22,
+        "sha256": "32315dad8eed0970891be989d9de2e097d8d367bc12948a8e32190b4c3d8a5a6"
+      },
+      {
+        "version": 23,
+        "sha256": "fd81901234dabd727722c78e6dc4acb3ca9b540ac80d7b585fd783b34a7f76d0"
+      },
+      {
+        "version": 24,
+        "sha256": "822f1eeed7c1581ea0c7d45ba1990ab37783454fde1943784f261db81adb2386"
+      },
+      {
+        "version": 25,
+        "sha256": "75d065c7f9a72b40416f4ff60c5851e016568c25198c0209a870210689a99737"
+      },
+      {
+        "version": 26,
+        "sha256": "46cd5dc725e21d8005410ee7754e1195887ef57db7df2654a898acf38b6cfb7d"
+      },
+      {
+        "version": 27,
+        "sha256": "a1227a5d324a027f56a9afd403672f5288af5339b1f14ea054dd0dcedd313572"
+      },
+      {
+        "version": 28,
+        "sha256": "97e0b85c790914231c0a96005ffbae0298d518612212d40321090ad0c903fd6e"
+      },
+      {
+        "version": 29,
+        "sha256": "8608ac9856879781a1474dbceede9732ba6dc86aa58a91419e6e760d77180c70"
+      },
+      {
+        "version": 30,
+        "sha256": "3d83669ab30a2e78cdf74f7e1c14171d3621943cb7b94df9065790057d2a1432"
+      },
+      {
+        "version": 31,
+        "sha256": "ba4d844b4c69754f60947fdceed3717534a66c00f04c98b45de9cecef9fde5c1"
+      },
+      {
+        "version": 32,
+        "sha256": "061a95219995a7bb9ebd173af081868b20dd2f8c6875d76f706e9d17c106aa95"
+      },
+      {
+        "version": 33,
+        "sha256": "52118b2eb1c27ac59b4a9048bbc9f0f7b94de3e8ee80f6e1ccebbba52ee7a3e3"
+      },
+      {
+        "version": 35,
+        "sha256": "94cd74f965516076f3739ee038492fc6e9610caf759004b3e2aa4ae859d6aef8"
+      },
+      {
+        "version": 36,
+        "sha256": "3693e013851528b7944940c5d766593812b96e2053de2d7d4cc30c11ec53b89e"
+      },
+      {
+        "version": 37,
+        "sha256": "143e903029c2b56031a1e5f809b05b592b4f3c27143d4906190d363c038c196c"
+      },
+      {
+        "version": 38,
+        "sha256": "1c3d3326ef81fc1dc462df7b31acffdf9ec6697e6a5c1e9e490c32804446ba61"
+      },
+      {
+        "version": 39,
+        "sha256": "75aefe204d8e9b72819aaf6dc3ab918822e3ce375c32d62c3c813ed7e510f173"
+      },
+      {
+        "version": 40,
+        "sha256": "2720c7c80cac174aefde88af42738e7473b21a4e4ac089497c55b41b90ca381a"
+      },
+      {
+        "version": 41,
+        "sha256": "918ff84444281fb67aa6b09e66df7b5586b915614ea52a956b05d66772eea57c"
+      },
+      {
+        "version": 42,
+        "sha256": "f14d5fc5a50265330ccc5de5fe7417600159c559bacdb3afa90c85287e25af32"
+      },
+      {
+        "version": 43,
+        "sha256": "711e77eb60c97dec801a38a516e2ad7846e894ae50770fbd6c8b86b91084d8e6"
+      },
+      {
+        "version": 44,
+        "sha256": "037667151a0d0be70fc1be5a6bcc63f2a38446e913cb6c34786605a69b847353"
+      }
+    ]
+  },
+  "target_migrations": {
+    "engine": "postgres",
+    "entries": [
+      {
+        "version": 1,
+        "sha256": "eea5885c5ec812068112fd813cbeb4bb3d7397afcb380454edf09a46002a0ecd"
+      },
+      {
+        "version": 2,
+        "sha256": "a97b48e0075aa82b7365c79e1052a458eb2bcbb99cdf55a9ff8a8a596ffef5b5"
+      },
+      {
+        "version": 3,
+        "sha256": "e20df54b31080470757f6202fc4fe04130b9e98421f5f2f3696dd902a3b51792"
+      },
+      {
+        "version": 4,
+        "sha256": "dbfaa89e853eb4cb500937f5d64718b4ebc7aed56c093622308752db3cdec5c5"
+      },
+      {
+        "version": 5,
+        "sha256": "cd3db9fc9edf5669cca3875621d3e9530d3d8e41c7842125ec8e35f6562035df"
+      },
+      {
+        "version": 6,
+        "sha256": "8a8162d7d2bd03004463a886e268194cfb13ced057f0239089acabf1433a31c1"
+      },
+      {
+        "version": 7,
+        "sha256": "024471a575be90c0b85a70b4b56e7e8eb9dacfddfdaedefe1d3edbeae577e899"
+      },
+      {
+        "version": 8,
+        "sha256": "241723301173f5105c753652904b460a17a0866cb9c3c183a8a3acc7a4148db0"
+      },
+      {
+        "version": 9,
+        "sha256": "3a34f86fb17dc51c10c7276891921721010458b9589891be90d627b21be9f32f"
+      },
+      {
+        "version": 10,
+        "sha256": "87762947acaf730d97f6700c8f5552a983fb748b87afbeaf3ee085e8175654df"
+      },
+      {
+        "version": 11,
+        "sha256": "925ed4f50194a35e9eac9683b6e3cd44eb7c3737bc577e2b5488b7011dcad4b4"
+      },
+      {
+        "version": 12,
+        "sha256": "4bcbe15ad62c442cc718bd2ce75a65227330b8f9cf762827328297d0d5755a3d"
+      },
+      {
+        "version": 13,
+        "sha256": "62c86518bc6bc863450203975267da6b83fa80ffe63823a13881ac1b5dacdf5f"
+      },
+      {
+        "version": 14,
+        "sha256": "9e442fb01d2accaa55b4169f7ad144a04f101cd46c665d665bb256e0f01e6c2c"
+      },
+      {
+        "version": 15,
+        "sha256": "9d6308eb036c516ce50bae4fd15e4500e2d49db3783333f98f811882151ab89a"
+      },
+      {
+        "version": 16,
+        "sha256": "7327299939f6147df486d833a25bd699b6b833dbd537cae3c5364a500b83a2d5"
+      },
+      {
+        "version": 17,
+        "sha256": "b6789c8f61db3c56893d5e3c764d7387b51b4947a3e32b771809da49886be20d"
+      },
+      {
+        "version": 18,
+        "sha256": "756228fa797c0e123033e99dc0a4cd294a7ace8f1a4d637cb77350b2bfe857ca"
+      },
+      {
+        "version": 19,
+        "sha256": "2a1a3d5876c4bb38cb6c043aa74a6627d43ac7d6b72a4055ba648b7aa1345357"
+      },
+      {
+        "version": 20,
+        "sha256": "e5fd3263688891ef0b3348d85ba66d6837ccf9babeeaec88b085d1037a4062ae"
+      },
+      {
+        "version": 21,
+        "sha256": "697052c2938e531828332ffc142a5944db170346bc64faf726b9a60f00c2bc02"
+      },
+      {
+        "version": 22,
+        "sha256": "32315dad8eed0970891be989d9de2e097d8d367bc12948a8e32190b4c3d8a5a6"
+      },
+      {
+        "version": 23,
+        "sha256": "fd81901234dabd727722c78e6dc4acb3ca9b540ac80d7b585fd783b34a7f76d0"
+      },
+      {
+        "version": 24,
+        "sha256": "822f1eeed7c1581ea0c7d45ba1990ab37783454fde1943784f261db81adb2386"
+      },
+      {
+        "version": 25,
+        "sha256": "75d065c7f9a72b40416f4ff60c5851e016568c25198c0209a870210689a99737"
+      },
+      {
+        "version": 26,
+        "sha256": "46cd5dc725e21d8005410ee7754e1195887ef57db7df2654a898acf38b6cfb7d"
+      },
+      {
+        "version": 27,
+        "sha256": "a1227a5d324a027f56a9afd403672f5288af5339b1f14ea054dd0dcedd313572"
+      },
+      {
+        "version": 28,
+        "sha256": "97e0b85c790914231c0a96005ffbae0298d518612212d40321090ad0c903fd6e"
+      },
+      {
+        "version": 29,
+        "sha256": "8608ac9856879781a1474dbceede9732ba6dc86aa58a91419e6e760d77180c70"
+      },
+      {
+        "version": 30,
+        "sha256": "3d83669ab30a2e78cdf74f7e1c14171d3621943cb7b94df9065790057d2a1432"
+      },
+      {
+        "version": 31,
+        "sha256": "ba4d844b4c69754f60947fdceed3717534a66c00f04c98b45de9cecef9fde5c1"
+      },
+      {
+        "version": 32,
+        "sha256": "061a95219995a7bb9ebd173af081868b20dd2f8c6875d76f706e9d17c106aa95"
+      },
+      {
+        "version": 33,
+        "sha256": "52118b2eb1c27ac59b4a9048bbc9f0f7b94de3e8ee80f6e1ccebbba52ee7a3e3"
+      },
+      {
+        "version": 35,
+        "sha256": "94cd74f965516076f3739ee038492fc6e9610caf759004b3e2aa4ae859d6aef8"
+      },
+      {
+        "version": 36,
+        "sha256": "3693e013851528b7944940c5d766593812b96e2053de2d7d4cc30c11ec53b89e"
+      },
+      {
+        "version": 37,
+        "sha256": "143e903029c2b56031a1e5f809b05b592b4f3c27143d4906190d363c038c196c"
+      },
+      {
+        "version": 38,
+        "sha256": "1c3d3326ef81fc1dc462df7b31acffdf9ec6697e6a5c1e9e490c32804446ba61"
+      },
+      {
+        "version": 39,
+        "sha256": "75aefe204d8e9b72819aaf6dc3ab918822e3ce375c32d62c3c813ed7e510f173"
+      },
+      {
+        "version": 40,
+        "sha256": "2720c7c80cac174aefde88af42738e7473b21a4e4ac089497c55b41b90ca381a"
+      },
+      {
+        "version": 41,
+        "sha256": "918ff84444281fb67aa6b09e66df7b5586b915614ea52a956b05d66772eea57c"
+      },
+      {
+        "version": 42,
+        "sha256": "f14d5fc5a50265330ccc5de5fe7417600159c559bacdb3afa90c85287e25af32"
+      },
+      {
+        "version": 43,
+        "sha256": "711e77eb60c97dec801a38a516e2ad7846e894ae50770fbd6c8b86b91084d8e6"
+      },
+      {
+        "version": 44,
+        "sha256": "037667151a0d0be70fc1be5a6bcc63f2a38446e913cb6c34786605a69b847353"
+      },
+      {
+        "version": 45,
+        "sha256": "86932d127083a831a19dcf1c5e8bc49b1a58891d3c12de5fc0603256ad04edc2"
+      },
+      {
+        "version": 46,
+        "sha256": "ad6f3635d6110276dd8dc2a5e6c7118f18ac84ffcaec96eb79a2d9566828be92"
+      },
+      {
+        "version": 47,
+        "sha256": "a8c540b69397505957e080c0d1d2703bdbe7269f0b5e84f2966d2572a079fd86"
+      },
+      {
+        "version": 48,
+        "sha256": "29e40717e8887e68a40c9ba0164f76f88603c3ace889c3790d13c93ae0fd6404"
+      },
+      {
+        "version": 49,
+        "sha256": "2a112cc0a7cbcf1a0f691c23ddd51f71e12ba34b4a0829ddd9d2a32e2aae0188"
+      }
+    ]
+  },
+  "source_schema_sha256": "f9ad9908d1d1d5bb47c129eb0508458cf73a5940b2a02a7e60aa929315e222f0",
+  "target_schema_sha256": "ea79cbcb82a670f303ab790c62b577fc181d4c231abc3e9095a3dd32e11dba20",
+  "mode": "maintenance"
+}

--- a/release/trust/bridges/e0a262775b4d9dfccbc81de2d97879b6102f00d7fc4f5a16a835f342d3d65705/statement.sigstore.json
+++ b/release/trust/bridges/e0a262775b4d9dfccbc81de2d97879b6102f00d7fc4f5a16a835f342d3d65705/statement.sigstore.json
@@ -1,0 +1,1 @@
+{"base64Signature":"MEUCIQDDLtlgjKUh3sls9WG2GSxfrjl7YyoBPPPwC7emY1qEMwIgd5BAzIetKme1gXSTJWzB1kmleT+FYG8dlquFpESlYFg="}

--- a/release/trust/catalog.json
+++ b/release/trust/catalog.json
@@ -1,9 +1,12 @@
 {
   "schema": "hikyo.dev/upgrade-trust/v1",
-  "sequence": 1,
+  "sequence": 2,
   "stable_metadata_sha256": "cc7470eb6d2aac727bdaff9f5bb30c5c1fbbbaa3de9d2e8a0b5a9bb77a4c8d09",
   "nightly_policies": [
     "afaeb19fc0299f700234a74aa0817f77ce0833853b327a9d9d9d126d25d5b04f"
   ],
-  "bridges": []
+  "bridges": [
+    "afb19f55f6e8fc47f7946653b5c9ec558cb4d5215c52edf43653e59fd6920b63",
+    "e0a262775b4d9dfccbc81de2d97879b6102f00d7fc4f5a16a835f342d3d65705"
+  ]
 }

--- a/release/trust/catalog.sigstore.json
+++ b/release/trust/catalog.sigstore.json
@@ -1,1 +1,1 @@
-{"base64Signature":"MEUCIQCqkohse/Pu4mVXD94AAbjj9Dg1YWUQVc6golPSygGDBwIgft39zB0+qF6sweIFv3JisvR3YHB6bnA1W/AMdeXaWEI="}
+{"base64Signature":"MEQCIFFPsfmCo6e9gXFB5p9FYXWUdOZ6NJFSdVzhL4tExcvJAiBmk9sT/g8FM9ck4Lu93CBRUNMKei2i5uy+I9OMU9L8lg=="}


### PR DESCRIPTION
Existing pre-ledger installations need an independently recovery-authorized first hop into the new signed-nightly channel. Catalog sequence 2 adds exact SQLite and PostgreSQL maintenance bridges from the reviewed migration-44 schema to published nightly `v0.0.1-nightly.20260906.26.g52c8b012` (migration 49), binding its manifest, compatibility declaration and existing nightly policy.

Both statements and the advancing catalog are signed by the pinned recovery key using the operator-approved encrypted local nightly custody setup. Stable metadata and policy remain unchanged. The source inventories match every migration hash in the recovered September 5 nightly commit. Installation-specific inspection, backup/drill attestation and a full writer stop remain mandatory.

Validation: independently downloaded and authenticated all 22 immutable release assets; release CI verified real OIDC and packaged fresh production startup/restart on both engines. Assembled the actual signed runtime bundle; both legacy routes require one maintenance bridge and operator attestation. Missing bridge, wrong source schema and catalog rollback refuse. Independent signature/artifact review CLEAN. No live installation was modified. Public provenance and handoff are included.
