### PR TITLE
feat(upgrade): add sudo hikyo upgrade for signed nightlies on systemd hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           shellcheck_dir="$RUNNER_TEMP/shellcheck-$SHELLCHECK_VERSION"
           "$shellcheck_dir/shellcheck" \
             .githooks/* scripts/git/*.sh scripts/lib/*.sh scripts/ci/*.sh \
-            scripts/release/*.sh scripts/bench/*.sh scripts/compose-demo.sh install/install.sh.in
+            scripts/release/*.sh scripts/bench/*.sh scripts/compose-demo.sh install/install.sh.in install/upgrade-nightly*.sh
           echo "$shellcheck_dir" >>"$GITHUB_PATH"
       - name: Actionlint
         run: ./scripts/ci/run-go-tool.sh actionlint
@@ -239,6 +239,8 @@ jobs:
         run: ./scripts/release/release-channel_test.sh
       - name: Pinned installer fixture
         run: ./scripts/release/render-installer_test.sh
+      - name: First-use nightly bootstrap refusal boundaries
+        run: sh install/upgrade-nightly_test.sh
 
   # Build the release-shaped app once for browser legs plus ui-tagged/no-egress
   # checks. Go/API/client changes select these app checks without selecting the
@@ -954,6 +956,10 @@ jobs:
         run: |
           ./scripts/ci/test-core-packages_test.sh
           ./scripts/ci/test-core-packages.sh
+      - name: Root systemd upgrade adapter boundaries in isolated Linux
+        run: sh scripts/ci/test-host-upgrade.sh
+      - name: Real systemd upgrade service and reboot fence acceptance
+        run: sh scripts/ci/test-host-upgrade-systemd.sh
       - name: MCP 2026-07-28 upstream conformance
         run: ./scripts/ci/check-mcp-conformance.sh
       - name: Verify dynamic-secret target port discovery refusals

--- a/cmd/hikyo/main.go
+++ b/cmd/hikyo/main.go
@@ -4,11 +4,14 @@ package main
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"slices"
 	"syscall"
@@ -311,7 +314,13 @@ func runOperator(ctx context.Context, name string, args []string,
 		log.Warn(w)
 	}
 	terminalSession, terminalError := disclose.OpenTerminalSession()
-	err = run(ctx, cfg, log, args, os.Stderr, terminalSession, terminalError)
+	var output io.Writer = os.Stderr
+	if name == "backup" && len(args) > 0 && args[0] == "upgrade-export" {
+		// Public artifact locators (including --json) are command results.
+		// Diagnostics retain stderr so the coordinator can parse stdout alone.
+		output = os.Stdout
+	}
+	err = run(ctx, cfg, log, args, output, terminalSession, terminalError)
 	_ = terminalSession.Close()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hikyo %s: %v\n", name, err)
@@ -347,8 +356,34 @@ func runMigrate(ctx context.Context, args []string) int {
 
 func runUpgradeOperator(ctx context.Context, args []string) int {
 	if len(args) == 0 || args[0] != "operator" {
-		fmt.Fprintln(os.Stderr, "usage: hikyo upgrade operator rotate --statement FILE --signature FILE --new-public-key FILE")
-		return 2
+		terminal, terminalErr := disclose.OpenTerminalSession()
+		defer terminal.Close()
+		readPassword := func(prompt string) (string, error) {
+			if terminalErr != nil {
+				return "", terminalErr
+			}
+			return terminal.ReadPassword(prompt)
+		}
+		err := app.RunAutomaticUpgrade(ctx, args, os.Stdout, readPassword)
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		var handoff *app.AutomaticHandoff
+		if errors.As(err, &handoff) {
+			if err := terminal.Close(); err != nil {
+				fmt.Fprintln(os.Stderr, "hikyo upgrade:", err)
+				return 1
+			}
+			command := exec.CommandContext(ctx, handoff.Executable, handoff.Arguments...)
+			command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
+			command.Env = []string{"PATH=/usr/bin:/bin", "LANG=C.UTF-8"}
+			err = command.Run()
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "hikyo upgrade:", err)
+			return 1
+		}
+		return 0
 	}
 	cfg, warnings, err := config.Load("upgrade", nil, os.Getenv, os.Environ())
 	if err != nil {
@@ -370,6 +405,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, `hikyo — one binary, several roles
 
 server commands:
+  sudo hikyo upgrade [--target VERSION] [--config FILE]
   hikyo server [--dev] [--listen ADDR] [--auto-migrate=BOOL]
   hikyo migrate [--dev]
 

--- a/docs/adr/signed-upgrade-compatibility.md
+++ b/docs/adr/signed-upgrade-compatibility.md
@@ -170,6 +170,37 @@ runtime writers, and crashes after each phase and each migration commit.
 
 ## Backup and restore custody
 
+### Operator-approved local custody for nightly CLI upgrades (2026-09-06)
+
+The operator explicitly approved running a single `sudo hikyo upgrade` command
+on the server, with encrypted operator-only recovery keys stored locally. For
+this nightly CLI flow, the operator process may hold an encrypted age identity,
+an independent attestation key and root-key escrow in a root-owned directory
+outside the runtime user's writable paths. Unlocking requires an interactive
+operator passphrase. Private material is decrypted only in operator-process
+memory and is never placed in server environment variables, command arguments,
+public evidence directories or the database. The unprivileged server and host
+adapter receive public evidence only. This explicit exception supersedes the
+off-host custody requirement below for this flow; it does not establish an
+off-host disaster-recovery copy or authorize unattended key unlocking.
+
+The CLI automates authenticated release discovery, complete bundle assembly,
+encrypted export, real scratch restore and credential proof, installation,
+migration and bounded health checks. Build trust pins and migration policy are
+embedded. The final release signature remains detached because its signed
+manifest covers the final executable bytes; the CLI fetches and verifies it.
+No manual evidence assembly is required. Existing unsigned installations enter
+through their exact recovery-signed bridge. Intermediate hops remain in
+maintenance, and every executable independently enforces the runtime gate.
+
+The operator CLI owns a durable host journal and persistent systemd startup
+fence. Before invoking migration it records an uncertain-write boundary. A
+failed or interrupted post-boundary operation never automatically restarts an
+older binary or restores a database. A later invocation reconciles the journal
+with authenticated database state before continuing. The retired remote apply
+protocol remains disabled; this exception grants no service-control privilege
+to the Hikyo server, browser or remote client.
+
 Populated-database upgrades require a verified pre-upgrade backup; this
 explicitly supersedes the existing loud no-recipient skip as a successful
 upgrade outcome. A fresh empty database needs no source-data backup. Ordinary
@@ -219,6 +250,14 @@ Compose project or unit from the browser. It verifies the pinned plan and releas
 proof itself, retains a durable journal, drains the configured deployment,
 applies digest-pinned artifacts, checks health and reconciles restart state.
 The server receives no Docker socket or systemd control authority.
+
+A failed platform candidate health check first retains the service fence and
+records a terminal host `restore-required` journal; automatic retries are refused.
+If the exact runtime operation is still `schema-applied`, the coordinator also
+advances that database operation to `restore-required` through its existing CAS.
+If runtime-local health already established `healthy` before platform readiness
+failed, its applied identity remains intact behind the terminal host fence;
+operator recovery is required without rewriting successful database history.
 
 Flux uses a separate pull-based upgrade controller with narrowly scoped access
 to one declared deployment and Git path. Credentials can update only a dedicated single-application repository and protected ref. Ordinary Git

--- a/docs/handoff/20260906-automatic-nightly-upgrade.md
+++ b/docs/handoff/20260906-automatic-nightly-upgrade.md
@@ -1,0 +1,83 @@
+# Automatic systemd nightly upgrades
+
+## Operator request and scope
+
+The operator approved `sudo hikyo upgrade` on the Hikyo server, including locally
+stored encrypted operator keys. The locked signed-upgrade ADR records this
+explicit nightly custody exception. Linux systemd with one local SQLite database
+is supported. Stable, PostgreSQL, Compose, Kubernetes and remote fleet apply keep
+their existing manual procedures.
+
+The coordinator is new work after nightly 26. Existing binaries cannot gain the
+command without a first-use bootstrap. Once this change is published, the
+Upgrades docs provide one HTTPS bootstrap command; it verifies the downloaded
+coordinator before running it, without replacing the working server first.
+If an interrupted first upgrade leaves an intermediate binary without the new
+command, rerun that same bootstrap command. Subsequent upgrades use the CLI.
+
+## Implementation map
+
+- `internal/app/automatic_*.go`: exact signed release selection, bounded route
+  discovery, authenticated target coordinator handoff, proof preparation and
+  durable per-hop reconciliation. Existing database inspection and admission
+  remain authoritative; no version comparison authorizes schema changes.
+- `internal/hostupgrade`: root-owned deployment config, systemd preflight,
+  durable startup fence, full writer stop, runtime UID and root credential
+  isolation, atomic executable replacement and exact process/readiness proof.
+- `internal/upgradecustody`: age-encrypted, installation-bound backup identity,
+  independent attestation signer and root escrow. Root-only vault defaults to
+  `/etc/hikyo/upgrade-keys/operator.age`; the passphrase is interactive and is
+  never persisted. Runtime receives only the public operator pin and proof.
+- `internal/selfupdate` and `internal/upgradeassembly`: reuse complete nightly
+  verification and atomic public bundle assembly. Cached assets are rechecked
+  against immutable API inventory and current signed trust. Route discovery
+  stops once it proves the installed source's route, including exact legacy
+  bridges. The old notification flow still stages without applying remotely.
+- `install/upgrade-nightly.sh`: first-use verification through pinned Cosign,
+  complete OIDC certificate policy and pinned recovery-key authorization of the
+  current catalog/policy, including revocations and persisted trust floors.
+  `docs/site/scripts/prepare-content.mjs` copies the canonical script to the
+  published docs artifact. No private release key is in the script or binary.
+
+## Durable state and interruption handling
+
+Default config is `/etc/hikyo/upgrade.json`. Controller state and its operation
+journal are under `/var/lib/hikyo-upgrader`; public runtime evidence lives under
+`/var/lib/hikyo-upgrade`. Persistent installation custody is a separate runtime
+directory at `/var/lib/hikyo-installation`.
+
+One encrypted backup and signed restore-drill attestation bind the full route.
+The scratch drill reconciles one existing eligible principal, mints and revokes
+a credential through existing authorization, and never changes live authority.
+Each target performs its existing migration and boot gates. Intermediate hops
+stay in maintenance; only the final exact process and healthy database allow
+removal of the systemd fence. Consumed proof is removed from restart config.
+
+The journal distinguishes preparing, proved, write intent, schema applied,
+healthy hop, complete and terminal recovery-required states. An unchanged source
+can retry before writes; schema-applied and healthy admissions reconcile against
+the exact original source, route and hop. Uncertain writes or failed candidate
+health retain the fence and require explicit recovery. An already healthy DB
+record is not falsified if external readiness fails: the terminal host journal
+and startup fence preserve that additional failure. No automatic old-binary or
+database rollback occurs.
+
+## Validation and delivery limits
+
+`TestAutomaticUpgradePackagedNightlyRoute` builds production-stamped executable
+fixtures with real signed declarations. It proves a populated legacy bridge and
+two nightly hops, actual encrypted CLI export, automatic scratch proof, real
+migrations, HTTP maintenance/readiness, protected-value readability and a restart
+without consumed evidence. It also proves post-migration install interruption
+resume and terminal refusal after actual wrong-root startup. Normal and race
+runs passed. Only service lifecycle is substituted in this packaged test.
+
+The relevant Go packages, Go vet, bootstrap refusal tests, root Linux adapter
+tests, ShellCheck, and docs typecheck/build/PWA browser checks passed locally.
+Additional real-systemd acceptance exercises the actual generated unit and
+drop-ins separately from the packaged database test.
+
+No live installation was changed. Local tests do not mean a nightly containing
+this feature has been published; check the eventual PR, merge and signed nightly
+publication before giving the operator the bootstrap command as available.
+Local encrypted custody does not provide an off-host disaster recovery copy.

--- a/docs/handoff/20260906-automatic-nightly-upgrade.md
+++ b/docs/handoff/20260906-automatic-nightly-upgrade.md
@@ -81,3 +81,42 @@ No live installation was changed. Local tests do not mean a nightly containing
 this feature has been published; check the eventual PR, merge and signed nightly
 publication before giving the operator the bootstrap command as available.
 Local encrypted custody does not provide an off-host disaster recovery copy.
+
+## Continuation on 2026-09-06 (second session)
+
+The first session ended at the real-systemd acceptance fix. The second session
+rebased onto main after #686, found main red, and fixed it first:
+
+- PR #691 `fix(config): accept ephemeral listeners for production nodes`. #686
+  rejected port 0 outside development mode without a test or rationale, which
+  broke `TestPackagedNightlyReleaseUpgrade` and
+  `TestNightlyAssemblyAuthenticatesCompleteDownload` on main. This PR is the
+  stacked base of the feature PR.
+
+Adversarial review of the feature produced two fixes folded into this branch:
+
+- `fix(release): enforce current nightly policy revocations online`. Revocation
+  was judged only against the policy copy bundled inside each immutable release,
+  so a single nightly could not be revoked without refusing every nightly of its
+  policy period. Online verifiers now also fetch the live
+  `release/trust/nightly/policy.json`, require a catalog-authorized digest, and
+  refuse manifests it revokes. The offline boot gate is unchanged. The runbook
+  gained a "Revoke one published nightly" section.
+- `fix(upgrade): prune stale public evidence and report unlock failures
+  alongside outcomes`. Completed runs now remove earlier `bundle-*`,
+  `evidence-*` and `backup-*` directories the journal no longer references. The
+  lock release error no longer hides a migration failure.
+
+Verified locally after the rebase: Go tests for app, hostupgrade, selfupdate,
+releasetrust, upgradecustody, upgradeassembly, upgradebundle, upgradegate,
+updatecheck, upgradecompat, store/upgrade, service, devupgrade, config, the
+release and CI script packages; both Docker acceptance scripts (root adapter and
+real systemd); bootstrap shell tests; ShellCheck; actionlint; docs check, build
+and verify-docs.
+
+Open items for the human: the standing Codex review of the Claude-authored fixes
+could not run (Codex usage limit until 2026-09-13); a fallback reviewer model
+needs Marc's choice. Merge of #691 and of the feature PR is gated on CI green plus
+that review. The server on nightly 23 still cannot upgrade until a nightly
+containing this feature is published; then the bootstrap command in the Upgrades
+docs applies.

--- a/docs/operations/manual-upgrades.md
+++ b/docs/operations/manual-upgrades.md
@@ -1,5 +1,11 @@
 # Manual verified installation and upgrade
 
+For nightly releases on a Linux systemd host with local SQLite, use
+`sudo hikyo upgrade`. It automates the procedure below, including encrypted local
+operator custody, signed legacy bridges, backup restoration to scratch and
+service health checks. See the [one-command upgrade instructions](https://hikyo.app/docs/upgrades/).
+This manual runbook remains available for other deployment types and recovery.
+
 Every production boot and `hikyo migrate` authenticates its exact build and
 offline release bundle. Installing an image or binary alone is insufficient.
 Remote apply, the old host helpers and WebUI apply remain disabled. The

--- a/docs/operations/signed-nightlies.md
+++ b/docs/operations/signed-nightlies.md
@@ -121,9 +121,15 @@ Never reuse a signature after reformatting or changing the statement.
 
 ## Download and install
 
+For the supported Linux systemd/SQLite deployment, `sudo hikyo upgrade` performs
+download, bundle assembly, local encrypted operator custody, backup restoration
+to scratch, migration and verified restart. Its first-use bootstrap also covers
+older binaries without the command. See the [one-command upgrade instructions](https://hikyo.app/docs/upgrades/).
+The remaining steps describe manual preparation for other deployment types.
+
 In clients carrying the new trust stamp, `hikyo update check` verifies and stages
-the complete signed nightly in the CLI state directory. It preserves the
-installed executable and reports the staging path. Unsigned assets, rollback,
+the complete signed nightly and assembles its runtime bundle in the CLI state
+directory. It preserves the installed executable and reports both paths. Unsigned assets, rollback,
 equivocation or missing trust refuse. Older clients cannot safely bootstrap this
 trust through their old binary-only self-update flow; perform the first
 installation with independently authenticated public trust and downloads.

--- a/docs/operations/signed-nightlies.md
+++ b/docs/operations/signed-nightlies.md
@@ -99,7 +99,12 @@ To revoke a nightly, add its `release-manifest.json` SHA-256 to
 sequence while keeping the earlier policy digest listed, and recovery-sign the
 catalog. Keeping the earlier digest lets other nightlies from that policy period
 keep verifying; dropping it refuses all of them at once. Publish the policy and
-catalog together. The offline server boot gate keeps using the bundled policy;
+catalog together. Note the limit of keeping the earlier digest: the verifier
+accepts any catalog-listed policy as current, so a party able to substitute the
+published trust files could serve the earlier clean policy and re-enable the
+revoked nightly. That holds the revocation against accidental selection, not
+against an adversary; when it must hold adversarially, drop the earlier digest
+and accept refusing that policy period. The offline server boot gate keeps using the bundled policy;
 a revoked release that is already installed remains inspectable and is never
 selected again as an upgrade target.
 

--- a/docs/operations/signed-nightlies.md
+++ b/docs/operations/signed-nightlies.md
@@ -85,6 +85,24 @@ operator evidence, upgrades with the candidate binary, and checks readiness,
 secret readability and restart. The first signed release has no authenticated
 predecessor, so only its fresh-install route is automatically exercised.
 
+## Revoke one published nightly
+
+Every nightly bundles the policy it was built under, and a GitHub release is
+immutable, so a revocation cannot be written into the release itself. Online
+verifiers (`hikyo upgrade`, `hikyo update`, the first-use bootstrap and the
+release preflight) therefore also fetch the currently published
+`release/trust/nightly/policy.json` and refuse any manifest it lists in
+`revoked_manifests`, even when the release's own bundled policy is clean.
+
+To revoke a nightly, add its `release-manifest.json` SHA-256 to
+`revoked_manifests` in the reviewed policy, regenerate the catalog with the next
+sequence while keeping the earlier policy digest listed, and recovery-sign the
+catalog. Keeping the earlier digest lets other nightlies from that policy period
+keep verifying; dropping it refuses all of them at once. Publish the policy and
+catalog together. The offline server boot gate keeps using the bundled policy;
+a revoked release that is already installed remains inspectable and is never
+selected again as an upgrade target.
+
 ## Bridge existing unsigned installations once
 
 A pre-ledger database remains `legacy/v1`, identified by its inspected schema

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -1,6 +1,7 @@
 .astro/
 dist/
 node_modules/
+public/upgrade-nightly.sh
 src/content/docs/security.md
 src/content/docs/support.md
 src/content/docs/governance.md

--- a/docs/site/scripts/prepare-content.mjs
+++ b/docs/site/scripts/prepare-content.mjs
@@ -7,6 +7,13 @@ const siteRoot = resolve(scriptDirectory, '..');
 const repositoryRoot = resolve(siteRoot, '../..');
 const docsRoot = resolve(siteRoot, 'src/content/docs');
 
+// Keep the first-use upgrade entrypoint identical to the reviewed source.
+await mkdir(resolve(siteRoot, 'public'), { recursive: true });
+await writeFile(
+  resolve(siteRoot, 'public/upgrade-nightly.sh'),
+  await readFile(resolve(repositoryRoot, 'install/upgrade-nightly.sh')),
+);
+
 const pages = [
   { source: 'SECURITY.md', target: 'security.md', title: 'Security policy' },
   { source: 'SUPPORT.md', target: 'support.md', title: 'Support policy' },

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -1,11 +1,62 @@
 ---
 title: Upgrades
-description: Upgrade a Hikyo instance with an encrypted rollback artifact and explicit schema control.
+description: Upgrade a systemd nightly with one command, including signed release verification and a tested encrypted backup.
 editUrl: https://github.com/Hikyo-Org/Hikyo/edit/main/docs/site/src/content/docs/docs/upgrades.mdx
 ---
 
 Hikyo migrations move forward only. A downgrade means restoring a pre-upgrade
 archive with a compatible binary, not running a down migration.
+
+## One-command nightly upgrade
+
+On a Linux systemd server with a local SQLite database, run:
+
+```sh
+sudo hikyo upgrade
+```
+
+The command verifies the signed nightly and its complete migration route,
+assembles release evidence, stops writers, exports an encrypted backup, restores
+it to scratch, proves key and credential recovery, and upgrades the service.
+Intermediate releases stay in maintenance. The command reports success only
+after the exact final executable and database state pass health checks.
+
+The first run creates `/etc/hikyo/upgrade.json` for the standard `hikyo.service`
+installation and prompts twice for a recovery-key passphrase. Subsequent runs
+prompt once to unlock the encrypted operator keys. Custom deployments can supply
+a root-owned config with `--config FILE`; unsupported unit settings fail before
+the service stops. This command currently supports nightly releases on a single
+Linux systemd host with SQLite. Compose, Kubernetes, PostgreSQL and stable
+deployment upgrades use the manual procedure below.
+
+Older nightlies, including the pre-ledger releases, do not contain this command.
+After a signed release containing it is published, bootstrap the new coordinator
+without replacing the working server first. The bootstrap needs `curl`,
+`python3` and `openssl` on the server, plus an interactive terminal for the
+recovery-key passphrase:
+
+```sh
+curl --fail --silent --show-error --proto '=https' https://hikyo.app/upgrade-nightly.sh | sudo sh
+```
+
+The bootstrap verifies the release before running the staged coordinator. Future
+upgrades use `sudo hikyo upgrade`. The first legacy transition still requires an
+exact recovery-signed bridge; the command finds and verifies it automatically.
+
+Encrypted operator custody lives in `/etc/hikyo/upgrade-keys/operator.age`, owned
+by root and inaccessible to the runtime user. It includes the backup identity,
+independent attestation key and root escrow. The passphrase is never saved.
+This explicitly chosen local custody model does not provide an off-host recovery
+copy. Preserve the encrypted vault and passphrase through your recovery process.
+No operator private key enters the service configuration or release workflow.
+
+If an upgrade is interrupted, rerun the same command. During the first upgrade,
+an intermediate older binary can still lack `hikyo upgrade`; in that case rerun
+the bootstrap command above. Its durable journal and
+systemd startup fence survive reboot. Proven pre-write attempts and known healthy
+or schema-applied targets can continue. An uncertain or failed schema change
+leaves the service stopped and requires explicit operator recovery; the command
+never automatically rolls back the database or starts an older binary.
 
 ## Release channels
 
@@ -21,8 +72,8 @@ nightly history cannot hide the latest published stable release.
 
 Server-side and remote workspace checks are notification-only. Remote apply is
 disabled for every release channel because the legacy helper cannot prove safe
-rollback once a migration has started. Signed release discovery and verified
-manual downloads remain available.
+rollback once a migration has started. The local operator command above and
+verified manual downloads remain available.
 
 Release binaries also check their own CLI track before dispatching a command
 when stderr and a controlling terminal are available. Stable artifacts default to `stable`, nightly artifacts default to
@@ -35,8 +86,9 @@ At most once per 24 hours, Hikyo refreshes the selected track. When a newer
 release exists, the controlling terminal offers the appropriate download flow.
 Nightlies require an immutable release, authenticated policy, complete Sigstore
 bundle and the exact closed inventory of all published payloads. Accepting stages
-the verified download and prints its path; it preserves the current executable.
-Server upgrades also require the runtime bundle and backup/drill evidence below.
+the verified download and assembled runtime bundle and prints their paths; it
+preserves the current executable. Use `sudo hikyo upgrade` to upgrade a supported
+server, including its installation-specific backup and restore proof.
 Unsigned historical nightlies cannot pass this verification.
 
 Stable updates download the exact archive for the running OS and architecture,
@@ -64,8 +116,9 @@ confirmation flow immediately.
 
 The legacy `hikyo updater` helper and its Compose, systemd, and Flux adapters are
 retired. They could automatically restore a database after schema writes had
-started; the Flux adapter also used ambient Git credentials. Replacement platform application remains disabled. Manual installation and
-migration use the same mandatory signed-release gate as server startup.
+started; the Flux adapter also used ambient Git credentials. Remote platform
+application remains disabled. The operator-invoked systemd command and manual
+installation use the same mandatory signed-release gate as server startup.
 
 `HIKYO_UPDATER_SOCKET` now prevents server startup. Remove that setting to start
 the server with release notifications. `hikyo updater` refuses before reading
@@ -84,14 +137,14 @@ reached apply, investigate the datastore and use the operator-led recovery
 procedure below. Retirement does not mark existing jobs successful or restored.
 
 Every connected workspace still checks release metadata directly. Administrators
-retain update notifications and links to release notes. Upgrades use the manual
-signed-bundle and maintenance procedure below. The viewing instance holds no
+retain update notifications and links to release notes. An operator runs the
+local command above or the manual procedure below. The viewing instance holds no
 fleet deployment credentials.
 
 For stable artifacts, use the [installation and release-verification instructions](/docs/installation/)
 to obtain and verify the signed bundle before the maintenance window.
 
-## Required upgrade inputs
+## Manual upgrade inputs
 
 Every production boot and `hikyo migrate` needs `HIKYO_UPGRADE_BUNDLE`, naming
 a complete authenticated offline release bundle, and the installation's public
@@ -109,7 +162,8 @@ For nightlies, follow the [signed nightly runbook](https://github.com/Hikyo-Org/
 It covers the one-time recovery authorization, automated publication and
 complete-download assembly. Existing unsigned pre-ledger databases additionally
 require an exact recovery-signed legacy bridge and fresh operator backup proof.
-The CLI download flow does not install that bridge or replace the server binary.
+The notification/download flow does not replace the server binary. The explicit
+`sudo hikyo upgrade` command handles the bridge and deployment on supported hosts.
 
 ## Before the change
 

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -48,6 +48,10 @@ by root and inaccessible to the runtime user. It includes the backup identity,
 independent attestation key and root escrow. The passphrase is never saved.
 This explicitly chosen local custody model does not provide an off-host recovery
 copy. Preserve the encrypted vault and passphrase through your recovery process.
+After each completed upgrade the command keeps only the encrypted backup taken
+before the current schema under `/var/lib/hikyo-upgrade`; earlier `backup-*`,
+`bundle-*` and `evidence-*` directories there are removed. Copy any backup you
+want to keep elsewhere.
 No operator private key enters the service configuration or release workflow.
 
 If an upgrade is interrupted, rerun the same command. During the first upgrade,

--- a/install/upgrade-nightly.sh
+++ b/install/upgrade-nightly.sh
@@ -1,0 +1,410 @@
+#!/bin/sh
+# First-use bridge for an installed Hikyo binary without `hikyo upgrade`.
+# HTTPS delivers this script. Pinned Cosign authenticates all executable bytes
+# downloaded by it before the coordinator touches the installed deployment.
+set -eu
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+umask 077
+
+fail() { printf 'hikyo upgrade bootstrap: %s\n' "$*" >&2; exit 1; }
+[ "$(id -u)" = 0 ] || fail 'run this bootstrap with sudo sh'
+[ "$(uname -s)" = Linux ] || fail 'only Linux systemd is supported'
+[ -d /run/systemd/system ] || fail 'systemd must be running on this host'
+for command_name in curl python3 openssl; do
+	command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
+done
+
+case "$(uname -m)" in
+	x86_64 | amd64)
+		arch=amd64
+		cosign_sha256=4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
+		;;
+	aarch64 | arm64)
+		arch=arm64
+		cosign_sha256=c5d324e091826b0d7a78eb16fef316450b4eb9aaec045611c08ba06f5e73220a
+		;;
+	*) fail 'only Linux amd64 and arm64 are supported' ;;
+esac
+trusted_root_sha256=6494e21ea73fa7ee769f85f57d5a3e6a08725eae1e38c755fc3517c9e6bc0b66
+repository=Hikyo-Org/Hikyo
+
+# Use a root-owned hierarchy, not a world-writable /tmp ancestor: the verified
+# coordinator independently enforces ownership before staging an executable.
+scratch=$(python3 - <<'PY'
+import os, pathlib, stat, tempfile
+root = pathlib.Path('/var/lib/hikyo-upgrader')
+for parent in reversed(root.parents):
+    info = parent.lstat()
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != 0 or info.st_mode & 0o022:
+        raise SystemExit('unsafe bootstrap parent directory')
+try:
+    root.mkdir(mode=0o700)
+except FileExistsError:
+    pass
+info = root.lstat()
+if not stat.S_ISDIR(info.st_mode) or info.st_uid != 0 or info.st_mode & 0o077:
+    raise SystemExit('bootstrap state directory must be root-owned mode0700')
+print(tempfile.mkdtemp(prefix='bootstrap-', dir=root))
+PY
+)
+trap 'rm -rf "$scratch"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+cat >"$scratch/verify.py" <<'PY'
+# BEGIN BOOTSTRAP VERIFIER
+import hashlib
+import base64
+import fcntl
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import stat
+import sys
+import tarfile
+import tempfile
+
+def fail(message):
+    raise SystemExit('hikyo upgrade bootstrap: ' + message)
+
+def unique_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            fail('duplicate JSON field')
+        value[key] = item
+    return value
+
+def document(path):
+    with open(path, 'rb') as source:
+        raw = source.read(4 * 1024 * 1024 + 1)
+    if len(raw) > 4 * 1024 * 1024:
+        fail('JSON input exceeds 4 MiB')
+    return json.loads(raw, object_pairs_hook=unique_object)
+
+def digest(path):
+    result = hashlib.sha256()
+    with open(path, 'rb') as source:
+        for block in iter(lambda: source.read(1024 * 1024), b''):
+            result.update(block)
+    return result.hexdigest()
+
+tag_pattern = re.compile(r'v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)-nightly\.[0-9]{8}\.([1-9][0-9]*)\.g[0-9a-f]{8}')
+sha_pattern = re.compile(r'[0-9a-f]{64}')
+
+def recovery_authorization(directory, manifest_path, state_directory):
+    directory, state_directory = pathlib.Path(directory), pathlib.Path(state_directory)
+    recovery_hash = '1eb7ad2092668b73621c21a1eeb801ed6391bc794df1909abce8e1d45e03a229'
+    if digest(directory / 'recovery-1.pub') != recovery_hash:
+        fail('recovery public key differs from bootstrap pin')
+    # OpenSSL verifies the existing key-based Cosign envelope. The envelope
+    # cannot supply a key; only the independently pinned recovery key is used.
+    for name in ('metadata', 'catalog'):
+        envelope = document(directory / (name + '.sigstore.json'))
+        if not isinstance(envelope, dict) or not set(envelope) <= {'base64Signature', 'cert', 'rekorBundle'}:
+            fail('invalid recovery signature envelope')
+        signature = base64.b64decode(envelope['base64Signature'], validate=True)
+        if not 1 <= len(signature) <= 16384:
+            fail('invalid recovery signature size')
+        signature_path = directory / (name + '.signature')
+        signature_path.write_bytes(signature)
+        subprocess.run(['openssl', 'dgst', '-sha256', '-verify', str(directory / 'recovery-1.pub'), '-signature', str(signature_path), str(directory / (name + '.json'))], check=True, capture_output=True, timeout=10)
+    metadata, catalog, policy = (document(directory / name) for name in ('metadata.json', 'catalog.json', 'policy.json'))
+    if metadata.get('schema') != 'hikyo.dev/trust-metadata/v1' or metadata.get('recovery') != {'id': 'recovery-1', 'sha256': recovery_hash} or metadata.get('event', {}).get('signed_by') != 'recovery-1':
+        fail('invalid recovery-authorized metadata identity')
+    if set(catalog) != {'schema', 'sequence', 'stable_metadata_sha256', 'nightly_policies', 'bridges'} or catalog['schema'] != 'hikyo.dev/upgrade-trust/v1' or catalog['stable_metadata_sha256'] != digest(directory / 'metadata.json'):
+        fail('catalog does not bind the authenticated metadata')
+    for name, limit in (('nightly_policies', 256), ('bridges', 1024)):
+        inventory = catalog[name]
+        if not isinstance(inventory, list) or len(inventory) > limit or not all(isinstance(value, str) and sha_pattern.fullmatch(value) for value in inventory) or len(set(inventory)) != len(inventory):
+            fail('invalid authorized digest inventory')
+    if digest(directory / 'policy.json') not in catalog['nightly_policies']:
+        fail('nightly policy is not currently recovery-authorized')
+    expected_policy = {
+        'schema': 'hikyo.dev/nightly-policy/v1',
+        'trusted_root_sha256': '6494e21ea73fa7ee769f85f57d5a3e6a08725eae1e38c755fc3517c9e6bc0b66',
+        'issuer': 'https://token.actions.githubusercontent.com',
+        'repository_uri': 'https://github.com/Hikyo-Org/Hikyo',
+        'repository_id': '1316165429', 'repository_owner_uri': 'https://github.com/Hikyo-Org',
+        'repository_owner_id': '316726515', 'workflow_path': '.github/workflows/nightly.yml',
+        'protected_ref': 'refs/heads/main', 'runner_environment': 'github-hosted', 'require_sct': True,
+        'rekor_log_id': 'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+        'checkpoint_origin': 'rekor.sigstore.dev - 1193050959916656506',
+    }
+    if not isinstance(policy, dict) or set(policy) != set(expected_policy) | {'revoked_manifests'} or any(type(policy[key]) is not type(value) or policy[key] != value for key, value in expected_policy.items()):
+        fail('authorized nightly policy differs from this bootstrap verifier')
+    revoked = policy['revoked_manifests']
+    if not isinstance(revoked, list) or len(revoked) > 256 or not all(isinstance(value, str) and sha_pattern.fullmatch(value) for value in revoked) or len(set(revoked)) != len(revoked):
+        fail('invalid revoked manifest inventory')
+    floor = {'metadata_sequence': metadata['sequence'], 'metadata_sha256': digest(directory / 'metadata.json'), 'catalog_sequence': catalog['sequence'], 'catalog_sha256': digest(directory / 'catalog.json')}
+    minimum = {'metadata_sequence': 1, 'metadata_sha256': 'cc7470eb6d2aac727bdaff9f5bb30c5c1fbbbaa3de9d2e8a0b5a9bb77a4c8d09', 'catalog_sequence': 2, 'catalog_sha256': 'd688b21bbaee7f5dfc789e7f03b544853e90b40b5004e6203155dfce3df99262'}
+    def check_floor(known):
+        for name in ('metadata', 'catalog'):
+            sequence, checksum = name + '_sequence', name + '_sha256'
+            if type(floor[sequence]) is not int or type(known[sequence]) is not int or known[sequence] < 1 or not isinstance(known[checksum], str) or not sha_pattern.fullmatch(known[checksum]):
+                fail('invalid trust floor')
+            if floor[sequence] < known[sequence] or floor[sequence] == known[sequence] and floor[checksum] != known[checksum]:
+                fail('recovery trust rollback or equivocation refused')
+    def private_open(path, flags):
+        descriptor = os.open(path, flags | os.O_NOFOLLOW | os.O_CLOEXEC, 0o600)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.geteuid() or info.st_mode & 0o077 or info.st_nlink != 1:
+            os.close(descriptor)
+            fail('unsafe bootstrap trust state')
+        return os.fdopen(descriptor, 'r+')
+    # Serialize the floor with other bootstraps. The root-private parent was
+    # checked before staging; a crash cannot erase an observed revocation.
+    with private_open(state_directory / 'bootstrap-trust.lock', os.O_RDWR | os.O_CREAT) as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        check_floor(minimum)
+        state_path = state_directory / 'bootstrap-trust.json'
+        for path in (state_path, state_directory / 'downloads/nightly-trust.json'):
+            try:
+                with private_open(path, os.O_RDWR) as source:
+                    raw = source.read(4 * 1024 * 1024 + 1)
+                    if len(raw) > 4 * 1024 * 1024:
+                        fail('trust state exceeds bound')
+                    known = json.loads(raw, object_pairs_hook=unique_object)
+                    check_floor(known if path == state_path else known['floor'])
+            except FileNotFoundError:
+                pass
+        descriptor, temporary = tempfile.mkstemp(prefix='.bootstrap-trust-', dir=state_directory)
+        try:
+            with os.fdopen(descriptor, 'w') as output:
+                json.dump(floor, output)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, state_path)
+            parent = os.open(state_directory, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(parent)
+            finally:
+                os.close(parent)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+    if digest(manifest_path) in revoked:
+        fail('nightly manifest revoked by current recovery-authorized policy')
+
+def certificate_policy(bundle_path, commit):
+    # Cosign has already authenticated this bundle's exact leaf certificate.
+    # OpenSSL owns X.509/ASN.1 decoding; this code only compares decoded policy
+    # claims. Never use this operation in place of signature verification.
+    bundle = document(bundle_path)
+    if bundle.get('mediaType') != 'application/vnd.dev.sigstore.bundle.v0.3+json':
+        fail('unsupported Sigstore bundle format')
+    material = bundle['verificationMaterial']
+    certificate = base64.b64decode(material['certificate']['rawBytes'], validate=True)
+    if len(certificate) > 65536:
+        fail('certificate exceeds 64 KiB')
+    entries = material['tlogEntries']
+    if not isinstance(entries, list) or len(entries) != 1:
+        fail('exactly one authenticated transparency entry is required')
+    entry = entries[0]
+    if base64.b64decode(entry['logId']['keyId'], validate=True).hex() != 'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d':
+        fail('transparency log differs from pinned nightly policy')
+    proof = entry['inclusionProof']
+    checkpoint = proof['checkpoint']['envelope'].splitlines()
+    if len(checkpoint) < 3 or checkpoint[0] != 'rekor.sigstore.dev - 1193050959916656506' or not re.fullmatch(r'[1-9][0-9]*', str(proof['treeSize'])) or checkpoint[1] != str(proof['treeSize']):
+        fail('transparency checkpoint differs from pinned nightly policy')
+    if not entry['inclusionPromise']['signedEntryTimestamp'] or not re.fullmatch(r'[1-9][0-9]*', str(entry['integratedTime'])):
+        fail('authenticated integrated timestamp is required')
+
+    def openssl(*flags):
+        result = subprocess.run(['openssl', *flags], input=certificate, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10, check=True)
+        if len(result.stdout) > 262144:
+            fail('certificate parser output exceeds 256 KiB')
+        return result.stdout.decode('ascii')
+
+    openssl('x509', '-inform', 'DER', '-noout')
+    lines = openssl('asn1parse', '-inform', 'DER').splitlines()
+    workflow = 'https://github.com/Hikyo-Org/Hikyo/.github/workflows/nightly.yml@refs/heads/main'
+    expected = {
+        8: 'https://token.actions.githubusercontent.com',
+        9: workflow,
+        10: commit,
+        11: 'github-hosted',
+        12: 'https://github.com/Hikyo-Org/Hikyo',
+        13: commit,
+        14: 'refs/heads/main',
+        15: '1316165429',
+        16: 'https://github.com/Hikyo-Org',
+        17: '316726515',
+        18: workflow,
+        19: commit,
+    }
+    for number, value in expected.items():
+        oid = '1.3.6.1.4.1.57264.1.' + str(number)
+        matching = [i for i, line in enumerate(lines) if re.fullmatch(r'\s*[0-9]+:d=5\s+hl=[0-9]+\s+l=\s*[0-9]+\s+prim:\s+OBJECT\s+:' + re.escape(oid), line)]
+        if len(matching) != 1 or matching[0] + 1 >= len(lines):
+            fail('missing or duplicate authenticated certificate claim ' + oid)
+        extension = re.fullmatch(r'\s*([0-9]+):d=5\s+hl=[0-9]+\s+l=\s*[0-9]+\s+prim:\s+OCTET STRING\s+\[HEX DUMP\]:[0-9A-Fa-f]+', lines[matching[0] + 1])
+        if not extension:
+            fail('unexpected certificate extension encoding')
+        decoded = openssl('asn1parse', '-inform', 'DER', '-strparse', extension.group(1)).strip()
+        claim = re.fullmatch(r'0:d=0\s+hl=[0-9]+\s+l=\s*[0-9]+\s+prim:\s+UTF8STRING\s+:(.*)', decoded)
+        if not claim or claim.group(1) != value:
+            fail('authenticated certificate claim differs from nightly policy: ' + oid)
+
+def main():
+    action, *args = sys.argv[1:]
+    if action == 'hash':
+        if not sha_pattern.fullmatch(args[1]) or digest(args[0]) != args[1]:
+            fail('download SHA-256 mismatch')
+    elif action == 'certificate-policy':
+        certificate_policy(*args)
+    elif action == 'authorize':
+        recovery_authorization(*args)
+    elif action == 'release':
+        releases = document(args[0])
+        if not isinstance(releases, list) or len(releases) > 100:
+            fail('invalid GitHub release inventory')
+        candidates = {}
+        for release in releases:
+            if not isinstance(release, dict):
+                fail('invalid GitHub release')
+            tag = release.get('tag_name', '')
+            match = tag_pattern.fullmatch(tag) if isinstance(tag, str) else None
+            if not match or release.get('draft') is not False or release.get('prerelease') is not True or release.get('immutable') is not True:
+                continue
+            assets = release.get('assets')
+            if not isinstance(assets, list) or not all(isinstance(asset, dict) for asset in assets):
+                fail('invalid GitHub release assets')
+            names = [asset.get('name') for asset in assets]
+            if names.count('release-manifest.json') != 1 or names.count('release-manifest.sigstore.json') != 1:
+                continue
+            sequence = int(match.group(1))
+            if sequence in candidates:
+                fail('ambiguous nightly release sequence')
+            candidates[sequence] = tag
+        if not candidates or max(candidates) <= 26:
+            fail('no signed nightly containing the automatic upgrade coordinator has been published yet')
+        print(candidates[max(candidates)])
+    elif action in ('commit', 'artifact'):
+        manifest = document(args[0])
+        tag = args[1]
+        if not isinstance(manifest, dict) or manifest.get('schema') != 'hikyo.dev/nightly-manifest/v1' or manifest.get('profile') != 'nightly/v1':
+            fail('invalid nightly manifest profile')
+        match = tag_pattern.fullmatch(tag)
+        if not match or manifest.get('tag') != tag or manifest.get('version') != tag[1:] or type(manifest.get('release_sequence')) is not int or manifest['release_sequence'] != int(match.group(1)):
+            fail('manifest release identity mismatch')
+        commit = manifest.get('source_commit')
+        if not isinstance(commit, str) or not re.fullmatch(r'[0-9a-f]{40}', commit) or not commit.startswith(tag.rsplit('.g', 1)[1]):
+            fail('invalid source commit')
+        if action == 'commit':
+            print(commit)
+            return
+        inventory = manifest.get('artifacts')
+        if not isinstance(inventory, list) or not 1 <= len(inventory) <= 100:
+            fail('invalid signed artifact inventory')
+        seen, selected = set(), []
+        for artifact in inventory:
+            if not isinstance(artifact, dict):
+                fail('invalid signed artifact')
+            name, checksum = artifact.get('name'), artifact.get('sha256')
+            if not isinstance(name, str) or not re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._-]{0,199}', name) or '..' in name or name in seen:
+                fail('unsafe or duplicate signed artifact name')
+            if not isinstance(checksum, str) or not sha_pattern.fullmatch(checksum):
+                fail('invalid signed artifact digest')
+            seen.add(name)
+            if artifact.get('kind') == 'binary' and artifact.get('platform') == 'linux/' + args[2]:
+                if not name.endswith('.tar.gz'):
+                    fail('unexpected Linux archive format')
+                selected.append((name, checksum))
+        if len(selected) != 1:
+            fail('signed inventory must contain exactly one binary for this platform')
+        print(*selected[0], sep='\n')
+    elif action == 'extract':
+        archive, output, checksum, arch = args
+        if digest(archive) != checksum:
+            fail('archive SHA-256 differs from the authenticated inventory')
+        with tarfile.open(archive, mode='r:gz') as package:
+            count, total, binary = 0, 0, None
+            for member in package:
+                count += 1
+                parts = pathlib.PurePosixPath(member.name).parts
+                if member.name.startswith('/') or not parts or '..' in parts or '\\' in member.name or member.name.startswith('./'):
+                    fail('unsafe archive member path')
+                if not member.isfile() and not member.isdir():
+                    fail('archive contains a link or special file')
+                total += member.size
+                if count > 10000 or total > 512 * 1024 * 1024 or member.size < 0:
+                    fail('archive exceeds bounded extraction limits')
+                if member.name == 'hikyo':
+                    if binary is not None or not member.isfile() or member.size == 0:
+                        fail('archive must contain one regular hikyo executable')
+                    binary = member
+            if binary is None:
+                fail('archive has no hikyo executable')
+            with package.extractfile(binary) as source, open(output, 'xb') as target:
+                shutil.copyfileobj(source, target, 1024 * 1024)
+                target.flush()
+                os.fsync(target.fileno())
+        with open(output, 'rb') as candidate:
+            header = candidate.read(20)
+        machine = {'amd64': 62, 'arm64': 183}.get(arch)
+        if len(header) != 20 or header[:6] != b'\x7fELF\x02\x01' or int.from_bytes(header[18:20], 'little') != machine:
+            fail('candidate is not the expected Linux ELF executable')
+        os.chmod(output, 0o700)
+    else:
+        fail('unknown verification operation')
+
+if __name__ == '__main__':
+    try:
+        main()
+    except (OSError, ValueError, TypeError, KeyError, AttributeError, subprocess.SubprocessError, tarfile.TarError) as error:
+        fail('invalid bootstrap input: ' + type(error).__name__)
+# END BOOTSTRAP VERIFIER
+PY
+
+download() {
+	curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+		--connect-timeout 15 --max-time 300 --max-filesize "$3" "$1" --output "$2"
+}
+
+printf 'Authenticating the latest signed nightly upgrade coordinator...\n' >&2
+download "https://api.github.com/repos/$repository/releases?per_page=100" "$scratch/releases.json" 4194304
+tag=$(python3 "$scratch/verify.py" release "$scratch/releases.json")
+base_url="https://github.com/$repository/releases/download/$tag"
+download "$base_url/release-manifest.json" "$scratch/manifest.json" 4194304
+download "$base_url/release-manifest.sigstore.json" "$scratch/manifest.sigstore.json" 4194304
+commit=$(python3 "$scratch/verify.py" commit "$scratch/manifest.json" "$tag")
+
+download "https://github.com/sigstore/cosign/releases/download/v3.1.3/cosign-linux-$arch" "$scratch/cosign" 314572800
+python3 "$scratch/verify.py" hash "$scratch/cosign" "$cosign_sha256"
+chmod 700 "$scratch/cosign"
+download "https://raw.githubusercontent.com/$repository/refs/heads/main/release/trust/nightly/trusted-root.json" "$scratch/trusted-root.json" 4194304
+python3 "$scratch/verify.py" hash "$scratch/trusted-root.json" "$trusted_root_sha256"
+"$scratch/cosign" verify-blob --bundle "$scratch/manifest.sigstore.json" \
+	--trusted-root "$scratch/trusted-root.json" \
+	--certificate-identity "https://github.com/$repository/.github/workflows/nightly.yml@refs/heads/main" \
+	--certificate-oidc-issuer https://token.actions.githubusercontent.com \
+	--certificate-github-workflow-repository "$repository" \
+	--certificate-github-workflow-ref refs/heads/main \
+	--certificate-github-workflow-sha "$commit" "$scratch/manifest.json"
+python3 "$scratch/verify.py" certificate-policy "$scratch/manifest.sigstore.json" "$commit"
+
+# The signing workflow alone is insufficient: authenticate current recovery
+# authorization and revocations before even asking a candidate for --help.
+trust_url="https://raw.githubusercontent.com/$repository/refs/heads/main/release/trust"
+for trust_file in recovery-1.pub metadata.json metadata.sigstore.json catalog.json catalog.sigstore.json; do
+	download "$trust_url/$trust_file" "$scratch/$trust_file" 4194304
+done
+download "$trust_url/nightly/policy.json" "$scratch/policy.json" 4194304
+python3 "$scratch/verify.py" authorize "$scratch" "$scratch/manifest.json" /var/lib/hikyo-upgrader
+
+# Only after Cosign authenticates the exact manifest may its inventory choose
+# executable bytes. Neither a GitHub asset checksum nor an unsigned checksums
+# file grants execution authority.
+python3 "$scratch/verify.py" artifact "$scratch/manifest.json" "$tag" "$arch" >"$scratch/artifact"
+artifact=$(sed -n '1p' "$scratch/artifact")
+artifact_sha256=$(sed -n '2p' "$scratch/artifact")
+download "$base_url/$artifact" "$scratch/archive.tar.gz" 536870912
+python3 "$scratch/verify.py" extract "$scratch/archive.tar.gz" "$scratch/hikyo" "$artifact_sha256" "$arch"
+"$scratch/hikyo" upgrade --help >/dev/null 2>&1 || fail 'the latest signed nightly does not include automatic upgrades yet; wait for the next published nightly'
+printf 'Verified %s. Starting the upgrade coordinator; the installed binary is unchanged.\n' "$tag" >&2
+"$scratch/hikyo" upgrade "$@" </dev/tty

--- a/install/upgrade-nightly_test.sh
+++ b/install/upgrade-nightly_test.sh
@@ -1,0 +1,242 @@
+#!/bin/sh
+# Offline bootstrap boundary tests. No downloads or installed service changes.
+set -eu
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+python3 - "$script_dir/upgrade-nightly.sh" <<'PY'
+import hashlib
+import base64
+import io
+import json
+import os
+import pathlib
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+
+script = pathlib.Path(sys.argv[1]).read_text()
+helper = script.split('# BEGIN BOOTSTRAP VERIFIER\n', 1)[1].split('# END BOOTSTRAP VERIFIER', 1)[0]
+tag = 'v0.0.1-nightly.20260907.27.gaaaaaaaa'
+
+class BootstrapBoundaries(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = pathlib.Path(self.temp.name)
+        self.verifier = self.root / 'verify.py'
+        self.verifier.write_text(helper)
+
+    def run_verify(self, action, *args, success=True):
+        result = subprocess.run([sys.executable, str(self.verifier), action, *map(str, args)], capture_output=True, text=True)
+        self.assertEqual(result.returncode == 0, success, result.stdout + result.stderr)
+        return result.stdout.strip()
+
+    def manifest(self, artifacts=None):
+        if artifacts is None:
+            artifacts = [{'name': 'hikyo_linux_arm64.tar.gz', 'kind': 'binary', 'platform': 'linux/arm64', 'sha256': 'b' * 64}]
+        value = {'schema': 'hikyo.dev/nightly-manifest/v1', 'profile': 'nightly/v1', 'tag': tag, 'version': tag[1:], 'source_commit': 'a' * 40, 'release_sequence': 27, 'artifacts': artifacts}
+        path = self.root / 'manifest.json'
+        path.write_text(json.dumps(value))
+        return path
+
+    def archive(self, names=('hikyo',), member_type=tarfile.REGTYPE):
+        path = self.root / 'archive.tar.gz'
+        header = bytearray(20)
+        header[:6] = b'\x7fELF\x02\x01'
+        header[18:20] = (183).to_bytes(2, 'little')
+        with tarfile.open(path, 'w:gz') as output:
+            for name in names:
+                entry = tarfile.TarInfo(name)
+                entry.type = member_type
+                entry.size = len(header) if member_type == tarfile.REGTYPE else 0
+                entry.linkname = '/etc/shadow'
+                output.addfile(entry, io.BytesIO(header) if entry.size else None)
+        return path, hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def test_authenticated_inventory_selection(self):
+        manifest = self.manifest()
+        self.assertEqual(self.run_verify('commit', manifest, tag), 'a' * 40)
+        self.assertEqual(self.run_verify('artifact', manifest, tag, 'arm64'), 'hikyo_linux_arm64.tar.gz\n' + 'b' * 64)
+
+    def test_unsafe_duplicate_and_wrong_platform_inventory(self):
+        for name in ('../hikyo', '/hikyo', 'hikyo\nrun', 'hikyo;exec', 'hikyo..tar.gz'):
+            manifest = self.manifest([{'name': name, 'kind': 'binary', 'platform': 'linux/arm64', 'sha256': 'b' * 64}])
+            self.run_verify('artifact', manifest, tag, 'arm64', success=False)
+        item = {'name': 'hikyo.tar.gz', 'kind': 'binary', 'platform': 'linux/arm64', 'sha256': 'b' * 64}
+        self.run_verify('artifact', self.manifest([item, item]), tag, 'arm64', success=False)
+        self.run_verify('artifact', self.manifest(), tag, 'amd64', success=False)
+
+    def test_duplicate_json_and_source_commit_fail(self):
+        path = self.manifest()
+        path.write_text(path.read_text().replace('"source_commit":', '"source_commit":"' + 'c' * 40 + '","source_commit":'))
+        self.run_verify('commit', path, tag, success=False)
+        path = self.manifest()
+        value = json.loads(path.read_text())
+        value['source_commit'] = 'c' * 40
+        path.write_text(json.dumps(value))
+        self.run_verify('commit', path, tag, success=False)
+
+    def test_download_hash_mismatch_fails(self):
+        path = self.root / 'cosign'
+        path.write_bytes(b'unauthenticated executable')
+        self.run_verify('hash', path, 'a' * 64, success=False)
+
+    def test_safe_extraction_and_no_overwrite(self):
+        archive, digest = self.archive()
+        output = self.root / 'hikyo'
+        self.run_verify('extract', archive, output, digest, 'arm64')
+        self.assertEqual(output.stat().st_mode & 0o777, 0o700)
+        original = output.read_bytes()
+        self.run_verify('extract', archive, output, digest, 'arm64', success=False)
+        self.assertEqual(output.read_bytes(), original)
+
+    def test_archive_digest_paths_links_duplicates_and_platform(self):
+        output = self.root / 'hikyo'
+        archive, digest = self.archive()
+        self.run_verify('extract', archive, output, 'a' * 64, 'arm64', success=False)
+        self.assertFalse(output.exists())
+        for names, kind in [(('../hikyo',), tarfile.REGTYPE), (('/hikyo',), tarfile.REGTYPE), (('hikyo',), tarfile.SYMTYPE), (('hikyo',), tarfile.LNKTYPE), (('hikyo',), tarfile.FIFOTYPE), (('hikyo', 'hikyo'), tarfile.REGTYPE)]:
+            archive, digest = self.archive(names, kind)
+            self.run_verify('extract', archive, output, digest, 'arm64', success=False)
+            self.assertFalse(output.exists())
+
+    def test_only_immutable_signed_nightlies_selected(self):
+        release = {'tag_name': tag, 'draft': False, 'prerelease': True, 'immutable': True, 'assets': [{'name': 'release-manifest.json'}, {'name': 'release-manifest.sigstore.json'}]}
+        path = self.root / 'releases.json'
+        path.write_text(json.dumps([release]))
+        self.assertEqual(self.run_verify('release', path), tag)
+        for key in ('draft', 'prerelease', 'immutable'):
+            changed = dict(release)
+            changed[key] = not changed[key]
+            path.write_text(json.dumps([changed]))
+            self.run_verify('release', path, success=False)
+        path.write_text(json.dumps([release, release]))
+        self.run_verify('release', path, success=False)
+
+    def test_future_version_nightly_release_selection(self):
+        future = 'v1.2.0-nightly.20260908.28.gaaaaaaaa'
+        release = {'tag_name': future, 'draft': False, 'prerelease': True, 'immutable': True, 'assets': [{'name': 'release-manifest.json'}, {'name': 'release-manifest.sigstore.json'}]}
+        path = self.root / 'releases.json'
+        path.write_text(json.dumps([release]))
+        self.assertEqual(self.run_verify('release', path), future)
+
+    def test_full_certificate_claim_policy_before_execution(self):
+        workflow = 'https://github.com/Hikyo-Org/Hikyo/.github/workflows/nightly.yml@refs/heads/main'
+        values = {8: 'https://token.actions.githubusercontent.com', 9: workflow, 10: 'a' * 40, 11: 'github-hosted', 12: 'https://github.com/Hikyo-Org/Hikyo', 13: 'a' * 40, 14: 'refs/heads/main', 15: '1316165429', 16: 'https://github.com/Hikyo-Org', 17: '316726515', 18: workflow, 19: 'a' * 40}
+        for replacement in (None, (11, 'self-hosted'), (15, '999'), (17, '999')):
+            claims = dict(values)
+            if replacement:
+                claims[replacement[0]] = replacement[1]
+            args = ['openssl', 'req', '-new', '-x509', '-newkey', 'ec', '-pkeyopt', 'ec_paramgen_curve:P-256', '-nodes', '-keyout', str(self.root / 'fixture.key'), '-outform', 'DER', '-out', str(self.root / 'fixture.der'), '-subj', '/CN=policy-parser-fixture', '-days', '1']
+            for number, value in claims.items():
+                args.extend(['-addext', '1.3.6.1.4.1.57264.1.' + str(number) + '=ASN1:UTF8String:' + value])
+            subprocess.run(args, check=True, capture_output=True)
+            # These synthetic bytes test policy decoding only. The production
+            # shell must first pass Cosign; the prior test proves that order.
+            bundle = {'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json', 'verificationMaterial': {'certificate': {'rawBytes': base64.b64encode((self.root / 'fixture.der').read_bytes()).decode()}, 'tlogEntries': [{'logId': {'keyId': base64.b64encode(bytes.fromhex('c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d')).decode()}, 'inclusionProof': {'treeSize': '1', 'checkpoint': {'envelope': 'rekor.sigstore.dev - 1193050959916656506\n1\nfixture\n'}}, 'inclusionPromise': {'signedEntryTimestamp': 'fixture'}, 'integratedTime': '1'}]}}
+            path = self.root / 'certificate.sigstore.json'
+            path.write_text(json.dumps(bundle))
+            self.run_verify('certificate-policy', path, 'a' * 40, success=replacement is None)
+
+    def test_signature_failure_stops_before_policy_or_download(self):
+        # Execute the production shell's signature-verification section with a
+        # failing maintained-verifier stand-in. No production bypass variable
+        # or unauthenticated execution path is added to the distributed script.
+        verifier = self.root / 'cosign'
+        verifier.write_text('#!/bin/sh\nexit 23\n')
+        verifier.chmod(0o700)
+        section = script.split('"$scratch/cosign" verify-blob', 1)[1].split('# Only after Cosign', 1)[0]
+        shell = 'set -eu\nscratch=' + shlex.quote(str(self.root)) + '\nrepository=Hikyo-Org/Hikyo\ncommit=' + 'a' * 40 + '\n"$scratch/cosign" verify-blob' + section
+        result = subprocess.run(['sh', '-c', shell], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 23)
+        self.assertNotIn('certificate-policy', result.stderr)
+        for required in ('--certificate-identity', '--certificate-oidc-issuer', '--certificate-github-workflow-repository', '--certificate-github-workflow-ref', '--certificate-github-workflow-sha', '--trusted-root'):
+            self.assertIn(required, section)
+        self.assertNotIn('--insecure-ignore', section)
+
+    def authorization_fixture(self):
+        self.key = self.root / 'test-recovery.key'
+        subprocess.run(['openssl', 'genpkey', '-algorithm', 'EC', '-pkeyopt', 'ec_paramgen_curve:P-256', '-out', str(self.key)], check=True, capture_output=True)
+        subprocess.run(['openssl', 'pkey', '-in', str(self.key), '-pubout', '-out', str(self.root / 'recovery-1.pub')], check=True, capture_output=True)
+        key_digest = hashlib.sha256((self.root / 'recovery-1.pub').read_bytes()).hexdigest()
+        # Replace the independently pinned fixture key in the extracted helper,
+        # never add a production override or a key selected by signed evidence.
+        self.verifier.write_text(helper.replace('1eb7ad2092668b73621c21a1eeb801ed6391bc794df1909abce8e1d45e03a229', key_digest))
+        policy_path = pathlib.Path(sys.argv[1]).parent.parent / 'release/trust/nightly/policy.json'
+        self.policy = json.loads(policy_path.read_text())
+        self.metadata = {'schema': 'hikyo.dev/trust-metadata/v1', 'sequence': 2, 'recovery': {'id': 'recovery-1', 'sha256': key_digest}, 'event': {'signed_by': 'recovery-1'}}
+        self.catalog = {'schema': 'hikyo.dev/upgrade-trust/v1', 'sequence': 3, 'bridges': []}
+        self.state = self.root / 'state'
+        self.state.mkdir(mode=0o700)
+        return self.manifest()
+
+    def sign_authorization(self, authorized=True):
+        policy = self.root / 'policy.json'
+        policy.write_text(json.dumps(self.policy))
+        metadata = self.root / 'metadata.json'
+        metadata.write_text(json.dumps(self.metadata))
+        self.catalog['stable_metadata_sha256'] = hashlib.sha256(metadata.read_bytes()).hexdigest()
+        self.catalog['nightly_policies'] = [hashlib.sha256(policy.read_bytes()).hexdigest()] if authorized else []
+        (self.root / 'catalog.json').write_text(json.dumps(self.catalog))
+        for name in ('metadata', 'catalog'):
+            result = subprocess.run(['openssl', 'dgst', '-sha256', '-sign', str(self.key), str(self.root / (name + '.json'))], check=True, capture_output=True)
+            (self.root / (name + '.sigstore.json')).write_text(json.dumps({'base64Signature': base64.b64encode(result.stdout).decode()}))
+
+    def test_recovery_revocation_persists_and_rejects_older_authorization(self):
+        manifest = self.authorization_fixture()
+        self.sign_authorization()
+        self.run_verify('authorize', self.root, manifest, self.state)
+        self.policy['revoked_manifests'] = [hashlib.sha256(manifest.read_bytes()).hexdigest()]
+        self.catalog['sequence'] = 4
+        self.sign_authorization()
+        self.assertIn('revoked', subprocess.run([sys.executable, str(self.verifier), 'authorize', str(self.root), str(manifest), str(self.state)], capture_output=True, text=True).stderr)
+        self.assertEqual(json.loads((self.state / 'bootstrap-trust.json').read_text())['catalog_sequence'], 4)
+        self.policy['revoked_manifests'] = []
+        self.catalog['sequence'] = 3
+        self.sign_authorization()
+        self.run_verify('authorize', self.root, manifest, self.state, success=False)
+
+    def test_unauthorized_policy_and_tampered_signature_refuse(self):
+        manifest = self.authorization_fixture()
+        self.sign_authorization(authorized=False)
+        self.run_verify('authorize', self.root, manifest, self.state, success=False)
+        self.sign_authorization()
+        (self.root / 'catalog.json').write_text((self.root / 'catalog.json').read_text() + ' ')
+        self.run_verify('authorize', self.root, manifest, self.state, success=False)
+        self.assertFalse((self.state / 'bootstrap-trust.json').exists())
+
+    def test_existing_installer_floor_and_symlink_refuse(self):
+        manifest = self.authorization_fixture()
+        self.sign_authorization()
+        downloads = self.state / 'downloads'
+        downloads.mkdir(mode=0o700)
+        floor = {'metadata_sequence': 2, 'metadata_sha256': hashlib.sha256((self.root / 'metadata.json').read_bytes()).hexdigest(), 'catalog_sequence': 4, 'catalog_sha256': 'a' * 64}
+        known = downloads / 'nightly-trust.json'
+        known.write_text(json.dumps({'floor': floor}))
+        known.chmod(0o600)
+        self.run_verify('authorize', self.root, manifest, self.state, success=False)
+        known.unlink()
+        (self.state / 'bootstrap-trust.json').symlink_to(self.verifier)
+        self.run_verify('authorize', self.root, manifest, self.state, success=False)
+
+    def test_recovery_refusal_prevents_first_candidate_execution(self):
+        manifest = self.authorization_fixture()
+        self.policy['revoked_manifests'] = [hashlib.sha256(manifest.read_bytes()).hexdigest()]
+        self.sign_authorization()
+        candidate = self.root / 'hikyo'
+        marker = self.root / 'executed'
+        candidate.write_text('#!/bin/sh\ntouch ' + shlex.quote(str(marker)) + '\n')
+        candidate.chmod(0o700)
+        # Exercise the production order, substituting only fixture paths and
+        # already-downloaded inputs; no executable is reached on refusal.
+        authorization = 'python3 "$scratch/verify.py" authorize "$scratch" "$scratch/manifest.json" /var/lib/hikyo-upgrader'
+        self.assertLess(script.index(authorization), script.index('"$scratch/hikyo" upgrade --help'))
+        shell = 'set -eu\nscratch=' + shlex.quote(str(self.root)) + '\n' + authorization.replace('/var/lib/hikyo-upgrader', shlex.quote(str(self.state))) + '\n"$scratch/hikyo" upgrade --help\n'
+        result = subprocess.run(['sh', '-c', shell], capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(marker.exists())
+
+unittest.main(argv=['bootstrap-tests'])
+PY

--- a/internal/app/automatic_apply.go
+++ b/internal/app/automatic_apply.go
@@ -22,6 +22,7 @@ type automaticApplyHost interface {
 	ConfigureRuntime(context.Context, hostupgrade.RuntimeEvidence) error
 	StartCandidate(context.Context, string, bool, time.Duration) error
 	Complete(context.Context) error
+	PrunePublic(hostupgrade.RuntimeEvidence) error
 }
 
 type automaticInspection interface {
@@ -152,7 +153,12 @@ func applyAutomaticRoute(ctx context.Context, host automaticApplyHost, database 
 		return err
 	}
 	journal.Phase = "complete"
-	return writeAutomaticJournal(journalPath, journal)
+	if err := writeAutomaticJournal(journalPath, journal); err != nil {
+		return err
+	}
+	// Earlier runs' public bundles, one-use attestations and backups are no
+	// longer referenced; only this run's evidence and encrypted backup remain.
+	return host.PrunePublic(journal.Runtime)
 }
 
 func validateAutomaticPosition(plan upgradecompat.Plan, journal *automaticJournal) error {

--- a/internal/app/automatic_apply.go
+++ b/internal/app/automatic_apply.go
@@ -1,0 +1,304 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+// Only process/service operations are abstracted here. Production inspection
+// always measures the real SQLite catalog, migration history and runtime ledger.
+type automaticApplyHost interface {
+	FenceAndStop(context.Context) error
+	Migrate(context.Context, string, hostupgrade.RuntimeEvidence) ([]byte, error)
+	InstallBinary(context.Context, string, string) error
+	ConfigureRuntime(context.Context, hostupgrade.RuntimeEvidence) error
+	StartCandidate(context.Context, string, bool, time.Duration) error
+	Complete(context.Context) error
+}
+
+type automaticInspection interface {
+	Control(context.Context) (upgrade.State, error)
+	Installed(context.Context, releaseidentity.MigrationManifest) (upgrade.InstalledSource, error)
+}
+
+type automaticStore struct{ config upgrade.Config }
+
+func (s automaticStore) Control(ctx context.Context) (upgrade.State, error) {
+	return upgrade.InspectControl(ctx, s.config)
+}
+func (s automaticStore) Installed(ctx context.Context, manifest releaseidentity.MigrationManifest) (upgrade.InstalledSource, error) {
+	return upgrade.InspectInstalled(ctx, s.config, manifest)
+}
+
+func applyAutomaticRoute(ctx context.Context, host automaticApplyHost, database automaticInspection, route automaticRoute, staged map[releaseidentity.Identity]string, journal *automaticJournal, journalPath string, out io.Writer) (err error) {
+	// Register the failure fence before any reconciliation or process operation.
+	defer func() {
+		if err != nil {
+			cleanup, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+			err = errors.Join(err, host.FenceAndStop(cleanup))
+		}
+	}()
+	if err := validateAutomaticPosition(route.Plan, journal); err != nil {
+		return err
+	}
+	steps := route.Plan.Steps()
+	start := journal.Hop
+	finalAlreadyHealthy := journal.Phase == "hop-healthy" && start == len(steps)
+	if finalAlreadyHealthy {
+		// Entry fenced the service during reconciliation. Repeat exact binary
+		// installation and readiness proof before removing that fence or completing.
+		start--
+	}
+	if journal.Phase == "hop-healthy" && journal.Hop > 0 {
+		state, err := database.Control(ctx)
+		if err != nil {
+			return errors.New("completed hop has uncertain database state; operator recovery is required")
+		}
+		if err := validateAutomaticHealthy(state, journal, route.Plan, journal.Hop-1); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintln(out, "4/5 Applying the authenticated migration route.")
+	for index := start; index < len(steps); index++ {
+		step := steps[index]
+		candidate, ok := staged[step.Target]
+		prepared, have := route.Executables[step.Target]
+		if !ok || !have || candidate == "" || prepared.Identity != step.Target || prepared.BinarySHA256.Validate() != nil {
+			return errors.New("authenticated route executable is missing or mismatched")
+		}
+		shouldMigrate := false
+		if !finalAlreadyHealthy {
+			shouldMigrate, err = automaticMigrationDisposition(ctx, database, journal, route.Plan, index)
+			if err != nil {
+				return err
+			}
+		}
+		if shouldMigrate {
+			journal.Hop, journal.Phase = index, "write-intent"
+			if err := writeAutomaticJournal(journalPath, journal); err != nil {
+				return err
+			}
+			if _, err := host.Migrate(ctx, candidate, journal.Runtime); err != nil {
+				return fmt.Errorf("migration failed; service remains stopped: %w", err)
+			}
+			// A successful child exit alone is insufficient. Confirm the exact durable
+			// target/hop before publishing schema-applied or installing its executable.
+			state, err := database.Control(ctx)
+			if err != nil {
+				return errors.New("migration returned without readable durable admission state")
+			}
+			if err := validateAutomaticPending(state, journal, route.Plan, index); err != nil {
+				return err
+			}
+			if state.Pending.Phase != upgrade.SchemaApplied {
+				return errors.New("migration did not establish exact schema-applied state")
+			}
+			journal.Phase = "schema-applied"
+			if err := writeAutomaticJournal(journalPath, journal); err != nil {
+				return err
+			}
+		}
+		if err := host.InstallBinary(ctx, candidate, string(prepared.BinarySHA256)); err != nil {
+			return err
+		}
+		startEvidence := journal.Runtime
+		if finalAlreadyHealthy {
+			// A completed final DB admission needs only restart evidence, not
+			// the old encrypted backup or one-use attestation files.
+			startEvidence.EvidenceDirectory, startEvidence.CiphertextPath = "", ""
+			startEvidence.LegacyWritersStopped = false
+		}
+		if err := host.ConfigureRuntime(ctx, startEvidence); err != nil {
+			return err
+		}
+		final := index == len(steps)-1
+		fmt.Fprintf(out, "5/5 Checking Hikyo %s (%d/%d).\n", step.Target.Version, index+1, len(steps))
+		if err := host.StartCandidate(ctx, string(prepared.BinarySHA256), final, 45*time.Second); err != nil {
+			return recordAutomaticHealthFailure(host, database, route.Plan, journal, journalPath, index, err)
+		}
+		state, err := database.Control(ctx)
+		if err != nil {
+			return recordAutomaticHealthFailure(host, database, route.Plan, journal, journalPath, index, err)
+		}
+		if err := validateAutomaticHealthy(state, journal, route.Plan, index); err != nil {
+			return recordAutomaticHealthFailure(host, database, route.Plan, journal, journalPath, index, err)
+		}
+		journal.Phase, journal.Hop = "hop-healthy", index+1
+		if err := writeAutomaticJournal(journalPath, journal); err != nil {
+			return err
+		}
+		if !final {
+			if err := host.FenceAndStop(ctx); err != nil {
+				return err
+			}
+		}
+	}
+	restartEvidence := journal.Runtime
+	restartEvidence.EvidenceDirectory, restartEvidence.CiphertextPath = "", ""
+	restartEvidence.LegacyWritersStopped = false
+	if err := host.ConfigureRuntime(ctx, restartEvidence); err != nil {
+		return err
+	}
+	if err := host.Complete(ctx); err != nil {
+		return err
+	}
+	journal.Phase = "complete"
+	return writeAutomaticJournal(journalPath, journal)
+}
+
+func validateAutomaticPosition(plan upgradecompat.Plan, journal *automaticJournal) error {
+	if journal == nil || !plan.Valid() || len(plan.Steps()) == 0 || journal.Target != plan.Target() || journal.Route != plan.Digest() || journal.Source.Identity != plan.Source() || journal.Source.SchemaSHA256 != plan.SourceSchemaDigest() || journal.Instance == "" {
+		return errors.New("host journal differs from the authenticated route")
+	}
+	expected, err := plan.SourceManifest(journal.Source.Migrations.Engine)
+	actualDigest, actualErr := journal.Source.Migrations.Digest()
+	expectedDigest, expectedErr := expected.Digest()
+	if err != nil || actualErr != nil || expectedErr != nil || actualDigest != expectedDigest {
+		return errors.New("host journal source migrations differ from the authenticated route")
+	}
+	length := len(plan.Steps())
+	if journal.Hop < 0 || journal.Hop > length {
+		return errors.New("host journal hop lies outside the authenticated route")
+	}
+	switch journal.Phase {
+	case "proved":
+		if journal.Hop != 0 {
+			return errors.New("backup proof journal must start at the first hop")
+		}
+	case "hop-healthy":
+		if journal.Hop == 0 {
+			return errors.New("healthy hop journal has no completed hop")
+		}
+	case "write-intent", "schema-applied":
+		if journal.Hop == length {
+			return errors.New("unfinished hop journal lies beyond the authenticated route")
+		}
+	default:
+		return errors.New("host journal is not ready to apply an authenticated route")
+	}
+	return nil
+}
+
+func validateAutomaticPending(state upgrade.State, journal *automaticJournal, plan upgradecompat.Plan, index int) error {
+	steps := plan.Steps()
+	if index < 0 || index >= len(steps) {
+		return errors.New("pending hop lies outside the authenticated route")
+	}
+	step := steps[index]
+	sourceDigest, sourceErr := step.SourceMigrations.Digest()
+	targetDigest, targetErr := step.TargetMigrations.Digest()
+	p := state.Pending
+	if sourceErr != nil || targetErr != nil || state.InstanceID != journal.Instance || p == nil || p.Kind != upgrade.UpgradeOperation || p.Invalidated || p.RouteDigest != journal.Route || p.RouteSource != journal.Source.Identity || p.Source != step.Source || p.Target != step.Target || p.Hop != int64(index) || p.RouteLength != int64(len(steps)) || p.SourceMigrationDigest != sourceDigest || p.TargetMigrationDigest != targetDigest || p.SourceSchemaDigest != step.SourceSchemaSHA256 || p.TargetSchemaDigest != step.TargetSchemaSHA256 {
+		return errors.New("database pending operation differs from the exact authenticated host route")
+	}
+	return nil
+}
+
+func validateAutomaticHealthy(state upgrade.State, journal *automaticJournal, plan upgradecompat.Plan, index int) error {
+	if err := validateAutomaticPending(state, journal, plan, index); err != nil {
+		return err
+	}
+	step := plan.Steps()[index]
+	digest, _ := step.TargetMigrations.Digest()
+	final := index == len(plan.Steps())-1
+	if state.Pending.Phase != upgrade.Healthy || state.Applied != (releaseidentity.Source{Release: step.Target}) || state.MigrationDigest != digest || state.SchemaDigest != step.TargetSchemaSHA256 || state.Maintenance == final {
+		return errors.New("candidate health did not establish the exact applied release and maintenance state")
+	}
+	return nil
+}
+
+func automaticMigrationDisposition(ctx context.Context, database automaticInspection, journal *automaticJournal, plan upgradecompat.Plan, index int) (bool, error) {
+	state, err := database.Control(ctx)
+	if err != nil && !errors.Is(err, upgrade.ErrAbsent) {
+		return false, errors.New("interrupted migration has uncertain database state; operator recovery is required")
+	}
+	if err == nil && validateAutomaticPending(state, journal, plan, index) == nil {
+		switch state.Pending.Phase {
+		case upgrade.SchemaApplied, upgrade.Healthy:
+			if journal.Phase != "write-intent" && journal.Phase != "schema-applied" {
+				return false, errors.New("database advanced beyond the recorded host migration intent")
+			}
+			return false, nil
+		case upgrade.Prepared:
+			if journal.Phase != "write-intent" {
+				return false, errors.New("database admission differs from recorded host migration intent")
+			}
+		default:
+			return false, errors.New("migration outcome requires operator recovery; the old binary will remain stopped")
+		}
+	} else {
+		if journal.Phase == "schema-applied" {
+			return false, errors.New("schema-applied host intent lacks its exact database operation")
+		}
+		if errors.Is(err, upgrade.ErrAbsent) {
+			if index != 0 || journal.Source.Identity.Genesis != releaseidentity.LegacyGenesisV1 {
+				return false, errors.New("runtime ledger disappeared after upgrade admission")
+			}
+		} else if state.Pending == nil || state.Pending.Invalidated || state.Pending.Phase != upgrade.Healthy {
+			return false, errors.New("database contains a different unfinished operation; operator recovery is required")
+		} else if index > 0 {
+			if err := validateAutomaticHealthy(state, journal, plan, index-1); err != nil {
+				return false, err
+			}
+		}
+	}
+	step := plan.Steps()[index]
+	actual, err := database.Installed(ctx, step.SourceMigrations)
+	digest, digestErr := step.SourceMigrations.Digest()
+	if err != nil || digestErr != nil || actual.InstanceID != journal.Instance || actual.Source != step.Source || actual.MigrationDigest != digest || actual.SchemaDigest != step.SourceSchemaSHA256 {
+		return false, errors.New("pre-write retry requires the exact unchanged inspected source")
+	}
+	return true, nil
+}
+
+// RequireRestore uses the existing exact-state CAS transition. Applied identity
+// is never reversed when the runtime already completed its own health checks.
+func (s automaticStore) RequireRestore(ctx context.Context, expected upgrade.State) error {
+	return upgrade.WithLock(ctx, s.config, func(session *upgrade.Session) error {
+		_, err := session.Advance(ctx, expected, upgrade.RestoreRequired)
+		return err
+	})
+}
+
+func recordAutomaticHealthFailure(host automaticApplyHost, database automaticInspection, plan upgradecompat.Plan, journal *automaticJournal, journalPath string, index int, cause error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	stopErr := host.FenceAndStop(ctx)
+	journal.Phase, journal.Hop = "restore-required", index
+	journalErr := writeAutomaticJournal(journalPath, journal)
+	state, stateErr := database.Control(ctx)
+	if stateErr == nil {
+		stateErr = validateAutomaticPending(state, journal, plan, index)
+	}
+	if stateErr == nil {
+		switch state.Pending.Phase {
+		case upgrade.Healthy:
+			// External service/readiness proof can fail after runtime health. The
+			// terminal host fence blocks retries without falsifying DB history.
+			stateErr = validateAutomaticHealthy(state, journal, plan, index)
+		case upgrade.RestoreRequired:
+			// The candidate's runtime gate already recorded its own refusal.
+		case upgrade.SchemaApplied:
+			recovery, ok := database.(interface {
+				RequireRestore(context.Context, upgrade.State) error
+			})
+			if !ok {
+				stateErr = errors.New("database inspection cannot record exact restore-required state")
+			} else {
+				stateErr = recovery.RequireRestore(ctx, state)
+			}
+		default:
+			stateErr = errors.New("failed candidate has uncertain runtime phase; recovery fence retained")
+		}
+	}
+	return errors.Join(errors.New("candidate health failed; explicit operator recovery is required"), cause, stopErr, journalErr, stateErr)
+}

--- a/internal/app/automatic_apply_test.go
+++ b/internal/app/automatic_apply_test.go
@@ -1,0 +1,353 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
+	bundlefixture "github.com/Hikyo-Org/hikyo/internal/upgradebundle/testfixture"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+type automaticTestInspection struct {
+	state          upgrade.State
+	absent         bool
+	installed      upgrade.InstalledSource
+	installedCalls int
+}
+
+func (d *automaticTestInspection) Control(context.Context) (upgrade.State, error) {
+	if d.absent {
+		return upgrade.State{}, upgrade.ErrAbsent
+	}
+	return d.state, nil
+}
+func (d *automaticTestInspection) Installed(context.Context, releaseidentity.MigrationManifest) (upgrade.InstalledSource, error) {
+	d.installedCalls++
+	return d.installed, nil
+}
+func (d *automaticTestInspection) RequireRestore(_ context.Context, expected upgrade.State) error {
+	if expected.Pending == nil || expected.Pending.Phase != upgrade.SchemaApplied {
+		return errors.New("invalid restore-required transition")
+	}
+	d.state.Pending.Phase = upgrade.RestoreRequired
+	return nil
+}
+
+type automaticTestHost struct {
+	t         *testing.T
+	db        *automaticTestInspection
+	plan      upgradecompat.Plan
+	journal   *automaticJournal
+	path      string
+	events    []string
+	failAt    string
+	failPhase upgrade.Phase
+	running   bool
+	completed bool
+	current   int
+}
+
+func (h *automaticTestHost) event(name string) error {
+	h.events = append(h.events, name)
+	if h.failAt == name {
+		return errors.New("injected host interruption")
+	}
+	return nil
+}
+func (h *automaticTestHost) FenceAndStop(context.Context) error {
+	h.running = false
+	return h.event("fence")
+}
+func (h *automaticTestHost) Migrate(_ context.Context, candidate string, _ hostupgrade.RuntimeEvidence) ([]byte, error) {
+	index := h.candidate(candidate)
+	persisted, err := readAutomaticJournal(h.path)
+	if err != nil || persisted.Phase != "write-intent" || persisted.Hop != index {
+		h.t.Fatalf("migration preceded durable exact write intent: %+v %v", persisted, err)
+	}
+	h.current = index
+	h.db.absent = false
+	h.db.state = automaticState(h.plan, h.journal, index, upgrade.SchemaApplied)
+	if h.failPhase != "" {
+		h.db.state.Pending.Phase = h.failPhase
+	}
+	return nil, h.event(fmt.Sprintf("migrate-%d", index))
+}
+func (h *automaticTestHost) candidate(candidate string) int {
+	h.t.Helper()
+	for n := range h.plan.Steps() {
+		if candidate == fmt.Sprintf("candidate-%d", n) {
+			return n
+		}
+	}
+	h.t.Fatalf("unknown candidate %q", candidate)
+	return 0
+}
+func (h *automaticTestHost) InstallBinary(_ context.Context, candidate, digest string) error {
+	h.current = h.candidate(candidate)
+	if digest != string(releaseidentity.Hash([]byte(candidate))) {
+		h.t.Fatal("wrong executable digest")
+	}
+	return h.event(fmt.Sprintf("install-%d", h.current))
+}
+func (h *automaticTestHost) ConfigureRuntime(_ context.Context, e hostupgrade.RuntimeEvidence) error {
+	if e.EvidenceDirectory == "" {
+		return h.event("configure-restart")
+	}
+	return h.event("configure-upgrade")
+}
+func (h *automaticTestHost) StartCandidate(_ context.Context, _ string, final bool, _ time.Duration) error {
+	if final != (h.current == len(h.plan.Steps())-1) {
+		h.t.Fatal("wrong final-hop readiness requirement")
+	}
+	h.db.state = automaticState(h.plan, h.journal, h.current, upgrade.Healthy)
+	step := h.plan.Steps()[h.current]
+	digest, _ := step.TargetMigrations.Digest()
+	h.db.installed = upgrade.InstalledSource{Source: releaseidentity.Source{Release: step.Target}, MigrationDigest: digest, SchemaDigest: step.TargetSchemaSHA256, InstanceID: h.journal.Instance}
+	h.running = true
+	return h.event(fmt.Sprintf("start-%d", h.current))
+}
+func (h *automaticTestHost) Complete(context.Context) error {
+	if !h.running {
+		h.t.Fatal("completed upgrade while service stopped")
+	}
+	h.completed = true
+	return h.event("complete")
+}
+
+func automaticState(plan upgradecompat.Plan, journal *automaticJournal, index int, phase upgrade.Phase) upgrade.State {
+	step := plan.Steps()[index]
+	sourceDigest, _ := step.SourceMigrations.Digest()
+	targetDigest, _ := step.TargetMigrations.Digest()
+	state := upgrade.State{InstanceID: journal.Instance, Applied: step.Source, MigrationDigest: sourceDigest, SchemaDigest: step.SourceSchemaSHA256, Maintenance: true, Pending: &upgrade.Operation{Kind: upgrade.UpgradeOperation, RouteSource: journal.Source.Identity, Source: step.Source, Target: step.Target, RouteDigest: journal.Route, Hop: int64(index), RouteLength: int64(len(plan.Steps())), SourceMigrationDigest: sourceDigest, TargetMigrationDigest: targetDigest, SourceSchemaDigest: step.SourceSchemaSHA256, TargetSchemaDigest: step.TargetSchemaSHA256, Phase: phase}}
+	if phase == upgrade.Healthy {
+		state.Applied = releaseidentity.Source{Release: step.Target}
+		state.MigrationDigest = targetDigest
+		state.SchemaDigest = step.TargetSchemaSHA256
+		state.Maintenance = index+1 < len(plan.Steps())
+	}
+	return state
+}
+
+func automaticApplyFixture(t *testing.T, hops int) (automaticRoute, *automaticJournal, *automaticTestHost, map[releaseidentity.Identity]string) {
+	t.Helper()
+	migrations := releaseidentity.MigrationManifest{Engine: releaseidentity.SQLite, Entries: []releaseidentity.Migration{{Version: 1, SHA256: releaseidentity.Hash([]byte("source SQL"))}}}
+	source := upgradecompat.InstalledSource{Identity: releaseidentity.Source{Genesis: releaseidentity.LegacyGenesisV1}, Migrations: migrations, SchemaSHA256: releaseidentity.Hash([]byte("source catalog"))}
+	targets := make([]bundlefixture.Target, 0, hops)
+	for n := range hops {
+		targets = append(targets, bundlefixture.Target{Version: fmt.Sprintf("1.%d.0", n), Sequence: uint64(n + 1), Commit: strings.Repeat("a", 40), Migrations: migrations, SchemaSHA256: source.SchemaSHA256})
+	}
+	signed := bundlefixture.Write(t, source, targets)
+	journal := &automaticJournal{Format: "hikyo.host-upgrade/v1", Phase: "proved", Target: signed.Target, Source: source, Instance: "fixture-installation", Route: signed.Plan.Digest(), Runtime: hostupgrade.RuntimeEvidence{EvidenceDirectory: "public-evidence", CiphertextPath: "backup.age"}}
+	digest, _ := source.Migrations.Digest()
+	db := &automaticTestInspection{absent: true, installed: upgrade.InstalledSource{InstanceID: journal.Instance, Source: source.Identity, MigrationDigest: digest, SchemaDigest: source.SchemaSHA256}}
+	route := automaticRoute{Bundle: signed.Bundle, Directory: signed.Directory, Plan: signed.Plan, Instance: journal.Instance, Executables: map[releaseidentity.Identity]selfupdate.PreparedNightly{}}
+	staged := map[releaseidentity.Identity]string{}
+	for n, step := range route.Plan.Steps() {
+		candidate := fmt.Sprintf("candidate-%d", n)
+		staged[step.Target] = candidate
+		route.Executables[step.Target] = selfupdate.PreparedNightly{Identity: step.Target, BinaryPath: candidate, BinarySHA256: releaseidentity.Hash([]byte(candidate))}
+	}
+	host := &automaticTestHost{t: t, db: db, plan: route.Plan, journal: journal, path: filepath.Join(t.TempDir(), "journal.json")}
+	return route, journal, host, staged
+}
+
+func TestAutomaticRouteMaintainsFenceAcrossHopsAndPersistsExactIntent(t *testing.T) {
+	route, journal, host, staged := automaticApplyFixture(t, 2)
+	if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	want := "migrate-0,install-0,configure-upgrade,start-0,fence,migrate-1,install-1,configure-upgrade,start-1,configure-restart,complete"
+	if strings.Join(host.events, ",") != want || journal.Phase != "complete" || !host.running {
+		t.Fatalf("incorrect coordinated route: %v %+v", host.events, journal)
+	}
+}
+
+func TestAutomaticFinalHealthyResumeRestartsBeforeCompletion(t *testing.T) {
+	route, journal, host, staged := automaticApplyFixture(t, 2)
+	journal.Phase, journal.Hop = "hop-healthy", 2
+	host.db.absent = false
+	host.db.state = automaticState(route.Plan, journal, 1, upgrade.Healthy)
+	if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(host.events, ",") != "install-1,configure-restart,start-1,configure-restart,complete" || !host.running {
+		t.Fatalf("final resume did not restart: %v", host.events)
+	}
+}
+
+func TestAutomaticWriteIntentReconcilesOnlyProvenPrewriteOrAppliedStates(t *testing.T) {
+	for _, phase := range []upgrade.Phase{"absent", upgrade.Prepared, upgrade.SchemaApplied, upgrade.Healthy, upgrade.SchemaWriteStarted, upgrade.RestoreRequired} {
+		t.Run(string(phase), func(t *testing.T) {
+			route, journal, host, staged := automaticApplyFixture(t, 1)
+			journal.Phase = "write-intent"
+			host.db.absent = phase == "absent"
+			if !host.db.absent {
+				host.db.state = automaticState(route.Plan, journal, 0, phase)
+			}
+			err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard)
+			refused := phase == upgrade.SchemaWriteStarted || phase == upgrade.RestoreRequired
+			if refused {
+				if err == nil || host.running || host.completed || strings.Join(host.events, ",") != "fence" {
+					t.Fatalf("ambiguous write outcome restarted: %v %v", host.events, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			migrated := strings.Contains(strings.Join(host.events, ","), "migrate-0")
+			if migrated != (phase == "absent" || phase == upgrade.Prepared) {
+				t.Fatalf("incorrect migration retry for %s: %v", phase, host.events)
+			}
+		})
+	}
+}
+
+func TestAutomaticIntermediatePreAdmissionCrashRetainsFullOriginalRoute(t *testing.T) {
+	route, journal, host, staged := automaticApplyFixture(t, 2)
+	journal.Phase, journal.Hop = "write-intent", 1
+	host.db.absent = false
+	host.db.state = automaticState(route.Plan, journal, 0, upgrade.Healthy)
+	step := route.Plan.Steps()[1]
+	digest, _ := step.SourceMigrations.Digest()
+	host.db.installed = upgrade.InstalledSource{InstanceID: journal.Instance, Source: step.Source, MigrationDigest: digest, SchemaDigest: step.SourceSchemaSHA256}
+	if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(host.events, ","), "migrate-0") || journal.Route != route.Plan.Digest() || journal.Source.Identity != route.Plan.Source() {
+		t.Fatal("resumption lost original route")
+	}
+}
+
+func TestAutomaticFailuresNeverRestartOldExecutable(t *testing.T) {
+	for _, failure := range []string{"migrate-0", "install-0", "configure-upgrade", "start-0"} {
+		t.Run(failure, func(t *testing.T) {
+			route, journal, host, staged := automaticApplyFixture(t, 1)
+			host.failAt = failure
+			if failure == "migrate-0" {
+				host.failPhase = upgrade.SchemaWriteStarted
+			}
+			var out bytes.Buffer
+			err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, &out)
+			if err == nil || host.running || host.completed || host.events[len(host.events)-1] != "fence" {
+				t.Fatalf("failure left active service: %v %v", host.events, err)
+			}
+			for _, event := range host.events {
+				if strings.Contains(event, "old") {
+					t.Fatal("old executable restarted")
+				}
+			}
+		})
+	}
+}
+
+func TestAutomaticPendingRejectsMismatchedHopAndBindings(t *testing.T) {
+	for _, mutation := range []string{"hop", "length", "source schema", "target migrations", "instance", "invalidated"} {
+		t.Run(mutation, func(t *testing.T) {
+			route, journal, host, staged := automaticApplyFixture(t, 1)
+			journal.Phase = "schema-applied"
+			host.db.absent = false
+			host.db.state = automaticState(route.Plan, journal, 0, upgrade.SchemaApplied)
+			state := &host.db.state
+			switch mutation {
+			case "hop":
+				state.Pending.Hop++
+			case "length":
+				state.Pending.RouteLength++
+			case "source schema":
+				state.Pending.SourceSchemaDigest = releaseidentity.Hash([]byte("different"))
+			case "target migrations":
+				state.Pending.TargetMigrationDigest = releaseidentity.Hash([]byte("different"))
+			case "instance":
+				state.InstanceID = "different"
+			case "invalidated":
+				state.Pending.Invalidated = true
+			}
+			if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err == nil || strings.Join(host.events, ",") != "fence" {
+				t.Fatalf("wrong pending binding accepted: %v %v", host.events, err)
+			}
+		})
+	}
+}
+
+func TestAutomaticPrewriteRetryMeasuresRealSQLiteAndRestoreProof(t *testing.T) {
+	f := newUpgradeDrillFixture(t, store.EngineSQLite, true, true)
+	result, err := DrillUpgrade(t.Context(), f.request)
+	if err != nil || !result.HierarchyReadable || result.SecretProof != "existing-secret-readable" || result.CredentialProof != "reconciled-minted-revoked" {
+		t.Fatalf("real encrypted backup restore proof failed: %v", err)
+	}
+	sourceManifest, err := f.bundle.Plan.SourceManifest(releaseidentity.SQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := &automaticJournal{Phase: "write-intent", Target: f.bundle.Target, Source: upgradecompat.InstalledSource{Identity: f.source.Source, Migrations: sourceManifest, SchemaSHA256: f.source.SchemaDigest}, Instance: f.source.InstanceID, Route: f.bundle.Plan.Digest()}
+	database := automaticStore{upgrade.Config{Engine: releaseidentity.SQLite, Path: f.cfg.Path}}
+	migrate, err := automaticMigrationDisposition(t.Context(), database, journal, f.bundle.Plan, 0)
+	if err != nil || !migrate {
+		t.Fatalf("unchanged actual legacy DB cannot retry: %v", err)
+	}
+	journal.Instance = "different-installation"
+	if _, err := automaticMigrationDisposition(t.Context(), database, journal, f.bundle.Plan, 0); err == nil {
+		t.Fatal("different DB instance accepted")
+	}
+	journal.Instance = f.source.InstanceID
+	changed, err := sql.Open("sqlite", f.cfg.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := changed.ExecContext(t.Context(), "CREATE TABLE unexpected_after_intent (id INTEGER)"); err != nil {
+		changed.Close()
+		t.Fatal(err)
+	}
+	if err := changed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := automaticMigrationDisposition(t.Context(), database, journal, f.bundle.Plan, 0); err == nil {
+		t.Fatal("changed real SQLite catalog accepted as pre-write retry")
+	}
+
+}
+
+func TestAutomaticHealthFailureIsTerminalWithoutRewritingHealthyDB(t *testing.T) {
+	for _, phase := range []upgrade.Phase{upgrade.SchemaApplied, upgrade.Healthy} {
+		t.Run(string(phase), func(t *testing.T) {
+			route, journal, host, staged := automaticApplyFixture(t, 1)
+			journal.Phase = "schema-applied"
+			host.db.absent = false
+			host.db.state = automaticState(route.Plan, journal, 0, phase)
+			before := host.db.state.Applied
+			err := recordAutomaticHealthFailure(host, host.db, route.Plan, journal, host.path, 0, errors.New("readiness unavailable"))
+			if err == nil || host.running || journal.Phase != "restore-required" {
+				t.Fatalf("health failure was not terminal: %v", err)
+			}
+			want := upgrade.RestoreRequired
+			if phase == upgrade.Healthy {
+				want = upgrade.Healthy
+			}
+			if host.db.state.Pending.Phase != want || host.db.state.Applied != before {
+				t.Fatal("health failure rewrote applied DB history")
+			}
+			persisted, err := readAutomaticJournal(host.path)
+			if err != nil || persisted.Phase != "restore-required" {
+				t.Fatal("terminal host journal was not durable", err)
+			}
+			host.events = nil
+			if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err == nil || strings.Join(host.events, ",") != "fence" {
+				t.Fatalf("terminal host journal retried automatically: %v %v", host.events, err)
+			}
+		})
+	}
+}

--- a/internal/app/automatic_apply_test.go
+++ b/internal/app/automatic_apply_test.go
@@ -126,6 +126,12 @@ func (h *automaticTestHost) Complete(context.Context) error {
 	h.completed = true
 	return h.event("complete")
 }
+func (h *automaticTestHost) PrunePublic(hostupgrade.RuntimeEvidence) error {
+	if !h.completed {
+		h.t.Fatal("pruned public evidence before completion")
+	}
+	return h.event("prune")
+}
 
 func automaticState(plan upgradecompat.Plan, journal *automaticJournal, index int, phase upgrade.Phase) upgrade.State {
 	step := plan.Steps()[index]
@@ -169,7 +175,7 @@ func TestAutomaticRouteMaintainsFenceAcrossHopsAndPersistsExactIntent(t *testing
 	if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	want := "migrate-0,install-0,configure-upgrade,start-0,fence,migrate-1,install-1,configure-upgrade,start-1,configure-restart,complete"
+	want := "migrate-0,install-0,configure-upgrade,start-0,fence,migrate-1,install-1,configure-upgrade,start-1,configure-restart,complete,prune"
 	if strings.Join(host.events, ",") != want || journal.Phase != "complete" || !host.running {
 		t.Fatalf("incorrect coordinated route: %v %+v", host.events, journal)
 	}
@@ -183,7 +189,7 @@ func TestAutomaticFinalHealthyResumeRestartsBeforeCompletion(t *testing.T) {
 	if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Join(host.events, ",") != "install-1,configure-restart,start-1,configure-restart,complete" || !host.running {
+	if strings.Join(host.events, ",") != "install-1,configure-restart,start-1,configure-restart,complete,prune" || !host.running {
 		t.Fatalf("final resume did not restart: %v", host.events)
 	}
 }

--- a/internal/app/automatic_discovery_test.go
+++ b/internal/app/automatic_discovery_test.go
@@ -1,0 +1,244 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	trustfixture "github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
+	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
+	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
+	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Hikyo-Org/hikyo/internal/upgradeassembly"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+type automaticDiscoveryFixture struct {
+	t          *testing.T
+	root       string
+	trust      *trustfixture.Fixture
+	options    upgradeassembly.Options
+	prepared   map[releaseidentity.Identity]selfupdate.PreparedNightly
+	identities []releaseidentity.Identity
+	source     upgradecompat.InstalledSource
+	fetched    []releaseidentity.Identity
+	assembled  int
+	forbidden  map[releaseidentity.Identity]bool
+}
+
+func (f *automaticDiscoveryFixture) Releases(context.Context) ([]updatecheck.Release, error) {
+	return nil, errors.New("unexpected broad release discovery")
+}
+func (f *automaticDiscoveryFixture) ReleaseByVersion(_ context.Context, version string) (updatecheck.Release, error) {
+	for _, identity := range f.identities {
+		if identity.Version == version {
+			return updatecheck.Release{Version: version, Prerelease: true, Immutable: true, Assets: []updatecheck.Asset{{Name: "release-manifest.sigstore.json"}}}, nil
+		}
+	}
+	return updatecheck.Release{}, errors.New("unavailable historical release")
+}
+func (f *automaticDiscoveryFixture) PrepareNightlySource(_ context.Context, status updatecheck.Status, expected releaseidentity.Identity) (selfupdate.PreparedNightly, error) {
+	f.fetched = append(f.fetched, expected)
+	if f.forbidden[expected] {
+		return selfupdate.PreparedNightly{}, errors.New("unrelated historical payload unavailable")
+	}
+	if status.LatestVersion != expected.Version {
+		return selfupdate.PreparedNightly{}, errors.New("wrong exact release requested")
+	}
+	prepared, ok := f.prepared[expected]
+	if !ok {
+		return prepared, errors.New("unknown source")
+	}
+	return prepared, nil
+}
+func (f *automaticDiscoveryFixture) AssembleNightlyRoute(ctx context.Context, target selfupdate.PreparedNightly, sources []selfupdate.PreparedNightly) (string, error) {
+	f.assembled++
+	options := f.options
+	options.OutputDirectory = filepath.Join(f.t.TempDir(), "bundle")
+	options.Nightlies = []string{target.Directory}
+	for _, source := range sources {
+		options.Nightlies = append(options.Nightlies, source.Directory)
+	}
+	return options.OutputDirectory, upgradeassembly.Assemble(ctx, options)
+}
+
+func newAutomaticDiscoveryFixture(t *testing.T) *automaticDiscoveryFixture {
+	t.Helper()
+	return newAutomaticDiscoveryGraph(t, [][]int{{}, {0}, {1}})
+}
+
+func newAutomaticDiscoveryGraph(t *testing.T, predecessors [][]int) *automaticDiscoveryFixture {
+	t.Helper()
+	f := &automaticDiscoveryFixture{t: t, root: t.TempDir(), prepared: map[releaseidentity.Identity]selfupdate.PreparedNightly{}, forbidden: map[releaseidentity.Identity]bool{}}
+	migrations := releaseidentity.MigrationManifest{Engine: releaseidentity.SQLite, Entries: []releaseidentity.Migration{{Version: 1, SHA256: releaseidentity.Hash([]byte("actual SQL"))}}}
+	schema := releaseidentity.Hash([]byte("actual catalog"))
+	f.source = upgradecompat.InstalledSource{Identity: releaseidentity.Source{Genesis: releaseidentity.LegacyGenesisV1}, Migrations: migrations, SchemaSHA256: schema}
+	materials := []releasetrust.NightlyMaterial{}
+	for index := range len(predecessors) {
+		declaration := upgradecompat.Declaration{Schema: upgradecompat.Schema, Profile: releaseidentity.NightlyV1, Version: fmt.Sprintf("1.1.0-nightly.%d", index+1), Sequence: uint64(index + 2), Commit: strings.Repeat("a", 40), Engines: []upgradecompat.EngineDeclaration{{Migrations: migrations, SchemaSHA256: schema, Sources: []upgradecompat.SourceEdge{}}}}
+		for _, predecessor := range predecessors[index] {
+			declaration.Engines[0].Sources = append(declaration.Engines[0].Sources, upgradecompat.SourceEdge{Source: releaseidentity.Source{Release: f.identities[predecessor]}, Migrations: migrations, SchemaSHA256: schema, Mode: upgradecompat.Maintenance})
+		}
+		claim := trustfixture.JSON(t, declaration)
+		var material releasetrust.NightlyMaterial
+		if index == 0 {
+			f.trust, material, _ = trustfixture.Nightly(t, claim, false)
+		} else {
+			material = f.trust.SignNightly(claim, declaration.Version, declaration.Sequence)
+		}
+		materials = append(materials, material)
+		f.identities = append(f.identities, releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)})
+	}
+	bridge := f.trust.AddBridge(t, releasetrust.BridgeStatement{Schema: "hikyo.dev/legacy-nightly-bridge/v1", SourceGenesis: releaseidentity.LegacyGenesisV1, Target: f.identities[0], TargetPolicySHA256: releaseidentity.Hash(materials[0].Policy), SourceMigrations: migrations, TargetMigrations: migrations, SourceSchemaSHA256: schema, TargetSchemaSHA256: schema, Mode: "maintenance"})
+	write := func(path string, raw []byte) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot := f.trust.Material(t)
+	for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature} {
+		write(filepath.Join(f.root, "snapshot", name), raw)
+	}
+	write(filepath.Join(f.root, "keys", "primary.pub"), f.trust.PrimaryPublic)
+	write(filepath.Join(f.root, "bridge", "statement.json"), bridge.Statement)
+	write(filepath.Join(f.root, "bridge", "statement.sigstore.json"), bridge.Signature)
+	f.options = upgradeassembly.Options{Pinned: f.trust.Pinned, SnapshotDirectory: filepath.Join(f.root, "snapshot"), KeysDirectory: filepath.Join(f.root, "keys"), Bridges: []string{filepath.Join(f.root, "bridge")}}
+	for index, material := range materials {
+		directory := filepath.Join(f.root, fmt.Sprintf("flat-%d", index))
+		for name, reader := range material.Artifacts {
+			raw, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			write(filepath.Join(directory, name), raw)
+		}
+		write(filepath.Join(directory, "release-manifest.json"), material.Manifest)
+		write(filepath.Join(directory, "release-manifest.sigstore.json"), material.Bundle)
+		options := f.options
+		options.Nightlies = []string{directory}
+		options.OutputDirectory = filepath.Join(f.root, fmt.Sprintf("bundle-%d", index))
+		if err := upgradeassembly.Assemble(t.Context(), options); err != nil {
+			t.Fatal(err)
+		}
+		identity := f.identities[index]
+		f.prepared[identity] = selfupdate.PreparedNightly{Identity: identity, Directory: directory, BundleDirectory: options.OutputDirectory}
+	}
+	return f
+}
+
+func (f *automaticDiscoveryFixture) inspection(index int) *automaticTestInspection {
+	source := f.source.Identity
+	absent := index < 0
+	if !absent {
+		source = releaseidentity.Source{Release: f.identities[index]}
+	}
+	digest, _ := f.source.Migrations.Digest()
+	return &automaticTestInspection{absent: absent, state: upgrade.State{Applied: source, Floor: f.trust.Snapshot(f.t).Floor()}, installed: upgrade.InstalledSource{Source: source, MigrationDigest: digest, SchemaDigest: f.source.SchemaSHA256, InstanceID: "actual-installation"}}
+}
+
+func TestAutomaticDiscoveryNoopDoesNotFetchHistoricalPredecessors(t *testing.T) {
+	f := newAutomaticDiscoveryFixture(t)
+	for _, identity := range f.identities[:2] {
+		f.forbidden[identity] = true
+	}
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(2), releaseidentity.SQLite, nil)
+	if err != nil || len(result.Plan.Steps()) != 0 || len(f.fetched) != 0 || f.assembled != 0 {
+		t.Fatalf("same-release restart fetched historical artifacts: %v fetched=%v assemblies=%d", err, f.fetched, f.assembled)
+	}
+}
+
+func TestAutomaticDiscoveryRecentUpgradeDoesNotFetchAncientHistory(t *testing.T) {
+	f := newAutomaticDiscoveryFixture(t)
+	f.forbidden[f.identities[0]] = true
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(1), releaseidentity.SQLite, nil)
+	if err != nil || len(result.Plan.Steps()) != 1 || !slices.Equal(f.fetched, []releaseidentity.Identity{f.identities[1]}) || f.assembled != 1 {
+		t.Fatalf("direct upgrade fetched unrelated predecessor: %v fetched=%v assemblies=%d", err, f.fetched, f.assembled)
+	}
+}
+
+func TestAutomaticDiscoveryLegacyAndInterruptedRouteKeepExactBridge(t *testing.T) {
+	for _, resume := range []bool{false, true} {
+		t.Run(fmt.Sprintf("resume=%t", resume), func(t *testing.T) {
+			f := newAutomaticDiscoveryFixture(t)
+			target := f.prepared[f.identities[1]]
+			inspection := f.inspection(-1)
+			var previous *automaticJournal
+			if resume {
+				full, err := f.AssembleNightlyRoute(t.Context(), target, []selfupdate.PreparedNightly{f.prepared[f.identities[0]]})
+				if err != nil {
+					t.Fatal(err)
+				}
+				bundle, err := upgradebundle.Load(t.Context(), full, f.trust.Pinned, releaseidentity.SnapshotFloor{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				plan, err := bundle.Plan(f.source, target.Identity)
+				if err != nil {
+					t.Fatal(err)
+				}
+				previous = &automaticJournal{Phase: "schema-applied", Target: target.Identity, Source: f.source, Instance: "actual-installation", Route: plan.Digest(), Hop: 1}
+				inspection = f.inspection(0)
+				// Original-route recovery must not mistake the intermediate database for
+				// a new independent upgrade and invalidate the accepted backup route.
+				inspection.installed.InstanceID = "must-not-inspect-new-source"
+				f.assembled = 0
+			}
+			result, err := discoverAutomaticRoute(t.Context(), f, f, target, f.trust.Pinned, inspection, releaseidentity.SQLite, previous)
+			if err != nil || len(result.Plan.Steps()) != 2 || len(result.Plan.BridgeDigests()) != 1 || !slices.Equal(f.fetched, []releaseidentity.Identity{f.identities[0]}) {
+				t.Fatalf("legacy bridge route unavailable: %v fetched=%v", err, f.fetched)
+			}
+			if resume && (result.Plan.Digest() != previous.Route || result.Instance != previous.Instance || inspection.installedCalls != 0) {
+				t.Fatal("resume replanned from intermediate source")
+			}
+		})
+	}
+}
+
+func TestAutomaticDiscoveryRejectsSnapshotBelowInstalledFloorBeforeFetching(t *testing.T) {
+	f := newAutomaticDiscoveryFixture(t)
+	inspection := f.inspection(1)
+	inspection.state.Floor.CatalogSequence++
+	if _, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, inspection, releaseidentity.SQLite, nil); err == nil || len(f.fetched) != 0 {
+		t.Fatal("stale trust evidence caused historical downloads")
+	}
+}
+
+func TestAutomaticDiscoveryResolvesShallowAlternativesBeforeLongerHistory(t *testing.T) {
+	// The newer predecessor offers a three-hop route, while the older branch
+	// offers two. Stop after authenticating the shorter branch and never fetch
+	// the unnecessary interior node of the longer branch.
+	f := newAutomaticDiscoveryGraph(t, [][]int{{}, {0}, {0}, {2}, {3, 1}})
+	f.forbidden[f.identities[2]] = true
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil)
+	if err != nil || len(result.Plan.Steps()) != 2 || result.Plan.Steps()[0].Target != f.identities[1] {
+		t.Fatalf("shortest authenticated branch was not selected: %v fetched=%v", err, f.fetched)
+	}
+	if slices.Contains(f.fetched, f.identities[2]) {
+		t.Fatal("downloaded unnecessary longer-route history")
+	}
+}
+
+func TestAutomaticDiscoveryPreservesDeterministicRouteTieBreak(t *testing.T) {
+	f := newAutomaticDiscoveryGraph(t, [][]int{{}, {}, {0}, {0}, {3, 2}})
+	f.forbidden[f.identities[1]] = true
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil)
+	if err != nil || len(result.Plan.Steps()) != 2 || result.Plan.Steps()[0].Target != f.identities[2] {
+		t.Fatalf("partial graph changed deterministic tie break: %v fetched=%v", err, f.fetched)
+	}
+	if !slices.Contains(f.fetched, f.identities[2]) || !slices.Contains(f.fetched, f.identities[3]) {
+		t.Fatal("did not authenticate both relevant shallow branches")
+	}
+}

--- a/internal/app/automatic_integration_test.go
+++ b/internal/app/automatic_integration_test.go
@@ -1,0 +1,472 @@
+//go:build darwin || linux
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
+	"github.com/Hikyo-Org/hikyo/internal/buildcompat"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
+	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	trustfixture "github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
+	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
+	"github.com/Hikyo-Org/hikyo/internal/service"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/keyring"
+	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+// This test substitutes subprocess management for systemd only. The backup CLI,
+// release/OIDC/bridge verification, restore drill, migration CLI, durable ledger,
+// production server and HTTP readiness are all the real implementations.
+func TestAutomaticUpgradePackagedNightlyRoute(t *testing.T) {
+	source := newUpgradeDrillFixture(t, store.EngineSQLite, true, true)
+	route, claims := automaticProcessRoute(t, source)
+	for _, scenario := range []string{"success", "install-interruption", "health-failure"} {
+		t.Run(scenario, func(t *testing.T) {
+			failInstall := scenario == "install-interruption"
+			f := source
+			if scenario != "success" {
+				f = newUpgradeDrillFixture(t, store.EngineSQLite, true, true)
+			}
+			host, journal := automaticProcessProof(t, f, route)
+			host.failInstall = failInstall
+			host.failHealth = scenario == "health-failure"
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_ = host.FenceAndStop(ctx)
+			})
+			database := automaticStore{upgrade.Config{Engine: releaseidentity.SQLite, Path: f.cfg.Path}}
+			staged := map[releaseidentity.Identity]string{}
+			for id, prepared := range route.Executables {
+				staged[id] = prepared.BinaryPath
+			}
+			path := filepath.Join(host.work, "operation.json")
+			if err := writeAutomaticJournal(path, journal); err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			err := applyAutomaticRoute(t.Context(), host, database, route, staged, journal, path, &output)
+			if host.failHealth {
+				if err == nil || !host.fenced || host.command != nil || journal.Phase != "restore-required" {
+					t.Fatal("actual post-migration candidate boot failure did not require explicit recovery")
+				}
+				if !strings.Contains(err.Error(), crypto.ErrRootKeyMismatch.Error()) {
+					t.Fatalf("candidate failed for a different reason than the injected root mismatch: %v", err)
+				}
+				state, inspectErr := database.Control(t.Context())
+				if inspectErr != nil || state.Pending == nil || state.Pending.Phase != upgrade.RestoreRequired || !state.Maintenance {
+					t.Fatal("candidate failure did not persist database restore-required", inspectErr)
+				}
+				if err := applyAutomaticRoute(t.Context(), host, database, route, staged, journal, path, &output); err == nil || host.migrations != 1 {
+					t.Fatal("failed candidate was retried or old binary restarted automatically")
+				}
+				return
+			}
+			if failInstall {
+				if err == nil || !host.fenced || host.command != nil {
+					t.Fatal("post-write failure did not leave service stopped and fenced")
+				}
+				state, inspectErr := database.Control(t.Context())
+				if inspectErr != nil || state.Pending == nil || state.Pending.Phase != upgrade.SchemaApplied || !state.Maintenance {
+					t.Fatalf("post-write failure lost durable schema-applied admission: %v", inspectErr)
+				}
+				if host.migrations != 1 {
+					t.Fatal("failure occurred outside first actual migration")
+				}
+				journal, err = readAutomaticJournal(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				host.failInstall = false
+				err = applyAutomaticRoute(t.Context(), host, database, route, staged, journal, path, &output)
+			}
+			if err != nil {
+				t.Fatalf("automatic packaged route: %v\n%s", err, output.String())
+			}
+			if journal.Phase != "complete" || host.fenced || host.command == nil || host.migrations != 2 || host.intermediateHealth != 1 || host.finalHealth != 1 {
+				t.Fatalf("incomplete real route: phase=%s fenced=%t migrations=%d intermediate=%d final=%d", journal.Phase, host.fenced, host.migrations, host.intermediateHealth, host.finalHealth)
+			}
+			if host.evidence.CiphertextPath != "" || host.evidence.EvidenceDirectory != "" || host.evidence.LegacyWritersStopped {
+				t.Fatal("completed runtime retained one-use upgrade evidence")
+			}
+			if err := host.FenceAndStop(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			var admission upgrade.Admission
+			node, err := route.Bundle.MatchBuild(claims[1])
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = upgrade.WithLock(t.Context(), database.config, func(session *upgrade.Session) error {
+				state, err := session.Read(t.Context())
+				if err != nil {
+					return err
+				}
+				admission, err = session.Admit(t.Context(), state, node)
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			db, err := store.Open(t.Context(), f.cfg, admission)
+			if err != nil {
+				t.Fatal(err)
+			}
+			kr, err := crypto.LoadKeyring(t.Context(), &keyring.Store{DB: db}, bytes.Clone(f.root))
+			if err != nil {
+				db.Close()
+				t.Fatal(err)
+			}
+			readable, err := (&service.Backup{DB: db}).ProveValuesReadable(t.Context(), kr)
+			if err != nil || !readable {
+				db.Close()
+				t.Fatal("automatic route lost actual protected value", err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			// A healthy restart uses only public long-lived trust and the root
+			// credential. Consumed backup evidence is no longer supplied.
+			if err := host.StartCandidate(t.Context(), string(route.Executables[route.Plan.Target()].BinarySHA256), true, 45*time.Second); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func automaticProcessRoute(t *testing.T, source upgradeDrillFixture) (automaticRoute, [][]byte) {
+	t.Helper()
+	work := t.TempDir()
+	directory := filepath.Join(work, "bundle")
+	_, declaration, err := buildcompat.Development()
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaration.Profile, declaration.Version, declaration.Sequence, declaration.Commit = releaseidentity.NightlyV1, "1.1.0-nightly.1", 2, strings.Repeat("a", 40)
+	first := trustfixture.JSON(t, declaration)
+	f, material, _ := trustfixture.Nightly(t, first, false)
+	writeRelease := func(material releasetrust.NightlyMaterial) releasetrust.VerifiedRelease {
+		t.Helper()
+		payloads := t.TempDir()
+		for name, reader := range material.Artifacts {
+			raw, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			automaticProcessPut(t, filepath.Join(payloads, name), raw)
+		}
+		automaticProcessPut(t, filepath.Join(payloads, "release-manifest.json"), material.Manifest)
+		automaticProcessPut(t, filepath.Join(payloads, "release-manifest.sigstore.json"), material.Bundle)
+		release, err := upgradebundle.CopyNightlyRelease(t.Context(), payloads, filepath.Join(directory, "releases"), f.Snapshot(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return release
+	}
+	previous := writeRelease(material)
+	var sqlite upgradecompat.EngineDeclaration
+	for _, engine := range declaration.Engines {
+		if engine.Migrations.Engine == releaseidentity.SQLite {
+			sqlite = engine
+		}
+	}
+	legacyManifest, err := upgrade.PinnedLegacyManifest(releaseidentity.SQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridge := f.AddBridge(t, releasetrust.BridgeStatement{Schema: "hikyo.dev/legacy-nightly-bridge/v1", SourceGenesis: releaseidentity.LegacyGenesisV1, Target: previous.Identity(), TargetPolicySHA256: previous.PolicyDigest(), SourceMigrations: legacyManifest, TargetMigrations: sqlite.Migrations, SourceSchemaSHA256: source.source.SchemaDigest, TargetSchemaSHA256: sqlite.SchemaSHA256, Mode: "maintenance"})
+	for i, engine := range declaration.Engines {
+		declaration.Engines[i].Sources = append(engine.Sources, upgradecompat.SourceEdge{Source: releaseidentity.Source{Release: previous.Identity()}, Migrations: engine.Migrations, SchemaSHA256: engine.SchemaSHA256, Mode: upgradecompat.Maintenance})
+	}
+	declaration.Version, declaration.Sequence = "1.1.0-nightly.2", 3
+	second := trustfixture.JSON(t, declaration)
+	target := writeRelease(f.SignNightly(second, declaration.Version, declaration.Sequence))
+	bridgeDigest := releaseidentity.Hash(bridge.Statement)
+	snapshot := f.Material(t)
+	for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature, "keys/test-primary.pub": f.PrimaryPublic,
+		"bridges/" + string(bridgeDigest) + "/statement.json": bridge.Statement, "bridges/" + string(bridgeDigest) + "/statement.sigstore.json": bridge.Signature} {
+		automaticProcessPut(t, filepath.Join(directory, name), raw)
+	}
+	index := upgradebundle.Index{Format: upgradebundle.IndexFormat, PrimaryKeyIDs: []string{"test-primary"}, Releases: []upgradebundle.ReleaseEntry{{Profile: releaseidentity.NightlyV1, ManifestSHA256: previous.Identity().ManifestSHA256}, {Profile: releaseidentity.NightlyV1, ManifestSHA256: target.Identity().ManifestSHA256}}, Bridges: []releaseidentity.Digest{bridgeDigest}}
+	automaticProcessPut(t, filepath.Join(directory, "index.json"), trustfixture.JSON(t, index))
+	bundle, err := upgradebundle.Load(t.Context(), directory, f.Pinned, releaseidentity.SnapshotFloor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := bundle.Plan(upgradecompat.InstalledSource{Identity: source.source.Source, Migrations: legacyManifest, SchemaSHA256: source.source.SchemaDigest}, target.Identity())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Steps()) != 2 || !plan.RequiresOperatorAttestation() {
+		t.Fatal("fixture must require signed legacy bridge and two-hop route")
+	}
+	route := automaticRoute{Bundle: bundle, Directory: directory, Plan: plan, Instance: source.source.InstanceID, Executables: map[releaseidentity.Identity]selfupdate.PreparedNightly{}}
+	claims := [][]byte{first, second}
+	for i, identity := range []releaseidentity.Identity{previous.Identity(), target.Identity()} {
+		binary := filepath.Join(work, fmt.Sprintf("hikyo-%d", i))
+		flags := "-X github.com/Hikyo-Org/hikyo/internal/buildcompat.encodedTrustRoot=" + base64.StdEncoding.EncodeToString(f.Pinned.Root) +
+			" -X github.com/Hikyo-Org/hikyo/internal/buildcompat.encodedRecoveryPublicKey=" + base64.StdEncoding.EncodeToString(f.Pinned.RecoveryPublicKey) +
+			" -X github.com/Hikyo-Org/hikyo/internal/buildcompat.encodedDeclaration=" + base64.StdEncoding.EncodeToString(claims[i]) +
+			" -X github.com/Hikyo-Org/hikyo/internal/buildcompat.declarationSHA256=" + string(releaseidentity.Hash(claims[i]))
+		command := exec.CommandContext(t.Context(), "go", "build", "-ldflags", flags, "-o", binary, "../../cmd/hikyo")
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("build production fixture: %v\n%s", err, output)
+		}
+		raw := automaticProcessRead(t, binary)
+		route.Executables[identity] = selfupdate.PreparedNightly{Identity: identity, BinaryPath: binary, BinarySHA256: releaseidentity.Hash(raw), BundleDirectory: directory}
+	}
+	return route, claims
+}
+
+func automaticProcessProof(t *testing.T, f upgradeDrillFixture, route automaticRoute) (*automaticProcessHost, *automaticJournal) {
+	t.Helper()
+	work := t.TempDir()
+	installation := filepath.Join(work, "installation")
+	if err := os.Mkdir(installation, 0700); err != nil {
+		t.Fatal(err)
+	}
+	operator := trustfixture.New(t)
+	publicPath := filepath.Join(work, "operator.pub")
+	automaticProcessPut(t, publicPath, operator.PrimaryPublic)
+	automaticProcessPut(t, filepath.Join(work, "root.key"), []byte(crypto.EncodeRootKey(f.root)))
+	host := &automaticProcessHost{work: work, installed: filepath.Join(work, "hikyo"), fenced: true, baseEnv: []string{"PATH=" + os.Getenv("PATH"), "HOME=" + work, "HIKYO_DB=sqlite:" + f.cfg.Path, "HIKYO_EXTERNAL_ORIGIN=https://automatic.fixture.invalid", "HIKYO_UPDATE_CHANNEL=off", "HIKYO_UPGRADE_STATE_DIR=" + installation}}
+	host.evidence = hostupgrade.RuntimeEvidence{BundleDirectory: route.Directory, OperatorPublicKey: publicPath, TargetManifest: string(route.Plan.Target().ManifestSHA256), LegacyWritersStopped: true}
+	identity, recipient, err := backup.GenerateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(work, "backup")
+	if err := os.Mkdir(output, 0700); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(t.Context(), route.Executables[route.Plan.Target()].BinaryPath, "backup", "upgrade-export", "--json", "--out", output, "--recipient", recipient)
+	command.Env = host.environment(host.evidence)
+	var stdout, stderr bytes.Buffer
+	command.Stdout, command.Stderr = &stdout, &stderr
+	if err := command.Run(); err != nil {
+		t.Fatalf("real JSON backup-export: %v\n%s", err, stderr.String())
+	}
+	var exported struct {
+		Ciphertext string `json:"ciphertext"`
+		Receipt    string `json:"receipt"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &exported); err != nil {
+		t.Fatalf("backup output must be JSON: %v\n%s", err, stdout.String())
+	}
+	receipt := automaticProcessRead(t, exported.Receipt)
+	pinned, err := backupreceipt.PinCiphertext(t.Context(), exported.Ciphertext, work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pinned.Close()
+	pin, err := backupreceipt.PinOperator(f.source.InstanceID, operator.PrimaryPublic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drill, err := DrillUpgrade(t.Context(), UpgradeDrillRequest{Scratch: store.Config{Engine: store.EngineSQLite, Path: filepath.Join(work, "scratch.db")}, Ciphertext: pinned, Receipt: receipt, Plan: route.Plan, Operator: pin, Unlock: backup.Unlock{Identity: identity}, RootKey: bytes.Clone(f.root), AutoCredentialProof: true, Now: time.Now(), Lifetime: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !drill.HierarchyReadable || drill.SecretProof != "existing-secret-readable" || drill.CredentialProof != "reconciled-minted-revoked" {
+		t.Fatal("real recovery proof incomplete")
+	}
+	evidence := filepath.Join(work, "evidence")
+	for name, raw := range map[string][]byte{"receipt.json": receipt, "attestation.json": drill.Attestation, "attestation.sigstore.json": trustfixture.Sign(t, operator.PrimarySigner, drill.Attestation)} {
+		automaticProcessPut(t, filepath.Join(evidence, name), raw)
+	}
+	host.evidence.EvidenceDirectory, host.evidence.CiphertextPath = evidence, exported.Ciphertext
+	manifest, err := route.Plan.SourceManifest(releaseidentity.SQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return host, &automaticJournal{Format: "hikyo.host-upgrade/v1", Phase: "proved", Target: route.Plan.Target(), Source: upgradecompat.InstalledSource{Identity: route.Plan.Source(), Migrations: manifest, SchemaSHA256: route.Plan.SourceSchemaDigest()}, Instance: f.source.InstanceID, Route: route.Plan.Digest(), Runtime: host.evidence}
+}
+
+type automaticProcessHost struct {
+	work, installed                             string
+	baseEnv                                     []string
+	evidence                                    hostupgrade.RuntimeEvidence
+	command                                     *exec.Cmd
+	done                                        chan error
+	fenced, failInstall, failHealth             bool
+	migrations, intermediateHealth, finalHealth int
+}
+
+func (h *automaticProcessHost) environment(e hostupgrade.RuntimeEvidence) []string {
+	return append(append([]string{}, h.baseEnv...), "HIKYO_UPGRADE_BUNDLE="+e.BundleDirectory, "HIKYO_UPGRADE_OPERATOR_PUBLIC_KEY="+e.OperatorPublicKey, "HIKYO_UPGRADE_TARGET_MANIFEST="+e.TargetManifest, "HIKYO_UPGRADE_EVIDENCE="+e.EvidenceDirectory, "HIKYO_UPGRADE_BACKUP="+e.CiphertextPath, fmt.Sprintf("HIKYO_UPGRADE_LEGACY_WRITERS_STOPPED=%t", e.LegacyWritersStopped))
+}
+func (h *automaticProcessHost) FenceAndStop(ctx context.Context) error {
+	h.fenced = true
+	if h.command == nil {
+		return nil
+	}
+	_ = h.command.Process.Signal(os.Interrupt)
+	select {
+	case err := <-h.done:
+		h.command = nil
+		return err
+	case <-ctx.Done():
+		_ = h.command.Process.Kill()
+		<-h.done
+		h.command = nil
+		return ctx.Err()
+	}
+}
+func (h *automaticProcessHost) Migrate(ctx context.Context, candidate string, e hostupgrade.RuntimeEvidence) ([]byte, error) {
+	if !h.fenced || h.command != nil {
+		return nil, errors.New("migration attempted without full stop")
+	}
+	h.migrations++
+	command := exec.CommandContext(ctx, candidate, "migrate")
+	command.Env = h.environment(e)
+	raw, err := command.CombinedOutput()
+	if err != nil {
+		return raw, fmt.Errorf("real migrate: %w: %s", err, raw)
+	}
+	return raw, nil
+}
+func (h *automaticProcessHost) InstallBinary(_ context.Context, candidate, digest string) error {
+	if h.failInstall {
+		return errors.New("injected post-schema installation interruption")
+	}
+	raw, err := os.ReadFile(candidate)
+	if err != nil {
+		return err
+	}
+	if string(releaseidentity.Hash(raw)) != digest {
+		return errors.New("candidate executable digest mismatch")
+	}
+	return os.WriteFile(h.installed, raw, 0700)
+}
+func (h *automaticProcessHost) ConfigureRuntime(_ context.Context, e hostupgrade.RuntimeEvidence) error {
+	h.evidence = e
+	return nil
+}
+func (h *automaticProcessHost) Complete(context.Context) error { h.fenced = false; return nil }
+func (h *automaticProcessHost) StartCandidate(ctx context.Context, digest string, final bool, timeout time.Duration) error {
+	if !h.fenced || h.command != nil {
+		return errors.New("candidate requires a stopped fenced service")
+	}
+	raw, err := os.ReadFile(h.installed)
+	if err != nil || string(releaseidentity.Hash(raw)) != digest {
+		return errors.New("installed process digest differs from candidate")
+	}
+	if h.failHealth {
+		// Corrupt only the runtime root credential after actual migrations.
+		// Real startup must reject the unreadable hierarchy before serving.
+		if err := os.WriteFile(filepath.Join(h.work, "root.key"), []byte(crypto.EncodeRootKey(bytes.Repeat([]byte{11}, crypto.KeySize))), 0600); err != nil {
+			return err
+		}
+	}
+	log, err := os.CreateTemp(h.work, "server-*.log")
+	if err != nil {
+		return err
+	}
+	defer log.Close()
+	command := exec.CommandContext(ctx, h.installed, "server", "--auto-migrate=false", "--root-key-file="+filepath.Join(h.work, "root.key"), "--listen=localhost:0", "--operational-listen=127.0.0.1:0")
+	command.Env, command.Stdout, command.Stderr = h.environment(h.evidence), log, log
+	if err := command.Start(); err != nil {
+		return err
+	}
+	h.command, h.done = command, make(chan error, 1)
+	go func() { h.done <- command.Wait() }()
+	check, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	client := &http.Client{Timeout: time.Second, Transport: &http.Transport{}}
+	defer client.CloseIdleConnections()
+	for {
+		select {
+		case err := <-h.done:
+			h.command = nil
+			logs, _ := os.ReadFile(log.Name())
+			return fmt.Errorf("real production server exited: %v: %s", err, logs)
+		case <-check.Done():
+			logs, _ := os.ReadFile(log.Name())
+			return fmt.Errorf("real production readiness timed out: %w: %s", check.Err(), logs)
+		case <-ticker.C:
+			logs, err := os.ReadFile(log.Name())
+			if err != nil {
+				return err
+			}
+			for _, line := range bytes.Split(logs, []byte("\n")) {
+				var event struct {
+					Message     string `json:"msg"`
+					Operational string `json:"operational_addr"`
+				}
+				if json.Unmarshal(line, &event) != nil || (event.Message != "server ready" && !strings.HasPrefix(event.Message, "maintenance active;")) {
+					continue
+				}
+				wantReady := http.StatusServiceUnavailable
+				if final {
+					wantReady = http.StatusOK
+				}
+				all := true
+				for path, expected := range map[string]int{"/healthz": http.StatusOK, "/readyz": wantReady} {
+					request, err := http.NewRequestWithContext(check, http.MethodGet, "http://"+event.Operational+path, nil)
+					if err != nil {
+						return err
+					}
+					response, err := client.Do(request)
+					if err != nil {
+						all = false
+						break
+					}
+					response.Body.Close()
+					if response.StatusCode != expected {
+						all = false
+						break
+					}
+				}
+				if all {
+					if final {
+						h.finalHealth++
+					} else {
+						h.intermediateHealth++
+					}
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func automaticProcessPut(t testing.TB, path string, raw []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+func automaticProcessRead(t testing.TB, path string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/app/automatic_integration_test.go
+++ b/internal/app/automatic_integration_test.go
@@ -364,6 +364,12 @@ func (h *automaticProcessHost) ConfigureRuntime(_ context.Context, e hostupgrade
 	return nil
 }
 func (h *automaticProcessHost) Complete(context.Context) error { h.fenced = false; return nil }
+func (h *automaticProcessHost) PrunePublic(hostupgrade.RuntimeEvidence) error {
+	if h.fenced {
+		return errors.New("pruned public evidence while still fenced")
+	}
+	return nil
+}
 func (h *automaticProcessHost) StartCandidate(ctx context.Context, digest string, final bool, timeout time.Duration) error {
 	if !h.fenced || h.command != nil {
 		return errors.New("candidate requires a stopped fenced service")

--- a/internal/app/automatic_release.go
+++ b/internal/app/automatic_release.go
@@ -1,0 +1,222 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
+	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
+	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+type automaticReleaseSource interface {
+	Releases(context.Context) ([]updatecheck.Release, error)
+	ReleaseByVersion(context.Context, string) (updatecheck.Release, error)
+}
+
+func nightlyStatus(release updatecheck.Release) (updatecheck.Status, error) {
+	if !release.Prerelease || !release.Immutable || !slices.ContainsFunc(release.Assets, func(asset updatecheck.Asset) bool { return asset.Name == "release-manifest.sigstore.json" }) {
+		return updatecheck.Status{}, errors.New("automatic upgrade requires an immutable signed nightly")
+	}
+	return updatecheck.Status{Available: true, Channel: updatecheck.ChannelNightly, LatestVersion: release.Version, Prerelease: true, Immutable: true, Assets: release.Assets, URL: release.URL}, nil
+}
+
+func selectAutomaticRelease(ctx context.Context, source automaticReleaseSource, version string) (updatecheck.Status, error) {
+	if version != "" {
+		release, err := source.ReleaseByVersion(ctx, version)
+		if err != nil {
+			return updatecheck.Status{}, err
+		}
+		return nightlyStatus(release)
+	}
+	releases, err := source.Releases(ctx)
+	if err != nil {
+		return updatecheck.Status{}, err
+	}
+	releases = slices.DeleteFunc(releases, func(release updatecheck.Release) bool { _, err := nightlyStatus(release); return err != nil })
+	status, err := updatecheck.Select("0.0.0", updatecheck.ChannelNightly, releases)
+	if err != nil {
+		return status, err
+	}
+	if !status.Available {
+		return status, errors.New("no signed nightly release is available")
+	}
+	return status, nil
+}
+
+type automaticRoute struct {
+	Bundle      upgradebundle.Bundle
+	Directory   string
+	Plan        upgradecompat.Plan
+	Instance    string
+	Executables map[releaseidentity.Identity]selfupdate.PreparedNightly
+}
+
+type automaticReleasePreparer interface {
+	PrepareNightlySource(context.Context, updatecheck.Status, releaseidentity.Identity) (selfupdate.PreparedNightly, error)
+	AssembleNightlyRoute(context.Context, selfupdate.PreparedNightly, []selfupdate.PreparedNightly) (string, error)
+}
+
+// prepareAutomaticRoute follows only authenticated identity references. It
+// stops as soon as the actual source has a complete authenticated route, so a
+// recent installation does not download unrelated predecessor history.
+func prepareAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database upgrade.Config, previous *automaticJournal) (automaticRoute, error) {
+	return discoverAutomaticRoute(ctx, installer, source, target, pinned, automaticStore{database}, database.Engine, previous)
+}
+
+func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database automaticInspection, engine releaseidentity.Engine, previous *automaticJournal) (automaticRoute, error) {
+	result := automaticRoute{Directory: target.BundleDirectory, Executables: map[releaseidentity.Identity]selfupdate.PreparedNightly{target.Identity: target}}
+	floor := releaseidentity.SnapshotFloor{}
+	control, err := database.Control(ctx)
+	if err == nil {
+		floor = control.Floor
+	} else if !errors.Is(err, upgrade.ErrAbsent) {
+		return result, err
+	}
+	resume := previous != nil && previous.Phase != "complete"
+	preferred := control.Applied
+	if resume {
+		if previous.Target != target.Identity {
+			return result, errors.New("unfinished upgrade pins a different exact target")
+		}
+		preferred = previous.Source.Identity
+	}
+	var lastPlanError error
+	depths := map[releaseidentity.Identity]int{target.Identity: 0}
+	expandedDepth := 0
+	for {
+		result.Bundle, err = upgradebundle.Load(ctx, result.Directory, pinned, floor)
+		if err != nil {
+			return result, err
+		}
+		floor = result.Bundle.Snapshot().Floor()
+		var candidatePlan upgradecompat.Plan
+		var candidateInstance string
+		if resume {
+			// Physical schema may already belong to an intermediate hop. Retain
+			// the original source and route; apply reconciliation measures its
+			// exact durable position before any process can migrate or serve.
+			plan, planErr := result.Bundle.Plan(previous.Source, target.Identity)
+			if planErr == nil && plan.Digest() == previous.Route {
+				result.Plan, result.Instance = plan, previous.Instance
+				return result, nil
+			}
+			lastPlanError = errors.New("unfinished upgrade no longer has its exact authenticated original route")
+		} else {
+			for _, candidate := range result.Bundle.Sources(engine) {
+				actual, inspectErr := database.Installed(ctx, candidate.Migrations)
+				digest, digestErr := candidate.Migrations.Digest()
+				if inspectErr != nil || digestErr != nil || actual.Source != candidate.Identity || actual.MigrationDigest != digest || actual.SchemaDigest != candidate.SchemaSHA256 || actual.InstanceID == "" {
+					continue
+				}
+				plan, planErr := result.Bundle.Plan(candidate, target.Identity)
+				if planErr == nil {
+					if len(plan.Steps()) == 0 {
+						result.Plan, result.Instance = plan, actual.InstanceID
+						return result, nil
+					}
+					candidatePlan, candidateInstance = plan, actual.InstanceID
+					break
+				}
+				lastPlanError = fmt.Errorf("installed source has no authenticated route: %w", planErr)
+			}
+		}
+		references, err := result.Bundle.ReferencedReleases(engine)
+		if err != nil {
+			return result, err
+		}
+		references = slices.DeleteFunc(references, func(identity releaseidentity.Identity) bool {
+			_, present := result.Executables[identity]
+			// Declaration and bridge verification require strictly increasing
+			// sequence edges. Nodes beyond the final target or before an exact
+			// installed release cannot participate in its route. This only prunes
+			// discovery; signatures, actual inspection and Plan grant authority.
+			return present || identity.Sequence > target.Identity.Sequence || (preferred.IsRelease() && identity.Sequence < preferred.Release.Sequence)
+		})
+		for _, identity := range references {
+			if depth, exists := depths[identity]; !exists || expandedDepth+1 < depth {
+				depths[identity] = expandedDepth + 1
+			}
+		}
+		slices.SortFunc(references, func(a, b releaseidentity.Identity) int {
+			if depths[a] < depths[b] {
+				return -1
+			}
+			if depths[a] > depths[b] {
+				return 1
+			}
+			if preferred.IsRelease() {
+				if a == preferred.Release && b != preferred.Release {
+					return -1
+				}
+				if b == preferred.Release && a != preferred.Release {
+					return 1
+				}
+			}
+			if a.Sequence > b.Sequence {
+				return -1
+			}
+			if a.Sequence < b.Sequence {
+				return 1
+			}
+			return strings.Compare(string(a.ManifestSHA256), string(b.ManifestSHA256))
+		})
+		// Unknown nodes at a shallower depth could supply a shorter route or
+		// change its deterministic tie break. Resolve that frontier first;
+		// older nodes beyond the found route cannot improve it.
+		if candidatePlan.Valid() && (len(references) == 0 || depths[references[0]] >= len(candidatePlan.Steps())) {
+			result.Plan, result.Instance = candidatePlan, candidateInstance
+			return result, nil
+		}
+		if len(references) == 0 {
+			if lastPlanError != nil {
+				return result, lastPlanError
+			}
+			return result, errors.New("installed database does not match an authenticated release or legacy bridge")
+		}
+		if len(result.Executables) >= upgradecompat.MaxReleases {
+			return result, errors.New("automatic upgrade graph exceeds release bound")
+		}
+		identity := references[0]
+		if identity.Profile != releaseidentity.NightlyV1 {
+			return result, errors.New("automatic nightly upgrade cannot cross into a stable release")
+		}
+		release, err := source.ReleaseByVersion(ctx, identity.Version)
+		if err != nil {
+			return result, err
+		}
+		status, err := nightlyStatus(release)
+		if err != nil {
+			return result, err
+		}
+		prepared, err := installer.PrepareNightlySource(ctx, status, identity)
+		if err != nil {
+			return result, err
+		}
+		if prepared.Identity != identity {
+			return result, errors.New("prepared source differs from authenticated reference")
+		}
+		result.Executables[identity] = prepared
+		expandedDepth = depths[identity]
+		evidence := make([]selfupdate.PreparedNightly, 0, len(result.Executables)-1)
+		for identity, prepared := range result.Executables {
+			if identity != target.Identity {
+				evidence = append(evidence, prepared)
+			}
+		}
+		slices.SortFunc(evidence, func(a, b selfupdate.PreparedNightly) int {
+			return strings.Compare(string(a.Identity.ManifestSHA256), string(b.Identity.ManifestSHA256))
+		})
+		result.Directory, err = installer.AssembleNightlyRoute(ctx, target, evidence)
+		if err != nil {
+			return result, err
+		}
+	}
+}

--- a/internal/app/automatic_upgrade.go
+++ b/internal/app/automatic_upgrade.go
@@ -1,0 +1,397 @@
+package app
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
+	"github.com/Hikyo-Org/hikyo/internal/buildcompat"
+	"github.com/Hikyo-Org/hikyo/internal/config"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/filedurability"
+	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
+	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecustody"
+	"github.com/gofrs/flock"
+)
+
+// AutomaticHandoff asks the entrypoint to run the authenticated target's own
+// coordinator. The current service executable has not been changed at this point.
+type AutomaticHandoff struct {
+	Executable string
+	Arguments  []string
+}
+
+func (e *AutomaticHandoff) Error() string {
+	return "continue upgrade with the verified target coordinator"
+}
+
+type automaticJournal struct {
+	Format   string                        `json:"format"`
+	Phase    string                        `json:"phase"`
+	Target   releaseidentity.Identity      `json:"target"`
+	Source   upgradecompat.InstalledSource `json:"source"`
+	Instance string                        `json:"instance"`
+	Route    releaseidentity.Digest        `json:"route"`
+	Hop      int                           `json:"hop"`
+	Runtime  hostupgrade.RuntimeEvidence   `json:"runtime"`
+}
+
+// RunAutomaticUpgrade is the root operator entrypoint. It is deliberately
+// separate from the retired remotely callable updater and server boot path.
+func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, readPassword func(string) (string, error)) (err error) {
+	fs := flag.NewFlagSet("hikyo upgrade", flag.ContinueOnError)
+	fs.SetOutput(out)
+	configuration := fs.String("config", hostupgrade.ConfigPath, "root-owned deployment configuration")
+	version := fs.String("target", "", "exact nightly version; default is latest signed nightly")
+	handoff := fs.Bool("handoff", false, "continue in the independently verified target executable")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: sudo hikyo upgrade [--target VERSION] [--config FILE]")
+	}
+	if runtime.GOOS != "linux" || os.Geteuid() != 0 {
+		return errors.New("automatic upgrades require sudo hikyo upgrade on the Linux systemd server")
+	}
+	pinned, err := buildcompat.ProductionTrust()
+	if err != nil {
+		return err
+	}
+	c, err := hostupgrade.InitializeConfig(*configuration)
+	if err != nil {
+		return err
+	}
+	host, err := hostupgrade.New(c)
+	if err != nil {
+		return err
+	}
+	if err := host.Preflight(ctx); err != nil {
+		return err
+	}
+	if err := host.PrepareDirectories(); err != nil {
+		return err
+	}
+	lock := flock.New(filepath.Join(c.StateDirectory, "upgrade.lock"))
+	locked, err := lock.TryLock()
+	if err != nil {
+		return err
+	}
+	if !locked {
+		return errors.New("another operator is already upgrading this installation")
+	}
+	defer func() {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			// A handoff is control flow: never wrap it around a failed unlock.
+			err = fmt.Errorf("release operator upgrade lock: %w", unlockErr)
+		}
+	}()
+	journalPath := filepath.Join(c.StateDirectory, "operation.json")
+	previous, err := readAutomaticJournal(journalPath)
+	if err != nil {
+		return err
+	}
+	if previous != nil && previous.Phase == "restore-required" {
+		return errors.Join(errors.New("previous candidate failed post-write health; explicit operator recovery is required"), host.FenceAndStop(ctx))
+	}
+	if previous != nil && previous.Phase != "complete" {
+		if *version != "" && *version != previous.Target.Version {
+			return errors.New("unfinished upgrade pins a different target; rerun sudo hikyo upgrade to reconcile it")
+		}
+		*version = previous.Target.Version
+	}
+	environment := host.Environment()
+	getenv := func(key string) string { return environment[key] }
+	cfg, _, err := config.Load("upgrade", nil, getenv, nil)
+	if err != nil {
+		return err
+	}
+	if !filepath.IsAbs(cfg.Store.Path) {
+		cfg.Store.Path = filepath.Join(c.WorkingDirectory, cfg.Store.Path)
+	}
+	database := upgrade.Config{Engine: releaseidentity.SQLite, Path: cfg.Store.Path}
+	cache := filepath.Join(c.StateDirectory, "downloads")
+	installer, err := selfupdate.NewInstaller(selfupdate.Config{StateDir: cache, TrustRootBase64: base64.StdEncoding.EncodeToString(pinned.Root), RecoveryKeyBase64: base64.StdEncoding.EncodeToString(pinned.RecoveryPublicKey)})
+	if err != nil {
+		return err
+	}
+	client, err := updatecheck.NewHTTPClient(60 * time.Second)
+	if err != nil {
+		return err
+	}
+	source := updatecheck.NewGitHubSource(client)
+	fmt.Fprintln(out, "1/5 Verifying the signed nightly and migration route.")
+	status, err := selectAutomaticRelease(ctx, source, *version)
+	if err != nil {
+		return err
+	}
+	var target selfupdate.PreparedNightly
+	if previous != nil && previous.Phase != "complete" {
+		// An unfinished operation pins its exact authenticated target even if a
+		// later release has since been observed in the download cache.
+		target, err = installer.PrepareNightlySource(ctx, status, previous.Target)
+	} else {
+		target, err = installer.PrepareNightly(ctx, status)
+	}
+	if err != nil {
+		return err
+	}
+	current, _, err := buildcompat.Current()
+	if err != nil {
+		return err
+	}
+	targetBundle, err := upgradebundle.Load(ctx, target.BundleDirectory, pinned, releaseidentity.SnapshotFloor{})
+	if err != nil {
+		return err
+	}
+	if node, matchErr := targetBundle.MatchBuild(current); matchErr != nil || node.Identity() != target.Identity {
+		if *handoff {
+			return errors.New("verified target binary does not match its signed compatibility declaration")
+		}
+		return &AutomaticHandoff{Executable: target.BinaryPath, Arguments: []string{"upgrade", "--config", *configuration, "--target", target.Identity.Version, "--handoff"}}
+	}
+	route, err := prepareAutomaticRoute(ctx, installer, source, target, pinned, database, previous)
+	if err != nil {
+		return err
+	}
+	if len(route.Plan.Steps()) == 0 {
+		fmt.Fprintf(out, "Hikyo %s is already installed.\n", target.Identity.Version)
+		return nil
+	}
+	if previous != nil && previous.Phase != "complete" && previous.Route != route.Plan.Digest() {
+		return errors.New("unfinished upgrade route differs from current authenticated evidence")
+	}
+	publicBundle, err := host.StagePublicBundle(route.Directory)
+	if err != nil {
+		return err
+	}
+	if _, err := upgradebundle.Load(ctx, publicBundle, pinned, route.Bundle.Snapshot().Floor()); err != nil {
+		return err
+	}
+	staged := make(map[releaseidentity.Identity]string)
+	for _, step := range route.Plan.Steps() {
+		prepared, ok := route.Executables[step.Target]
+		if !ok {
+			return errors.New("authenticated route executable is missing")
+		}
+		staged[step.Target], err = host.StageCandidate(prepared.BinaryPath, string(prepared.BinarySHA256))
+		if err != nil {
+			return err
+		}
+	}
+	resume := previous != nil && previous.Phase != "complete" && previous.Phase != "preparing"
+	journal := previous
+	if !resume {
+		vault, err := openAutomaticCustody(c, route.Instance, readPassword)
+		if err != nil {
+			return err
+		}
+		defer vault.Close()
+		publicKey, err := host.PublishPublicEvidence("operator.pub", vault.PublicKey())
+		if err != nil {
+			return err
+		}
+		manifest, err := route.Plan.SourceManifest(database.Engine)
+		if err != nil {
+			return err
+		}
+		journal = &automaticJournal{Format: "hikyo.host-upgrade/v1", Phase: "preparing", Target: target.Identity, Source: upgradecompat.InstalledSource{Identity: route.Plan.Source(), Migrations: manifest, SchemaSHA256: route.Plan.SourceSchemaDigest()}, Instance: route.Instance, Route: route.Plan.Digest(), Runtime: hostupgrade.RuntimeEvidence{BundleDirectory: publicBundle, OperatorPublicKey: publicKey, TargetManifest: string(target.Identity.ManifestSHA256), LegacyWritersStopped: route.Plan.Source().Genesis == releaseidentity.LegacyGenesisV1}}
+		if err := writeAutomaticJournal(journalPath, journal); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, "2/5 Stopping writers and creating the encrypted backup.")
+		if err := host.FenceAndStop(ctx); err != nil {
+			return err
+		}
+		// Every error after the full stop leaves the durable startup fence. A
+		// later command reconciles it; no old executable is silently restarted.
+		if err := prepareAutomaticEvidence(ctx, host, database, route, staged[target.Identity], vault, journal, out); err != nil {
+			return err
+		}
+		journal.Phase = "proved"
+		if err := writeAutomaticJournal(journalPath, journal); err != nil {
+			return err
+		}
+	} else {
+		journal.Runtime.BundleDirectory = publicBundle
+		if err := host.FenceAndStop(ctx); err != nil {
+			return err
+		}
+	}
+	if err := applyAutomaticRoute(ctx, host, automaticStore{database}, route, staged, journal, journalPath, out); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Hikyo %s is upgraded and ready. Encrypted backup retained at %s.\n", target.Identity.Version, journal.Runtime.CiphertextPath)
+	return nil
+}
+
+func openAutomaticCustody(c hostupgrade.Config, instance string, readPassword func(string) (string, error)) (*upgradecustody.Vault, error) {
+	if readPassword == nil {
+		return nil, errors.New("upgrade custody requires an interactive operator terminal")
+	}
+	_, err := os.Lstat(filepath.Join(c.CustodyDirectory, "operator.age"))
+	create := errors.Is(err, os.ErrNotExist)
+	if err != nil && !create {
+		return nil, err
+	}
+	prompt := "Unlock upgrade recovery keys: "
+	if create {
+		prompt = "Create a passphrase for encrypted upgrade recovery keys: "
+	}
+	password, err := readPassword(prompt)
+	if err != nil {
+		return nil, err
+	}
+	secret := []byte(password)
+	defer clear(secret)
+	if !create {
+		return upgradecustody.Open(c.CustodyDirectory, secret, instance)
+	}
+	confirm, err := readPassword("Confirm upgrade recovery passphrase: ")
+	if err != nil {
+		return nil, err
+	}
+	if confirm != password {
+		return nil, errors.New("upgrade recovery passphrases differ")
+	}
+	root, err := crypto.ReadRootKey(c.RootKeyFile, "")
+	if err != nil {
+		return nil, err
+	}
+	defer crypto.Zero(root)
+	return upgradecustody.Create(c.CustodyDirectory, secret, root, instance)
+}
+
+func prepareAutomaticEvidence(ctx context.Context, host *hostupgrade.Host, database upgrade.Config, route automaticRoute, candidate string, vault *upgradecustody.Vault, journal *automaticJournal, out io.Writer) error {
+	nonce, err := backupreceipt.NewNonce()
+	if err != nil {
+		return err
+	}
+	output, err := host.PreparePublicOutput("backup-" + string(nonce))
+	if err != nil {
+		return err
+	}
+	raw, err := host.Export(ctx, candidate, hostupgrade.ExportRequest{OutputDirectory: output, Recipient: vault.Recipient(), Runtime: journal.Runtime})
+	if err != nil {
+		return err
+	}
+	var exported struct {
+		Ciphertext string `json:"ciphertext"`
+		Receipt    string `json:"receipt"`
+	}
+	if definitions.DecodeStrict(raw, &exported) != nil || filepath.Dir(exported.Ciphertext) != output || filepath.Dir(exported.Receipt) != output {
+		return errors.New("backup export returned invalid artifact paths")
+	}
+	receipt, err := backupreceipt.ReadPublicArtifact(exported.Receipt, backupreceipt.MaxArtifactBytes)
+	if err != nil {
+		return err
+	}
+	ciphertext, err := backupreceipt.PinCiphertext(ctx, exported.Ciphertext, host.Config().StateDirectory)
+	if err != nil {
+		return err
+	}
+	defer ciphertext.Close()
+	work, err := os.MkdirTemp(host.Config().StateDirectory, ".restore-drill-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(work)
+	fmt.Fprintln(out, "3/5 Restoring the backup to scratch and proving recovery.")
+	scope := domain.Scope{}
+	if host.Config().Project != "" {
+		scope, err = parseDrillProject(host.Config().Project)
+		if err != nil {
+			return err
+		}
+	}
+	result, err := DrillUpgrade(ctx, UpgradeDrillRequest{Scratch: store.Config{Engine: store.EngineSQLite, Path: filepath.Join(work, "scratch.db")}, Ciphertext: ciphertext, Receipt: receipt, Plan: route.Plan, Operator: vault.Pin(), Unlock: vault.BackupUnlock(), RootKey: vault.RootKey(), Principal: domain.PrincipalID(host.Config().Principal), Scope: scope, AutoCredentialProof: host.Config().Principal == "", Now: time.Now(), Lifetime: backupreceipt.MaxAttestationLifetime})
+	if err != nil {
+		return err
+	}
+	signature, err := vault.SignAttestation(result.Attestation, time.Now())
+	if err != nil {
+		return err
+	}
+	directory := filepath.Join(host.Config().PublicDirectory, "evidence-"+string(nonce))
+	if err := os.Mkdir(directory, 0755); err != nil {
+		return err
+	}
+	for name, contents := range map[string][]byte{"receipt.json": receipt, "attestation.json": result.Attestation, "attestation.sigstore.json": signature} {
+		if err := writeAutomaticFile(filepath.Join(directory, name), contents, 0644); err != nil {
+			return err
+		}
+	}
+	if err := filedurability.SyncDirectory(host.Config().PublicDirectory); err != nil {
+		return err
+	}
+	journal.Runtime.EvidenceDirectory, journal.Runtime.CiphertextPath = directory, exported.Ciphertext
+	return nil
+}
+
+func writeAutomaticFile(path string, raw []byte, mode os.FileMode) error {
+	f, err := os.CreateTemp(filepath.Dir(path), ".upgrade-write-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	_, err = f.Write(raw)
+	if err = errors.Join(err, f.Chmod(mode), f.Sync(), f.Close()); err != nil {
+		return err
+	}
+	if err := os.Rename(f.Name(), path); err != nil {
+		return err
+	}
+	return filedurability.SyncDirectory(filepath.Dir(path))
+}
+
+func writeAutomaticJournal(path string, journal *automaticJournal) error {
+	raw, err := json.Marshal(journal)
+	if err != nil {
+		return err
+	}
+	return writeAutomaticFile(path, raw, 0600)
+}
+
+func readAutomaticJournal(path string) (*automaticJournal, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 || info.Size() > 1<<20 {
+		return nil, errors.New("invalid private upgrade journal")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var journal automaticJournal
+	if definitions.DecodeStrict(raw, &journal) != nil || journal.Format != "hikyo.host-upgrade/v1" || journal.Target.Validate() != nil || journal.Source.Identity.Validate() != nil || journal.Source.Migrations.Validate() != nil || journal.Source.SchemaSHA256.Validate() != nil || journal.Route.Validate() != nil || journal.Hop < 0 || journal.Hop > upgradecompat.MaxHops {
+		return nil, errors.New("invalid private upgrade journal")
+	}
+	switch journal.Phase {
+	case "preparing", "proved", "write-intent", "schema-applied", "hop-healthy", "restore-required", "complete":
+	default:
+		return nil, errors.New("unknown upgrade journal phase")
+	}
+	return &journal, nil
+}

--- a/internal/app/automatic_upgrade.go
+++ b/internal/app/automatic_upgrade.go
@@ -99,8 +99,15 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	}
 	defer func() {
 		if unlockErr := lock.Unlock(); unlockErr != nil {
-			// A handoff is control flow: never wrap it around a failed unlock.
-			err = fmt.Errorf("release operator upgrade lock: %w", unlockErr)
+			unlockErr = fmt.Errorf("release operator upgrade lock: %w", unlockErr)
+			// A handoff is control flow: the entrypoint must not execute it
+			// after a failed unlock. Any other outcome stays visible.
+			var handoff *AutomaticHandoff
+			if errors.As(err, &handoff) {
+				err = unlockErr
+			} else {
+				err = errors.Join(err, unlockErr)
+			}
 		}
 	}()
 	journalPath := filepath.Join(c.StateDirectory, "operation.json")

--- a/internal/app/backup_upgrade.go
+++ b/internal/app/backup_upgrade.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -55,6 +56,7 @@ func runUpgradeExport(ctx context.Context, cfg *config.Config, args []string, ou
 	fs.SetOutput(out)
 	bundleDir := fs.String("bundle", trust.BundleDirectory, "verified offline release artifact directory")
 	dir := fs.String("out", cfg.BackupDir, "public ciphertext and receipt destination")
+	jsonOutput := fs.Bool("json", false, "emit machine-readable ciphertext and receipt paths")
 	var recipients recipientList
 	fs.Var(&recipients, "recipient", "public age X25519 recipient; repeatable")
 	if err := fs.Parse(args); err != nil {
@@ -104,6 +106,12 @@ func runUpgradeExport(ctx context.Context, cfg *config.Config, args []string, ou
 		}
 		if exported.Receipt == nil || exported.Receipt.Snapshot.InstanceID != trust.OperatorPin.InstanceID() {
 			return errors.New("exported source differs from current installation operator pin")
+		}
+		if *jsonOutput {
+			return json.NewEncoder(out).Encode(struct {
+				Ciphertext string `json:"ciphertext"`
+				Receipt    string `json:"receipt"`
+			}{exported.Path, exported.ReceiptPath})
 		}
 		_, err = fmt.Fprintf(out, "ciphertext: %s\nreceipt: %s\n", exported.Path, exported.ReceiptPath)
 		return err

--- a/internal/app/backup_upgrade_auto_drill_test.go
+++ b/internal/app/backup_upgrade_auto_drill_test.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestUpgradeDrillAutomaticallyProvesExistingCredentialAuthority(t *testing.T) {
+	for _, engine := range []store.Engine{store.EngineSQLite, store.EnginePostgres} {
+		for _, orgScope := range []bool{false, true} {
+			name := string(engine) + "/project"
+			if orgScope {
+				name = string(engine) + "/org"
+			}
+			t.Run(name, func(t *testing.T) {
+				f := newUpgradeDrillFixture(t, engine, true, true, func(db *store.DB) {
+					// Earlier unsuitable candidates must not be accepted merely to
+					// make the automatic proof succeed.
+					drillExec(t, db, `INSERT INTO principals (id,kind,created_at) VALUES ('usr_a_no_grants','human','2026-09-05T00:00:00Z')`)
+					if orgScope {
+						drillExec(t, db, `UPDATE grants SET project_id=NULL WHERE id='gr_drill'`)
+						drillExec(t, db, `INSERT INTO grants (id,principal_id,capability,org_id,project_id,env_id,created_at) VALUES ('gr_read','usr_drill','read','org_drill',NULL,NULL,'2026-09-05T00:00:00Z')`)
+						drillExec(t, db, `INSERT INTO grant_origins (id,grant_id,kind,subject,created_at) VALUES ('gor_read','gr_read','manual','usr_drill','2026-09-05T00:00:00Z')`)
+					}
+				})
+				f.request.Principal, f.request.Scope = "", domain.Scope{}
+				f.request.AutoCredentialProof = true
+				result, err := DrillUpgrade(t.Context(), f.request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result.CredentialProof != "reconciled-minted-revoked" || !result.HierarchyReadable || result.SecretProof != "existing-secret-readable" {
+					t.Fatal("automatic drill did not prove real restored data and credential lifecycle")
+				}
+			})
+		}
+	}
+}
+
+func TestUpgradeDrillAutoSelectionSkipsUnusableScopeBeforeCommit(t *testing.T) {
+	for _, engine := range []store.Engine{store.EngineSQLite, store.EnginePostgres} {
+		for _, nextPrincipal := range []bool{false, true} {
+			for _, emptyOrg := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/next-principal=%t/empty-org=%t", engine, nextPrincipal, emptyOrg), func(t *testing.T) {
+					f := newUpgradeDrillFixture(t, engine, true, true, func(db *store.DB) {
+						// Both candidates use org scope so sorting cannot skip this
+						// regression by prioritizing the valid project-scoped grant.
+						drillExec(t, db, `UPDATE grants SET project_id=NULL WHERE id='gr_drill'`)
+						drillExec(t, db, `INSERT INTO grants (id,principal_id,capability,org_id,created_at) VALUES ('gr_read','usr_drill','read','org_drill','2026-09-05T00:00:00Z')`)
+						drillExec(t, db, `INSERT INTO grant_origins (id,grant_id,kind,subject,created_at) VALUES ('gor_read','gr_read','manual','usr_drill','2026-09-05T00:00:00Z')`)
+						drillExec(t, db, `INSERT INTO orgs (id,name,active,metadata,created_at) VALUES ('org_a_unusable','Empty or unreadable',TRUE,'{}','2026-09-05T00:00:00Z')`)
+						principal := "usr_drill"
+						if nextPrincipal {
+							principal = "usr_a_unusable"
+							drillExec(t, db, `INSERT INTO principals (id,kind,created_at) VALUES ('usr_a_unusable','human','2026-09-05T00:00:00Z')`)
+						}
+						drillExec(t, db, `INSERT INTO grants (id,principal_id,capability,org_id,created_at) VALUES ('gr_unusable',$1,'manage-identities','org_a_unusable','2026-09-05T00:00:00Z')`, principal)
+						drillExec(t, db, `INSERT INTO grant_origins (id,grant_id,kind,subject,created_at) VALUES ('gor_unusable','gr_unusable','manual',$1,'2026-09-05T00:00:00Z')`, principal)
+						if emptyOrg {
+							// Authorized project enumeration produces an empty set.
+							drillExec(t, db, `INSERT INTO grants (id,principal_id,capability,org_id,created_at) VALUES ('gr_empty_read',$1,'read','org_a_unusable','2026-09-05T00:00:00Z')`, principal)
+							drillExec(t, db, `INSERT INTO grant_origins (id,grant_id,kind,subject,created_at) VALUES ('gor_empty_read','gr_empty_read','manual',$1,'2026-09-05T00:00:00Z')`, principal)
+						} else {
+							// This org has a project, but no existing read authority.
+							drillExec(t, db, `INSERT INTO projects (id,org_id,name,created_at) VALUES ('prj_a_unusable','org_a_unusable','Unreadable','2026-09-05T00:00:00Z')`)
+						}
+					})
+					f.request.Principal, f.request.Scope = "", domain.Scope{}
+					f.request.AutoCredentialProof = true
+					result, err := DrillUpgrade(t.Context(), f.request)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if result.CredentialProof != "reconciled-minted-revoked" {
+						t.Fatal("later existing authority did not prove credentials")
+					}
+					assertOnlyAutomaticDrillPrincipalReconciled(t, f.request.Scratch, nextPrincipal)
+				})
+			}
+		}
+	}
+}
+
+func assertOnlyAutomaticDrillPrincipalReconciled(t *testing.T, cfg store.Config, haveUnusablePrincipal bool) {
+	t.Helper()
+	var count func(string) int
+	if cfg.Engine == store.EngineSQLite {
+		db, err := sql.Open("sqlite", store.SQLiteDSN(cfg.Path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		count = func(query string) int {
+			t.Helper()
+			var n int
+			if err := db.QueryRowContext(t.Context(), query).Scan(&n); err != nil {
+				t.Fatal(err)
+			}
+			return n
+		}
+	} else {
+		db, err := pgx.Connect(t.Context(), cfg.DSN)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close(t.Context())
+		count = func(query string) int {
+			t.Helper()
+			var n int
+			if err := db.QueryRow(t.Context(), query).Scan(&n); err != nil {
+				t.Fatal(err)
+			}
+			return n
+		}
+	}
+	if count(`SELECT COUNT(*) FROM principals WHERE id='usr_drill' AND reconciled_epoch=(SELECT restore_epoch FROM auth_instance_state WHERE id=1)`) != 1 {
+		t.Fatal("selected existing principal was not reconciled")
+	}
+	if haveUnusablePrincipal && count(`SELECT COUNT(*) FROM principals WHERE id='usr_a_unusable' AND reconciled_epoch<(SELECT restore_epoch FROM auth_instance_state WHERE id=1)`) != 1 {
+		t.Fatal("unsuitable principal reconciliation was not rolled back")
+	}
+	if count(`SELECT COUNT(*) FROM audit_instance_events WHERE type='restore.principal_reconciled'`) != 1 {
+		t.Fatal("automatic selection committed reconciliation audit events for unsuitable principals")
+	}
+}
+
+func TestUpgradeDrillAutoSelectionRefusesLostGrantAuthority(t *testing.T) {
+	f := newUpgradeDrillFixture(t, store.EngineSQLite, true, true, func(db *store.DB) {
+		drillExec(t, db, `DELETE FROM grant_origins WHERE grant_id='gr_drill'`)
+		drillExec(t, db, `DELETE FROM grants WHERE id='gr_drill'`)
+	})
+	f.request.Principal, f.request.Scope = "", domain.Scope{}
+	f.request.AutoCredentialProof = true
+	if _, err := DrillUpgrade(t.Context(), f.request); err == nil {
+		t.Fatal("automatic drill fabricated credential authority")
+	}
+}
+
+func TestUpgradeDrillManualSelectionStillRequiredByDefault(t *testing.T) {
+	f := newUpgradeDrillFixture(t, store.EngineSQLite, true, true)
+	f.request.Principal, f.request.Scope = "", domain.Scope{}
+	if _, err := DrillUpgrade(t.Context(), f.request); err == nil {
+		t.Fatal("ordinary manual drill silently selected a principal")
+	}
+}

--- a/internal/app/backup_upgrade_drill.go
+++ b/internal/app/backup_upgrade_drill.go
@@ -42,6 +42,9 @@ type UpgradeDrillRequest struct {
 	Scope      domain.Scope
 	Now        time.Time
 	Lifetime   time.Duration
+	// AutoCredentialProof selects one existing authorized principal only in
+	// this isolated scratch restore. Ordinary manual drills remain explicit.
+	AutoCredentialProof bool
 }
 
 // DrillUpgrade is a local operator operation. It consumes separately supplied
@@ -51,6 +54,9 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 	defer crypto.Zero(request.RootKey)
 	if request.Ciphertext == nil || !request.Operator.Valid() || request.Now.IsZero() || request.Lifetime <= 0 || request.Lifetime > backupreceipt.MaxAttestationLifetime {
 		return UpgradeDrillResult{}, errors.New("upgrade drill requires complete operator custody and bounded validity")
+	}
+	if request.AutoCredentialProof && (request.Principal != "" || request.Scope != (domain.Scope{})) {
+		return UpgradeDrillResult{}, errors.New("automatic scratch credential selection cannot be combined with an explicit principal or project")
 	}
 	receipt, err := backupreceipt.ParseReceipt(request.Receipt)
 	if err != nil {
@@ -145,6 +151,11 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 		}
 		if len(status.Pending) == 0 {
 			result.CredentialProof = "authoritatively-no-unreconciled-principal"
+		} else if request.AutoCredentialProof {
+			if err := recovery.AutoCredentialProof(ctx, kr); err != nil {
+				return fmt.Errorf("automatic scratch credential proof: %w", err)
+			}
+			result.CredentialProof = "reconciled-minted-revoked"
 		} else {
 			if request.Principal == "" {
 				return errors.New("populated identity inventory requires an explicit scratch reconciliation principal and project")

--- a/internal/app/backup_upgrade_drill_test.go
+++ b/internal/app/backup_upgrade_drill_test.go
@@ -106,7 +106,7 @@ type upgradeDrillFixture struct {
 	root     []byte
 }
 
-func newUpgradeDrillFixture(t *testing.T, engine store.Engine, secret, hierarchy bool) upgradeDrillFixture {
+func newUpgradeDrillFixture(t *testing.T, engine store.Engine, secret, hierarchy bool, prepare ...func(*store.DB)) upgradeDrillFixture {
 	t.Helper()
 	cfg := upgradeDrillDatabase(t, engine)
 	root, err := crypto.GenerateRootKey()
@@ -148,6 +148,9 @@ func newUpgradeDrillFixture(t *testing.T, engine store.Engine, secret, hierarchy
 			t.Fatal(err)
 		}
 		drillExec(t, db, `INSERT INTO value_entries (id,org_id,project_id,environment_id,key_id,ciphertext,updated_at,updated_by) VALUES ('val_drill','org_drill','prj_drill','env_drill','key_drill',$1,'2026-09-05T00:00:00Z','usr_drill')`, sealed)
+	}
+	for _, fn := range prepare {
+		fn(db)
 	}
 	// Construct a historical pre-ledger fixture only after real runtime admission
 	// and key writes. Removing the new control storage models the archive produced

--- a/internal/hostupgrade/config.go
+++ b/internal/hostupgrade/config.go
@@ -1,0 +1,194 @@
+// Package hostupgrade provides the bounded, operator-invoked systemd adapter.
+// It never accepts a shell command, service name, or destination from a release.
+package hostupgrade
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const ConfigPath = "/etc/hikyo/upgrade.json"
+
+// Config is operator-owned deployment configuration, never release metadata.
+type Config struct {
+	Unit                  string `json:"unit"`
+	User                  string `json:"user"`
+	Group                 string `json:"group"`
+	WorkingDirectory      string `json:"working_directory"`
+	EnvironmentFile       string `json:"environment_file"`
+	RootKeyFile           string `json:"root_key_file"`
+	Binary                string `json:"binary"`
+	HealthURL             string `json:"health_url"`
+	PublicDirectory       string `json:"public_directory"`
+	InstallationDirectory string `json:"installation_directory"`
+	StateDirectory        string `json:"state_directory"`
+	CustodyDirectory      string `json:"custody_directory"`
+	CandidateDirectory    string `json:"candidate_directory"`
+	Principal             string `json:"principal,omitempty"`
+	Project               string `json:"project,omitempty"`
+}
+
+func DefaultConfig() Config {
+	return Config{Unit: "hikyo.service", User: "hikyo", Group: "hikyo", WorkingDirectory: "/var/lib/hikyo", EnvironmentFile: "/etc/hikyo/hikyo.env", RootKeyFile: "/etc/hikyo/root.key", Binary: "/usr/bin/hikyo", HealthURL: "http://127.0.0.1:8081/readyz", PublicDirectory: "/var/lib/hikyo-upgrade", InstallationDirectory: "/var/lib/hikyo-installation", StateDirectory: "/var/lib/hikyo-upgrader", CustodyDirectory: "/etc/hikyo/upgrade-keys", CandidateDirectory: "/var/lib/hikyo-upgrade-candidates"}
+}
+
+var namePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,63}$`)
+var pathPattern = regexp.MustCompile(`^/[A-Za-z0-9_./-]+$`)
+
+func (c Config) Validate() error {
+	if !strings.HasPrefix(c.Unit, "hikyo") || !strings.HasSuffix(c.Unit, ".service") || !namePattern.MatchString(strings.TrimSuffix(c.Unit, ".service")) {
+		return errors.New("host upgrade requires a hikyo systemd service unit")
+	}
+	if !namePattern.MatchString(c.User) || !namePattern.MatchString(c.Group) || c.User == "root" || c.Group == "root" {
+		return errors.New("host upgrade requires an unprivileged runtime user and group")
+	}
+	paths := []string{c.WorkingDirectory, c.EnvironmentFile, c.RootKeyFile, c.Binary, c.PublicDirectory, c.InstallationDirectory, c.StateDirectory, c.CustodyDirectory, c.CandidateDirectory}
+	for _, p := range paths {
+		if !safePath(p) {
+			return fmt.Errorf("invalid host upgrade path %q", p)
+		}
+	}
+	// Runtime-writable directories cannot contain privileged controller files.
+	for _, private := range []string{c.StateDirectory, c.CustodyDirectory, c.CandidateDirectory, c.EnvironmentFile, c.RootKeyFile, c.Binary} {
+		for _, public := range []string{c.WorkingDirectory, c.PublicDirectory, c.InstallationDirectory} {
+			if within(public, private) {
+				return fmt.Errorf("privileged path %s is inside runtime-writable %s", private, public)
+			}
+		}
+	}
+	for i, p := range paths {
+		for j, q := range paths {
+			if i != j && p == q {
+				return errors.New("host upgrade paths must be distinct")
+			}
+		}
+	}
+	directories := []string{c.WorkingDirectory, c.PublicDirectory, c.InstallationDirectory, c.StateDirectory, c.CustodyDirectory, c.CandidateDirectory}
+	for i, p := range directories {
+		for j, q := range directories {
+			if i != j && within(p, q) {
+				return errors.New("upgrade directories must not contain one another")
+			}
+		}
+	}
+	u, err := url.Parse(c.HealthURL)
+	if err != nil || u.Scheme != "http" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "/readyz" {
+		return errors.New("health URL must be a loopback HTTP /readyz endpoint")
+	}
+	ip := net.ParseIP(u.Hostname())
+	if ip == nil || !ip.IsLoopback() {
+		return errors.New("health URL must use a literal loopback IP address")
+	}
+	return nil
+}
+
+func safePath(p string) bool {
+	return len(p) > 1 && filepath.IsAbs(p) && filepath.Clean(p) == p && pathPattern.MatchString(p)
+}
+func within(base, p string) bool {
+	return p == base || strings.HasPrefix(p, base+string(filepath.Separator))
+}
+
+// LoadConfig refuses unknown fields, symbolic links, and writable authority.
+func LoadConfig(path string) (Config, error) {
+	var c Config
+	if err := trustedFile(path); err != nil {
+		return c, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return c, err
+	}
+	if len(b) > 65536 {
+		return c, errors.New("host upgrade config exceeds 64 KiB")
+	}
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.DisallowUnknownFields()
+	if err = d.Decode(&c); err != nil {
+		return c, fmt.Errorf("host upgrade config: %w", err)
+	}
+	if err = d.Decode(new(any)); err != io.EOF {
+		return c, errors.New("host upgrade config contains trailing JSON")
+	}
+	return c, c.Validate()
+}
+
+// InitializeConfig creates the default configuration once, without replacing
+// existing operator configuration. It does not start or stop the deployment.
+func InitializeConfig(path string) (Config, error) {
+	if os.Geteuid() != 0 {
+		return Config{}, errors.New("host upgrade initialization requires root")
+	}
+	if _, err := os.Lstat(path); err == nil {
+		return LoadConfig(path)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Config{}, err
+	}
+	if err := trustedDirectory(filepath.Dir(path)); err != nil {
+		return Config{}, err
+	}
+	c := DefaultConfig()
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return c, err
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return c, err
+	}
+	_, writeErr := f.Write(append(b, '\n'))
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if err = errors.Join(writeErr, syncErr, closeErr); err != nil {
+		return c, err
+	}
+	return c, syncDirectory(filepath.Dir(path))
+}
+
+// ParseEnvironmentFile implements a deliberately bounded subset of systemd
+// EnvironmentFile syntax: one assignment per line, optional whole-value quotes,
+// no continuations or escapes. Unsupported syntax fails instead of being
+// interpreted differently by the updater and the service. No shell is used.
+func ParseEnvironmentFile(data []byte) (map[string]string, error) {
+	if len(data) > 1<<20 {
+		return nil, errors.New("environment file exceeds 1 MiB")
+	}
+	values := make(map[string]string)
+	for n, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if !ok || !envName.MatchString(key) || strings.ContainsAny(value, "\\\x00\r") {
+			return nil, fmt.Errorf("unsupported environment syntax on line %d", n+1)
+		}
+		if strings.HasPrefix(value, "\"") || strings.HasPrefix(value, "'") {
+			quote := value[0]
+			if len(value) < 2 || value[len(value)-1] != quote || strings.ContainsRune(value[1:len(value)-1], rune(quote)) {
+				return nil, fmt.Errorf("unsupported environment quoting on line %d", n+1)
+			}
+			value = value[1 : len(value)-1]
+		} else if strings.ContainsAny(value, "\"'") {
+			return nil, fmt.Errorf("unsupported environment quoting on line %d", n+1)
+		}
+		if _, exists := values[key]; exists {
+			return nil, fmt.Errorf("duplicate environment variable %s", key)
+		}
+		values[key] = value
+	}
+	return values, nil
+}
+
+var envName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)

--- a/internal/hostupgrade/files.go
+++ b/internal/hostupgrade/files.go
@@ -1,0 +1,162 @@
+package hostupgrade
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func trustedDirectory(path string) error {
+	if !safePath(path) && path != "/" {
+		return fmt.Errorf("invalid trusted directory %q", path)
+	}
+	for current := path; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0022 != 0 || fileOwner(info) != 0 {
+			return fmt.Errorf("directory %s must be root-owned and not group/world writable", current)
+		}
+		if current == "/" {
+			return nil
+		}
+	}
+}
+
+func trustedFile(path string) error {
+	if !safePath(path) {
+		return fmt.Errorf("invalid trusted file %q", path)
+	}
+	if err := trustedDirectory(filepath.Dir(path)); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0022 != 0 || fileOwner(info) != 0 {
+		return fmt.Errorf("file %s must be a regular root-owned file without group/world write permissions", path)
+	}
+	return nil
+}
+
+func syncDirectory(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return errors.Join(f.Sync(), f.Close())
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	if err := trustedDirectory(filepath.Dir(path)); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() || fileOwner(info) != 0 {
+			return fmt.Errorf("unsafe existing destination %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), ".hikyo-upgrade-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if err = f.Chmod(mode); err != nil {
+		f.Close()
+		return err
+	}
+	_, writeErr := f.Write(data)
+	err = errors.Join(writeErr, f.Sync(), f.Close())
+	if err != nil {
+		return err
+	}
+	if err = os.Rename(f.Name(), path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func fileDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("binary is not a regular file")
+	}
+	h := sha256.New()
+	n, err := io.Copy(h, io.LimitReader(f, 512<<20+1))
+	if err != nil {
+		return "", err
+	}
+	if n > 512<<20 {
+		return "", errors.New("binary exceeds 512 MiB")
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func validDigest(s string) bool {
+	b, err := hex.DecodeString(s)
+	return err == nil && len(b) == sha256.Size && s == hex.EncodeToString(b)
+}
+
+// copyBinary hashes the exact opened bytes before the atomic rename. The
+// authenticated digest comes from the parent's independently verified release.
+func copyBinary(source, destination, digest string) error {
+	if !validDigest(digest) {
+		return errors.New("invalid expected binary SHA-256")
+	}
+	if err := trustedFile(source); err != nil {
+		return err
+	}
+	if err := trustedDirectory(filepath.Dir(destination)); err != nil {
+		return err
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.CreateTemp(filepath.Dir(destination), ".hikyo-binary-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(out.Name())
+	h := sha256.New()
+	n, copyErr := io.Copy(io.MultiWriter(out, h), io.LimitReader(in, 512<<20+1))
+	if copyErr != nil || n > 512<<20 || hex.EncodeToString(h.Sum(nil)) != digest {
+		out.Close()
+		return errors.Join(copyErr, errors.New("candidate binary size or SHA-256 mismatch"))
+	}
+	if err = out.Chmod(0755); err != nil {
+		out.Close()
+		return err
+	}
+	if err = errors.Join(out.Sync(), out.Close()); err != nil {
+		return err
+	}
+	if _, err = os.Lstat(destination); err == nil {
+		if err = trustedFile(destination); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err = os.Rename(out.Name(), destination); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(destination))
+}

--- a/internal/hostupgrade/host.go
+++ b/internal/hostupgrade/host.go
@@ -1,0 +1,742 @@
+package hostupgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type command struct {
+	path      string
+	args      []string
+	env       []string
+	directory string
+	runtime   bool
+	uid, gid  uint32
+	rootKey   string
+}
+
+type boundedOutput struct{ bytes []byte }
+
+func (b *boundedOutput) Write(p []byte) (int, error) {
+	if len(b.bytes)+len(p) > 1<<20 {
+		return 0, errors.New("command output exceeds 1 MiB")
+	}
+	b.bytes = append(b.bytes, p...)
+	return len(p), nil
+}
+
+// Host exposes fixed deployment operations only. Root-owned configuration is
+// authoritative. The caller must authenticate releases and drive a durable
+// journal before any migration operation.
+type Host struct {
+	config       Config
+	uid, gid     uint32
+	env          map[string]string
+	run          func(context.Context, command) ([]byte, error)
+	client       *http.Client
+	cgroup       string
+	databasePath string
+	// Internal path injection is for isolated adapter acceptance tests only.
+	systemdDirectory string
+	runtimeDirectory string
+}
+
+func New(c Config) (*Host, error) {
+	if runtime.GOOS != "linux" {
+		return nil, errors.New("automatic host upgrades currently require Linux systemd")
+	}
+	if os.Geteuid() != 0 {
+		return nil, errors.New("automatic host upgrades require sudo hikyo upgrade")
+	}
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	u, err := user.Lookup(c.User)
+	if err != nil {
+		return nil, err
+	}
+	g, err := user.LookupGroup(c.Group)
+	if err != nil {
+		return nil, err
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil || uid == 0 {
+		return nil, errors.New("invalid runtime UID")
+	}
+	gid, err := strconv.ParseUint(g.Gid, 10, 32)
+	if err != nil || gid == 0 {
+		return nil, errors.New("invalid runtime GID")
+	}
+	return &Host{config: c, uid: uint32(uid), gid: uint32(gid), run: runCommand, client: &http.Client{Timeout: 3 * time.Second, Transport: &http.Transport{Proxy: nil}, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}}, nil
+}
+
+func (h *Host) Config() Config  { return h.config }
+func (h *Host) RuntimeUID() int { return int(h.uid) }
+func (h *Host) RuntimeGID() int { return int(h.gid) }
+func (h *Host) Environment() map[string]string {
+	result := make(map[string]string, len(h.env))
+	for k, v := range h.env {
+		result[k] = v
+	}
+	return result
+}
+
+// Preflight is read-only and must run before maintenance. PostgreSQL and HA
+// require a deployment-wide writer proof this single-unit adapter cannot give.
+func (h *Host) Preflight(ctx context.Context) error {
+	for _, p := range []string{h.config.EnvironmentFile, h.config.RootKeyFile, h.config.Binary, "/usr/bin/systemctl"} {
+		if err := trustedFile(p); err != nil {
+			return err
+		}
+	}
+	data, err := os.ReadFile(h.config.EnvironmentFile)
+	if err != nil {
+		return err
+	}
+	h.env, err = ParseEnvironmentFile(data)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(h.env["HIKYO_DB"], "sqlite:") || h.env["HIKYO_DB"] == "sqlite:" {
+		return errors.New("automatic systemd upgrade currently supports a local SQLite installation only")
+	}
+	dbPath := strings.TrimPrefix(h.env["HIKYO_DB"], "sqlite:")
+	if !filepath.IsAbs(dbPath) {
+		dbPath = filepath.Join(h.config.WorkingDirectory, dbPath)
+	}
+	if !safePath(dbPath) || !within(h.config.WorkingDirectory, dbPath) {
+		return errors.New("SQLite database must be a plain file under the configured working directory")
+	}
+	infoDB, err := os.Lstat(dbPath)
+	if err != nil {
+		return err
+	}
+	if !infoDB.Mode().IsRegular() {
+		return errors.New("SQLite database must be a regular file without symlinks")
+	}
+	h.databasePath = dbPath
+	if v := h.env["HIKYO_HA"]; v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil || enabled {
+			return errors.New("automatic systemd upgrade refuses HA deployments")
+		}
+	}
+	if h.env["HIKYO_ROOT_KEY"] != "" {
+		return errors.New("automatic upgrade requires the configured root-key file instead of HIKYO_ROOT_KEY")
+	}
+	info, err := os.Lstat(h.config.WorkingDirectory)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || fileOwner(info) != int(h.uid) || info.Mode().Perm()&0022 != 0 {
+		return errors.New("working directory must belong to the runtime user and not be group/world writable")
+	}
+	props, err := h.show(ctx, "User", "Group", "WorkingDirectory", "EnvironmentFiles", "ExecStart", "ExecStartPre", "ExecStartPost", "ExecStop", "ExecStopPost", "RootDirectory", "RootImage", "KillMode", "ControlGroup")
+	if err != nil {
+		return err
+	}
+	if err = validateUnit(h.config, props); err != nil {
+		return err
+	}
+	if err = h.validateUnitFiles(ctx); err != nil {
+		return err
+	}
+	h.cgroup = props["ControlGroup"]
+	if h.cgroup != "" && (!safePath(h.cgroup) || !strings.HasSuffix(h.cgroup, "/"+h.config.Unit)) {
+		return errors.New("unexpected systemd control group")
+	}
+	return nil
+}
+
+func (h *Host) fenceConfiguration() string {
+	return "[Unit]\nConditionPathExists=|!" + h.maintenanceFile() + "\nConditionPathExists=|" + h.startPermission() + "\n"
+}
+
+// An unrelated OR condition could satisfy systemd's trigger group while the
+// maintenance condition is false. A later reset could remove it entirely.
+// Refuse such unit configuration instead of weakening the reboot fence.
+func (h *Host) validateUnitFiles(ctx context.Context) error {
+	p, err := h.show(ctx, "FragmentPath", "DropInPaths")
+	if err != nil {
+		return err
+	}
+	paths := append([]string{p["FragmentPath"]}, strings.Fields(p["DropInPaths"])...)
+	for _, path := range paths {
+		if err := trustedFile(path); err != nil {
+			return err
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if info.Size() > 1<<20 {
+			return errors.New("systemd unit file exceeds 1 MiB")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if path == h.dropin("90-hikyo-upgrade-fence.conf") {
+			if string(data) != h.fenceConfiguration() {
+				return errors.New("systemd upgrade fence differs from configured maintenance condition")
+			}
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+				continue
+			}
+			if strings.HasSuffix(line, "\\") {
+				return errors.New("automatic upgrade requires systemd directives without line continuations")
+			}
+			key, value, ok := strings.Cut(line, "=")
+			if !ok {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if key == "ConditionPathExists" || strings.HasPrefix(key, "Condition") && strings.HasPrefix(value, "|") {
+				return errors.New("existing systemd condition could bypass the upgrade maintenance fence")
+			}
+		}
+	}
+	return nil
+}
+
+func validateUnit(c Config, p map[string]string) error {
+	for name, want := range map[string]string{"User": c.User, "Group": c.Group, "WorkingDirectory": c.WorkingDirectory, "KillMode": "control-group"} {
+		if p[name] != want {
+			return fmt.Errorf("systemd %s does not match fixed upgrade configuration", name)
+		}
+	}
+	for _, name := range []string{"ExecStartPre", "ExecStartPost", "ExecStop", "ExecStopPost", "RootDirectory", "RootImage"} {
+		if p[name] != "" {
+			return fmt.Errorf("automatic upgrade does not support systemd %s", name)
+		}
+	}
+	wantEnv := c.EnvironmentFile + " (ignore_errors=no)"
+	if p["EnvironmentFiles"] != wantEnv && p["EnvironmentFiles"] != wantEnv+" "+filepath.Join(c.StateDirectory, "runtime.env")+" (ignore_errors=no)" {
+		return errors.New("systemd EnvironmentFiles does not match fixed upgrade configuration")
+	}
+	// systemctl show's ExecStart includes state after the argv field. Match the
+	// complete argv field, not a substring that would admit an extra command.
+	start := p["ExecStart"]
+	prefix := "{ path=" + c.Binary + " ; argv[]=" + c.Binary + " server "
+	if !strings.HasPrefix(start, prefix) || strings.Count(start, "argv[]=") != 1 {
+		return errors.New("systemd ExecStart is not the configured hikyo server")
+	}
+	args, _, ok := strings.Cut(strings.TrimPrefix(start, prefix), " ;")
+	credential := "--root-key-file=/run/credentials/" + c.Unit + "/hikyo-root-key"
+	if !ok || (args != credential && args != "--auto-migrate=false "+credential && args != "--root-key-file=%d/hikyo-root-key" && args != "--auto-migrate=false --root-key-file=%d/hikyo-root-key") {
+		return errors.New("systemd ExecStart has unsupported arguments; use the configured root credential")
+	}
+	return nil
+}
+
+func (h *Host) PrepareDirectories() error {
+	for _, p := range []string{h.config.StateDirectory, h.config.CustodyDirectory, h.config.CandidateDirectory, h.config.PublicDirectory, h.config.InstallationDirectory} {
+		if err := trustedDirectory(filepath.Dir(p)); err != nil {
+			return err
+		}
+		mode := os.FileMode(0700)
+		owner := 0
+		if p == h.config.CandidateDirectory || p == h.config.PublicDirectory {
+			mode = 0755
+		}
+		if p == h.config.InstallationDirectory {
+			owner = int(h.uid)
+		}
+		if err := os.Mkdir(p, mode); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		info, err := os.Lstat(p)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() || (fileOwner(info) != 0 && fileOwner(info) != owner) || info.Mode().Perm()&0022 != 0 || info.Mode().Perm()&0077 != 0 && mode == 0700 {
+			return fmt.Errorf("unsafe upgrade directory %s", p)
+		}
+		if err = os.Chown(p, owner, int(h.gid)); err != nil {
+			return err
+		}
+		if err = os.Chmod(p, mode); err != nil {
+			return err
+		}
+		if err = syncDirectory(filepath.Dir(p)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *Host) maintenanceFile() string { return filepath.Join(h.config.StateDirectory, "maintenance") }
+func (h *Host) startPermission() string {
+	dir := h.runtimeDirectory
+	if dir == "" {
+		dir = "/run/hikyo-upgrader"
+	}
+	return filepath.Join(dir, h.config.Unit+"-start")
+}
+func (h *Host) dropin(name string) string {
+	dir := h.systemdDirectory
+	if dir == "" {
+		dir = "/etc/systemd/system"
+	}
+	return filepath.Join(dir, h.config.Unit+".d", name)
+}
+
+func (h *Host) writeDropin(name string, data []byte) error {
+	dir := filepath.Dir(h.dropin(name))
+	if err := trustedDirectory(filepath.Dir(dir)); err != nil {
+		return err
+	}
+	if err := os.Mkdir(dir, 0755); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	return atomicWrite(h.dropin(name), data, 0644)
+}
+
+func (h *Host) Maintenance() (bool, error) {
+	_, err := os.Lstat(h.maintenanceFile())
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// FenceAndStop first records maintenance and a persistent systemd condition,
+// then stops the whole control group. Reboot cannot resurrect the old writer.
+func (h *Host) FenceAndStop(ctx context.Context) error {
+	fence := h.fenceConfiguration()
+	if err := h.writeDropin("90-hikyo-upgrade-fence.conf", []byte(fence)); err != nil {
+		return err
+	}
+	if _, err := h.systemctl(ctx, "daemon-reload"); err != nil {
+		return err
+	}
+	// Install the boot condition before publishing its maintenance marker.
+	// A crash before this point has not changed the database or stopped the
+	// source. A crash after it cannot reboot an unfenced writer.
+	if err := atomicWrite(h.maintenanceFile(), []byte("upgrade in progress\n"), 0600); err != nil {
+		return err
+	}
+	if err := os.Remove(h.startPermission()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if _, err := h.systemctl(ctx, "stop", h.config.Unit); err != nil {
+		return err
+	}
+	return h.verifyStopped(ctx)
+}
+
+func (h *Host) verifyStopped(ctx context.Context) error {
+	p, err := h.show(ctx, "ActiveState", "MainPID", "ControlGroup")
+	if err != nil {
+		return err
+	}
+	if p["MainPID"] != "0" || (p["ActiveState"] != "inactive" && p["ActiveState"] != "failed") {
+		return errors.New("systemd unit still has a running writer")
+	}
+	group := h.cgroup
+	if p["ControlGroup"] != "" {
+		group = p["ControlGroup"]
+	}
+	if group != "" {
+		if !safePath(group) || !strings.HasSuffix(group, "/"+h.config.Unit) {
+			return errors.New("unexpected systemd control group")
+		}
+		if err := emptyControlGroup(filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(group, "/"))); err != nil {
+			return err
+		}
+	}
+	if h.databasePath != "" {
+		return noOpenDatabaseDescriptors("/proc", h.databasePath)
+	}
+	return nil
+}
+
+// Other local CLI/server processes may live outside the service's cgroup.
+// Refuse any open database descriptor before export or migration instead of
+// treating an inactive systemd unit as proof that every writer stopped.
+func noOpenDatabaseDescriptors(proc, database string) error {
+	processes, err := os.ReadDir(proc)
+	if err != nil {
+		return err
+	}
+	for _, process := range processes {
+		if !process.IsDir() {
+			continue
+		}
+		if _, err := strconv.ParseUint(process.Name(), 10, 32); err != nil {
+			continue
+		}
+		fdDir := filepath.Join(proc, process.Name(), "fd")
+		descriptors, err := os.ReadDir(fdDir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("cannot establish local SQLite writer stop: %w", err)
+		}
+		for _, descriptor := range descriptors {
+			path, err := os.Readlink(filepath.Join(fdDir, descriptor.Name()))
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("cannot inspect local database descriptor: %w", err)
+			}
+			path = strings.TrimSuffix(path, " (deleted)")
+			if path == database || path == database+"-wal" || path == database+"-shm" {
+				return fmt.Errorf("process %s still has the SQLite database open", process.Name())
+			}
+		}
+	}
+	return nil
+}
+
+func emptyControlGroup(root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return errors.New("unexpected symlink in systemd control group")
+		}
+		if entry.Name() == "cgroup.procs" {
+			b, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(b)) != "" {
+				return errors.New("systemd control group still contains writers")
+			}
+		}
+		return nil
+	})
+}
+
+type RuntimeEvidence struct {
+	BundleDirectory      string
+	OperatorPublicKey    string
+	EvidenceDirectory    string
+	CiphertextPath       string
+	TargetManifest       string
+	LegacyWritersStopped bool
+}
+
+func (h *Host) runtimeEnvironment(e RuntimeEvidence) (map[string]string, error) {
+	values := h.Environment()
+	for k := range values {
+		if strings.HasPrefix(k, "HIKYO_UPGRADE_") {
+			delete(values, k)
+		}
+	}
+	for key, path := range map[string]string{"HIKYO_UPGRADE_BUNDLE": e.BundleDirectory, "HIKYO_UPGRADE_OPERATOR_PUBLIC_KEY": e.OperatorPublicKey, "HIKYO_UPGRADE_EVIDENCE": e.EvidenceDirectory, "HIKYO_UPGRADE_BACKUP": e.CiphertextPath} {
+		if path == "" {
+			continue
+		}
+		if !safePath(path) || !within(h.config.PublicDirectory, path) {
+			return nil, fmt.Errorf("%s must be under the configured public upgrade directory", key)
+		}
+		values[key] = path
+	}
+	if e.BundleDirectory == "" || e.OperatorPublicKey == "" {
+		return nil, errors.New("runtime upgrade requires bundle and operator public key")
+	}
+	if e.TargetManifest != "" && !validDigest(e.TargetManifest) {
+		return nil, errors.New("invalid target manifest digest")
+	}
+	if e.TargetManifest != "" {
+		values["HIKYO_UPGRADE_TARGET_MANIFEST"] = e.TargetManifest
+	}
+	values["HIKYO_UPGRADE_STATE_DIR"] = h.config.InstallationDirectory
+	if e.LegacyWritersStopped {
+		values["HIKYO_UPGRADE_LEGACY_WRITERS_STOPPED"] = "true"
+	}
+	values["HIKYO_ROOT_KEY_FILE"] = "/proc/self/fd/3"
+	return values, nil
+}
+
+type ExportRequest struct {
+	OutputDirectory string
+	Recipient       string
+	Runtime         RuntimeEvidence
+}
+
+func (h *Host) Export(ctx context.Context, candidate string, request ExportRequest) ([]byte, error) {
+	if !safePath(request.OutputDirectory) || !within(h.config.PublicDirectory, request.OutputDirectory) {
+		return nil, errors.New("backup output must be inside the configured public upgrade directory")
+	}
+	if request.Recipient == "" || strings.ContainsAny(request.Recipient, "\x00\n\r") {
+		return nil, errors.New("missing or invalid backup recipient")
+	}
+	return h.runRuntime(ctx, candidate, []string{"backup", "upgrade-export", "--json", "--out", request.OutputDirectory, "--recipient", request.Recipient}, request.Runtime)
+}
+
+func (h *Host) Migrate(ctx context.Context, candidate string, e RuntimeEvidence) ([]byte, error) {
+	return h.runRuntime(ctx, candidate, []string{"migrate"}, e)
+}
+
+func (h *Host) runRuntime(ctx context.Context, candidate string, args []string, e RuntimeEvidence) ([]byte, error) {
+	if !within(h.config.CandidateDirectory, candidate) || filepath.Dir(candidate) != h.config.CandidateDirectory {
+		return nil, errors.New("runtime command requires a staged candidate")
+	}
+	if err := trustedFile(candidate); err != nil {
+		return nil, err
+	}
+	if active, err := h.Maintenance(); err != nil || !active {
+		return nil, errors.Join(err, errors.New("runtime preparation requires durable maintenance"))
+	}
+	if err := h.verifyStopped(ctx); err != nil {
+		return nil, err
+	}
+	values, err := h.runtimeEnvironment(e)
+	if err != nil {
+		return nil, err
+	}
+	return h.run(ctx, command{path: candidate, args: args, env: environmentList(values), directory: h.config.WorkingDirectory, runtime: true, uid: h.uid, gid: h.gid, rootKey: h.config.RootKeyFile})
+}
+
+func environmentList(values map[string]string) []string {
+	// Do not inherit sudo, loader, signing passwords, or operator shell state.
+	result := []string{"PATH=/usr/bin:/bin", "LANG=C.UTF-8"}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		if strings.HasPrefix(k, "HIKYO_") {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		result = append(result, k+"="+values[k])
+	}
+	return result
+}
+
+func (h *Host) StageCandidate(source, digest string) (string, error) {
+	if !validDigest(digest) {
+		return "", errors.New("invalid candidate SHA-256")
+	}
+	destination := filepath.Join(h.config.CandidateDirectory, "hikyo-"+digest)
+	return destination, copyBinary(source, destination, digest)
+}
+
+func (h *Host) InstallBinary(ctx context.Context, candidate, digest string) error {
+	if filepath.Dir(candidate) != h.config.CandidateDirectory {
+		return errors.New("binary installation requires a staged candidate")
+	}
+	if active, err := h.Maintenance(); err != nil || !active {
+		return errors.Join(err, errors.New("binary installation requires durable maintenance"))
+	}
+	if err := h.verifyStopped(ctx); err != nil {
+		return err
+	}
+	return copyBinary(candidate, h.config.Binary, digest)
+}
+
+func (h *Host) ConfigureRuntime(ctx context.Context, e RuntimeEvidence) error {
+	values, err := h.runtimeEnvironment(e)
+	if err != nil {
+		return err
+	}
+	// Absence in this later EnvironmentFile would leave old evidence active.
+	for _, key := range []string{"HIKYO_UPGRADE_BUNDLE", "HIKYO_UPGRADE_OPERATOR_PUBLIC_KEY", "HIKYO_UPGRADE_EVIDENCE", "HIKYO_UPGRADE_BACKUP", "HIKYO_UPGRADE_OPERATOR_INSTANCE", "HIKYO_UPGRADE_TARGET_MANIFEST", "HIKYO_UPGRADE_LEGACY_WRITERS_STOPPED"} {
+		if _, exists := values[key]; !exists {
+			values[key] = ""
+		}
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		if strings.HasPrefix(k, "HIKYO_UPGRADE_") {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var env strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&env, "%s=%s\n", k, values[k])
+	}
+	if err = atomicWrite(filepath.Join(h.config.StateDirectory, "runtime.env"), []byte(env.String()), 0600); err != nil {
+		return err
+	}
+	dropin := "[Service]\nEnvironmentFile=" + filepath.Join(h.config.StateDirectory, "runtime.env") + "\nReadWritePaths=" + h.config.PublicDirectory + " " + h.config.InstallationDirectory + "\nLoadCredential=hikyo-root-key:" + h.config.RootKeyFile + "\nExecStart=\nExecStart=" + h.config.Binary + " server --auto-migrate=false --root-key-file=%d/hikyo-root-key\n"
+	if err = h.writeDropin("91-hikyo-upgrade-runtime.conf", []byte(dropin)); err != nil {
+		return err
+	}
+	_, err = h.systemctl(ctx, "daemon-reload")
+	return err
+}
+
+// StartCandidate permits this boot only. The persistent maintenance condition
+// survives a host reboot until Complete follows the caller's exact DB check.
+func (h *Host) StartCandidate(ctx context.Context, digest string, requireReady bool, timeout time.Duration) (err error) {
+	if !validDigest(digest) || timeout <= 0 || timeout > 10*time.Minute {
+		return errors.New("invalid candidate health check parameters")
+	}
+	if active, e := h.Maintenance(); e != nil || !active {
+		return errors.Join(e, errors.New("candidate start requires durable maintenance"))
+	}
+	if err = os.Mkdir(filepath.Dir(h.startPermission()), 0700); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	if err = atomicWrite(h.startPermission(), []byte("temporary candidate start\n"), 0600); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			cleanup, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+			err = errors.Join(err, h.FenceAndStop(cleanup))
+		}
+	}()
+	if _, err = h.systemctl(ctx, "start", h.config.Unit); err != nil {
+		return err
+	}
+	check, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err = h.checkCandidate(check, digest, requireReady); err == nil {
+			return nil
+		}
+		select {
+		case <-check.Done():
+			return fmt.Errorf("candidate health check: %w", check.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (h *Host) checkCandidate(ctx context.Context, digest string, requireReady bool) error {
+	p, err := h.show(ctx, "ActiveState", "MainPID")
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.ParseUint(p["MainPID"], 10, 32)
+	if err != nil || pid == 0 || p["ActiveState"] != "active" {
+		return errors.New("candidate service is not active")
+	}
+	actual, err := fileDigest(filepath.Join("/proc", strconv.FormatUint(pid, 10), "exe"))
+	if err != nil || actual != digest {
+		return errors.Join(err, errors.New("running service binary does not match authenticated candidate"))
+	}
+	if err = h.checkHTTP(ctx, strings.TrimSuffix(h.config.HealthURL, "/readyz")+"/healthz", http.StatusOK); err != nil {
+		return err
+	}
+	status := http.StatusServiceUnavailable
+	if requireReady {
+		status = http.StatusOK
+	}
+	if err = h.checkHTTP(ctx, h.config.HealthURL, status); err != nil {
+		return err
+	}
+	// Re-read PID after HTTP probes so a replacement process cannot borrow a
+	// previous candidate's identity check.
+	after, err := h.show(ctx, "ActiveState", "MainPID")
+	if err != nil {
+		return err
+	}
+	if after["MainPID"] != p["MainPID"] || after["ActiveState"] != "active" {
+		return errors.New("candidate restarted during health check")
+	}
+	return nil
+}
+
+func (h *Host) checkHTTP(ctx context.Context, url string, status int) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	response, err := h.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+	if response.StatusCode != status {
+		return fmt.Errorf("candidate health endpoint returned %d, expected %d", response.StatusCode, status)
+	}
+	return nil
+}
+
+// Complete may only be called after the coordinator validates the exact final
+// database identity and healthy phase. It never performs a rollback.
+func (h *Host) Complete(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.Remove(h.maintenanceFile()); err != nil {
+		return err
+	}
+	if err := syncDirectory(h.config.StateDirectory); err != nil {
+		return err
+	}
+	if err := os.Remove(h.startPermission()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (h *Host) systemctl(ctx context.Context, args ...string) ([]byte, error) {
+	bounded, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	output, err := h.run(bounded, command{path: "/usr/bin/systemctl", args: append([]string{"--no-pager", "--no-ask-password"}, args...), env: []string{"PATH=/usr/bin:/bin", "LANG=C"}})
+	if err != nil {
+		return nil, fmt.Errorf("systemd %s: %w", args[0], err)
+	}
+	return output, nil
+}
+
+func (h *Host) show(ctx context.Context, properties ...string) (map[string]string, error) {
+	output, err := h.systemctl(ctx, "show", "--all", "--property="+strings.Join(properties, ","), h.config.Unit)
+	if err != nil {
+		return nil, err
+	}
+	values := make(map[string]string, len(properties))
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, errors.New("invalid systemd property output")
+		}
+		if _, exists := values[key]; exists {
+			if key == "EnvironmentFiles" {
+				// systemctl emits one line per EnvironmentFile, preserving order.
+				values[key] += " " + value
+				continue
+			}
+			return nil, errors.New("duplicate systemd property")
+		}
+		values[key] = value
+	}
+	for _, key := range properties {
+		if _, ok := values[key]; !ok {
+			// systemctl omits empty Exec* command arrays even with --all.
+			// Nonempty arrays are emitted and rejected by validateUnit; other
+			// omitted properties still indicate an unsupported manager response.
+			switch key {
+			case "ExecStartPre", "ExecStartPost", "ExecStop", "ExecStopPost":
+				values[key] = ""
+				continue
+			}
+			return nil, fmt.Errorf("systemd omitted required property %s", key)
+		}
+	}
+	return values, nil
+}

--- a/internal/hostupgrade/host_linux_test.go
+++ b/internal/hostupgrade/host_linux_test.go
@@ -1,0 +1,263 @@
+//go:build linux
+
+package hostupgrade
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func rootTestHost(t *testing.T) *Host {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("root filesystem acceptance requires Linux root")
+	}
+	base, err := os.MkdirTemp("/root", "hikyo-host-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(base) })
+	c := DefaultConfig()
+	c.StateDirectory = filepath.Join(base, "state")
+	c.CustodyDirectory = filepath.Join(base, "keys")
+	c.CandidateDirectory = filepath.Join(base, "candidates")
+	c.PublicDirectory = filepath.Join(base, "public")
+	c.InstallationDirectory = filepath.Join(base, "installation")
+	h := &Host{config: c, uid: 65534, gid: 65534, systemdDirectory: filepath.Join(base, "systemd"), runtimeDirectory: filepath.Join(base, "run")}
+	if err := os.Mkdir(h.systemdDirectory, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.PrepareDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestLinuxStopFailureLeavesDurableFence(t *testing.T) {
+	h := rootTestHost(t)
+	var operations []string
+	h.run = func(_ context.Context, c command) ([]byte, error) {
+		op := c.args[2]
+		operations = append(operations, op)
+		if op == "stop" {
+			return nil, errors.New("stop failed")
+		}
+		return nil, nil
+	}
+	if err := h.FenceAndStop(context.Background()); err == nil {
+		t.Fatal("ignored stop failure")
+	}
+	if active, err := h.Maintenance(); err != nil || !active {
+		t.Fatalf("lost fence: %v", err)
+	}
+	b, err := os.ReadFile(h.dropin("90-hikyo-upgrade-fence.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "ConditionPathExists=|!"+h.maintenanceFile()) || !strings.Contains(string(b), "ConditionPathExists=|"+h.startPermission()) {
+		t.Fatalf("bad reboot fence: %s", b)
+	}
+	if strings.Join(operations, ",") != "daemon-reload,stop" {
+		t.Fatalf("unexpected operations: %v", operations)
+	}
+}
+
+func TestLinuxCancelledStartUsesFreshStopContext(t *testing.T) {
+	h := rootTestHost(t)
+	h.run = func(ctx context.Context, c command) ([]byte, error) {
+		switch c.args[2] {
+		case "show":
+			return []byte("ActiveState=inactive\nMainPID=0\nControlGroup=\n"), nil
+		case "start":
+			return nil, ctx.Err()
+		case "stop":
+			if ctx.Err() != nil {
+				t.Fatal("cleanup inherited the canceled context")
+			}
+		}
+		return nil, nil
+	}
+	if err := h.FenceAndStop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := h.StartCandidate(ctx, strings.Repeat("a", 64), true, time.Second); err == nil {
+		t.Fatal("accepted canceled start")
+	}
+	if active, err := h.Maintenance(); err != nil || !active {
+		t.Fatal("lost durable maintenance")
+	}
+	if _, err := os.Lstat(h.startPermission()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("temporary restart permission survived failure")
+	}
+}
+
+func TestLinuxHealthyCandidateWaitsForCoordinatorCompletion(t *testing.T) {
+	for _, ready := range []bool{false, true} {
+		t.Run(strconv.FormatBool(ready), func(t *testing.T) {
+			h := rootTestHost(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/readyz" && !ready {
+					w.WriteHeader(http.StatusServiceUnavailable)
+				}
+			}))
+			defer server.Close()
+			h.config.HealthURL = server.URL + "/readyz"
+			h.client = server.Client()
+			active := false
+			h.run = func(_ context.Context, c command) ([]byte, error) {
+				switch c.args[2] {
+				case "start":
+					active = true
+				case "stop":
+					active = false
+				case "show":
+					if active {
+						return []byte("ActiveState=active\nMainPID=" + strconv.Itoa(os.Getpid()) + "\nControlGroup=\n"), nil
+					}
+					return []byte("ActiveState=inactive\nMainPID=0\nControlGroup=\n"), nil
+				}
+				return nil, nil
+			}
+			if err := h.FenceAndStop(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			digest, err := fileDigest("/proc/self/exe")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = h.StartCandidate(context.Background(), digest, ready, time.Second); err != nil {
+				t.Fatal(err)
+			}
+			if maintained, err := h.Maintenance(); err != nil || !maintained {
+				t.Fatal("candidate cleared maintenance before coordinator DB check")
+			}
+			if err = h.Complete(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if maintained, _ := h.Maintenance(); maintained {
+				t.Fatal("completion did not clear maintenance")
+			}
+		})
+	}
+}
+
+func TestLinuxCandidateDigestMismatchFencesAndStops(t *testing.T) {
+	h := rootTestHost(t)
+	active := false
+	h.run = func(_ context.Context, c command) ([]byte, error) {
+		switch c.args[2] {
+		case "start":
+			active = true
+		case "stop":
+			active = false
+		case "show":
+			if active {
+				return []byte("ActiveState=active\nMainPID=" + strconv.Itoa(os.Getpid()) + "\nControlGroup=\n"), nil
+			}
+			return []byte("ActiveState=inactive\nMainPID=0\nControlGroup=\n"), nil
+		}
+		return nil, nil
+	}
+	if err := h.FenceAndStop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.StartCandidate(context.Background(), strings.Repeat("b", 64), true, 20*time.Millisecond); err == nil {
+		t.Fatal("accepted a different executable")
+	}
+	if active {
+		t.Fatal("wrong executable still running")
+	}
+	if maintained, _ := h.Maintenance(); !maintained {
+		t.Fatal("lost durable fence")
+	}
+}
+
+func TestLinuxPublicFilesNeverFollowRuntimeSymlinks(t *testing.T) {
+	h := rootTestHost(t)
+	secret := filepath.Join(h.config.StateDirectory, "secret")
+	if err := os.WriteFile(secret, []byte("untouched"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(h.config.PublicDirectory, "receipt.json")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.PublishPublicEvidence("receipt.json", []byte("replacement")); err == nil {
+		t.Fatal("followed evidence symlink")
+	}
+	b, err := os.ReadFile(secret)
+	if err != nil || string(b) != "untouched" {
+		t.Fatal("modified private file")
+	}
+	source := filepath.Join(h.config.StateDirectory, "source")
+	if err = os.Mkdir(source, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.Symlink(secret, filepath.Join(source, "payload")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = h.StagePublicBundle(source); err == nil {
+		t.Fatal("followed source bundle symlink")
+	}
+}
+
+func TestLinuxRuntimeCredentialReadableOnlyByRuntimeUser(t *testing.T) {
+	h := rootTestHost(t)
+	keyPath := filepath.Join(h.config.StateDirectory, "root.key")
+	if err := os.WriteFile(keyPath, []byte(strings.Repeat("a", 64)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := runtimeCredential(keyPath, h.uid, h.gid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileOwner(info) != int(h.uid) || info.Mode().Perm() != 0600 {
+		t.Fatal("credential is not runtime-owned0600")
+	}
+	// Opening through /proc/self/fd exercises exactly the path ReadRootKey
+	// will use after credentials change, without copying a key onto disk.
+	b, err := os.ReadFile("/proc/self/fd/" + strconv.Itoa(int(f.Fd())))
+	if err != nil || len(b) != 64 {
+		t.Fatalf("credential fd not readable: %v", err)
+	}
+	child, err := runCommand(context.Background(), command{path: "/bin/cat", args: []string{"/proc/self/fd/3"}, env: []string{"PATH=/usr/bin:/bin"}, runtime: true, uid: h.uid, gid: h.gid, rootKey: keyPath})
+	if err != nil || string(child) != strings.Repeat("a", 64) {
+		t.Fatalf("runtime UID cannot reopen credential fd: %v", err)
+	}
+}
+
+func TestLinuxExistingConditionsCannotBypassFence(t *testing.T) {
+	h := rootTestHost(t)
+	unit := filepath.Join(h.systemdDirectory, h.config.Unit)
+	h.run = func(context.Context, command) ([]byte, error) {
+		return []byte("FragmentPath=" + unit + "\nDropInPaths=\n"), nil
+	}
+	for _, condition := range []string{"ConditionPathExists=", "ConditionPathExists=/somewhere", "ConditionUser=|root", "ConditionUser=\\\n |root"} {
+		if err := os.WriteFile(unit, []byte("[Unit]\n"+condition+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := h.validateUnitFiles(context.Background()); err == nil {
+			t.Fatalf("accepted fence bypass %q", condition)
+		}
+	}
+	if err := os.WriteFile(unit, []byte("[Unit]\nConditionUser=root\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.validateUnitFiles(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/hostupgrade/host_linux_test.go
+++ b/internal/hostupgrade/host_linux_test.go
@@ -261,3 +261,50 @@ func TestLinuxExistingConditionsCannotBypassFence(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestLinuxPrunePublicKeepsOnlyReferencedEvidence(t *testing.T) {
+	h := rootTestHost(t)
+	public := h.config.PublicDirectory
+	mk := func(name string) string {
+		path := filepath.Join(public, name)
+		if err := os.MkdirAll(filepath.Join(path, "inner"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	keptBundle, keptEvidence, keptBackup := mk("bundle-current"), mk("evidence-current"), mk("backup-current")
+	for _, stale := range []string{"bundle-old", "evidence-old", "backup-old"} {
+		mk(stale)
+	}
+	// A runtime-owned symlink inside a stale backup must never be followed.
+	secret := filepath.Join(h.config.StateDirectory, "secret")
+	if err := os.WriteFile(secret, []byte("untouched"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(h.config.StateDirectory, filepath.Join(public, "backup-old", "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.PublishPublicEvidence("operator.pub", []byte("public key")); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.PrunePublic(RuntimeEvidence{BundleDirectory: keptBundle, EvidenceDirectory: keptEvidence, CiphertextPath: filepath.Join(keptBackup, "backup.age")}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := []string{}
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if strings.Join(names, ",") != "backup-current,bundle-current,evidence-current,operator.pub" {
+		t.Fatalf("unexpected public directory after prune: %v", names)
+	}
+	if raw, err := os.ReadFile(secret); err != nil || string(raw) != "untouched" {
+		t.Fatal("prune followed a symlink out of the public directory", err)
+	}
+	if err := h.PrunePublic(RuntimeEvidence{BundleDirectory: filepath.Join(h.config.StateDirectory, "bundle-x")}); err == nil {
+		t.Fatal("accepted retained evidence outside the public directory")
+	}
+}

--- a/internal/hostupgrade/host_test.go
+++ b/internal/hostupgrade/host_test.go
@@ -1,0 +1,186 @@
+package hostupgrade
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestConfigRejectsAuthorityAndEndpointInjection(t *testing.T) {
+	if err := DefaultConfig().Validate(); err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]func(*Config){
+		"arbitrary service":         func(c *Config) { c.Unit = "sshd.service" },
+		"argument injection":        func(c *Config) { c.Unit = "hikyo.service --all" },
+		"root runtime":              func(c *Config) { c.User = "root" },
+		"path traversal":            func(c *Config) { c.Binary = "/usr/bin/../bin/hikyo" },
+		"systemd specifier":         func(c *Config) { c.Binary = "/usr/bin/%n" },
+		"private inside writable":   func(c *Config) { c.CustodyDirectory = c.WorkingDirectory + "/keys" },
+		"candidate inside writable": func(c *Config) { c.CandidateDirectory = c.PublicDirectory + "/bin" },
+		"remote health":             func(c *Config) { c.HealthURL = "http://192.0.2.1:8081/readyz" },
+		"DNS health":                func(c *Config) { c.HealthURL = "http://localhost:8081/readyz" },
+		"health userinfo":           func(c *Config) { c.HealthURL = "http://user@127.0.0.1:8081/readyz" },
+		"wrong probe":               func(c *Config) { c.HealthURL = "http://127.0.0.1:8081/healthz" },
+	}
+	for name, change := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := DefaultConfig()
+			change(&c)
+			if err := c.Validate(); err == nil {
+				t.Fatal("accepted unsafe config")
+			}
+		})
+	}
+}
+
+func TestEnvironmentIsDataNeverShellCode(t *testing.T) {
+	values, err := ParseEnvironmentFile([]byte("# comment\nHIKYO_DB = 'sqlite:/var/lib/hikyo/db.sqlite'\nHIKYO_EXTERNAL_ORIGIN=\"https://example.test\"\nLITERAL=$(touch /tmp/not-executed)\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["HIKYO_DB"] != "sqlite:/var/lib/hikyo/db.sqlite" || values["LITERAL"] != "$(touch /tmp/not-executed)" {
+		t.Fatalf("unexpected parsing: %#v", values)
+	}
+	for _, input := range []string{"export HIKYO_DB=sqlite:x", "HIKYO_DB=one\nHIKYO_DB=two", "HIKYO_DB=\"unterminated", "HIKYO_DB=one\\\ntwo", "HIKYO_DB=foo\"bar\"", "HIKYO_DB=bad\x00value"} {
+		if _, err := ParseEnvironmentFile([]byte(input)); err == nil {
+			t.Fatalf("accepted %q", input)
+		}
+	}
+}
+
+func standardProperties() map[string]string {
+	c := DefaultConfig()
+	return map[string]string{"User": c.User, "Group": c.Group, "WorkingDirectory": c.WorkingDirectory, "EnvironmentFiles": c.EnvironmentFile + " (ignore_errors=no)", "ExecStart": "{ path=/usr/bin/hikyo ; argv[]=/usr/bin/hikyo server --root-key-file=/run/credentials/hikyo.service/hikyo-root-key ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "KillMode": "control-group"}
+}
+
+func TestUnitValidationRequiresExactDeployment(t *testing.T) {
+	if err := validateUnit(DefaultConfig(), standardProperties()); err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{"User": "root", "EnvironmentFiles": "/tmp/user-controlled.env (ignore_errors=no)", "KillMode": "process", "ExecStartPre": "/bin/sh -c arbitrary", "RootDirectory": "/other", "ExecStart": "{ path=/usr/bin/hikyo ; argv[]=/usr/bin/hikyo server --root-key-file=/run/credentials/hikyo.service/hikyo-root-key --dev ; ignore_errors=no }"}
+	for property, value := range cases {
+		t.Run(property, func(t *testing.T) {
+			p := standardProperties()
+			p[property] = value
+			if err := validateUnit(DefaultConfig(), p); err == nil {
+				t.Fatal("accepted changed unit")
+			}
+		})
+	}
+	p := standardProperties()
+	p["ExecStart"] += " { path=/bin/sh ; argv[]=/bin/sh -c unsafe ; }"
+	if err := validateUnit(DefaultConfig(), p); err == nil {
+		t.Fatal("accepted a second process")
+	}
+}
+
+func TestStoppedProofRefusesSurvivingUnitWriter(t *testing.T) {
+	for _, output := range []string{"ActiveState=active\nMainPID=123\nControlGroup=\n", "ActiveState=deactivating\nMainPID=0\nControlGroup=\n", "ActiveState=inactive\nMainPID=0\nControlGroup=/../../outside\n", "ActiveState=inactive\nControlGroup=\n"} {
+		h := &Host{config: DefaultConfig(), run: func(context.Context, command) ([]byte, error) { return []byte(output), nil }}
+		if err := h.verifyStopped(context.Background()); err == nil {
+			t.Fatalf("accepted incomplete stop: %q", output)
+		}
+	}
+	h := &Host{config: DefaultConfig(), run: func(context.Context, command) ([]byte, error) {
+		return []byte("ActiveState=inactive\nMainPID=0\nControlGroup=\n"), nil
+	}}
+	if err := h.verifyStopped(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCgroupProofIncludesDescendants(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "worker"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(dir, "worker", "cgroup.procs")
+	if err := os.WriteFile(child, []byte("8123\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := emptyControlGroup(dir); err == nil {
+		t.Fatal("accepted a surviving child writer")
+	}
+	if err := os.WriteFile(child, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := emptyControlGroup(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWriterProofChecksProcessesOutsideUnit(t *testing.T) {
+	root := t.TempDir()
+	fd := filepath.Join(root, "456", "fd")
+	if err := os.MkdirAll(fd, 0700); err != nil {
+		t.Fatal(err)
+	}
+	database := "/var/lib/hikyo/hikyo.db"
+	if err := os.Symlink(database+"-wal", filepath.Join(fd, "3")); err != nil {
+		t.Fatal(err)
+	}
+	if err := noOpenDatabaseDescriptors(root, database); err == nil {
+		t.Fatal("ignored external WAL writer")
+	}
+	if err := os.Remove(filepath.Join(fd, "3")); err != nil {
+		t.Fatal(err)
+	}
+	if err := noOpenDatabaseDescriptors(root, database); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSystemctlUsesFixedArgvAndReportsFailure(t *testing.T) {
+	wantErr := errors.New("exit status 1")
+	h := &Host{config: DefaultConfig(), run: func(ctx context.Context, c command) ([]byte, error) {
+		if c.path != "/usr/bin/systemctl" || !reflect.DeepEqual(c.args, []string{"--no-pager", "--no-ask-password", "stop", "hikyo.service"}) {
+			t.Fatalf("unexpected command: %#v", c)
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("systemctl command has no deadline")
+		}
+		return nil, wantErr
+	}}
+	if _, err := h.systemctl(context.Background(), "stop", h.config.Unit); !errors.Is(err, wantErr) {
+		t.Fatalf("stop failure lost: %v", err)
+	}
+}
+
+func TestRuntimeEnvironmentStripsOperatorSecretsAndStaleEvidence(t *testing.T) {
+	h := &Host{config: DefaultConfig(), env: map[string]string{"HIKYO_DB": "sqlite:/var/lib/hikyo/hikyo.db", "HIKYO_UPGRADE_OPERATOR_INSTANCE": "stale", "HIKYO_UPGRADE_BACKUP": "old", "COSIGN_PASSWORD": "operator-secret", "LD_PRELOAD": "/malicious.so"}}
+	e := RuntimeEvidence{BundleDirectory: h.config.PublicDirectory + "/bundle", OperatorPublicKey: h.config.PublicDirectory + "/operator.pub"}
+	values, err := h.runtimeEnvironment(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range environmentList(values) {
+		if strings.Contains(entry, "operator-secret") || strings.Contains(entry, "malicious") || strings.Contains(entry, "stale") || strings.HasPrefix(entry, "HIKYO_UPGRADE_BACKUP=") {
+			t.Fatalf("leaked environment %q", entry)
+		}
+	}
+	if values["HIKYO_ROOT_KEY_FILE"] != "/proc/self/fd/3" {
+		t.Fatal("root key is not delivered through the inherited descriptor")
+	}
+	e.BundleDirectory = "/etc/hikyo/upgrade-keys"
+	if _, err = h.runtimeEnvironment(e); err == nil {
+		t.Fatal("accepted private runtime bundle path")
+	}
+}
+
+func TestRuntimeCommandCannotSelectArbitraryExecutable(t *testing.T) {
+	h := &Host{config: DefaultConfig(), run: func(context.Context, command) ([]byte, error) { t.Fatal("ran an unapproved command"); return nil, nil }}
+	if _, err := h.Migrate(context.Background(), "/bin/sh", RuntimeEvidence{}); err == nil {
+		t.Fatal("accepted shell as migration target")
+	}
+	if _, err := h.Export(context.Background(), "/bin/sh", ExportRequest{OutputDirectory: "/etc/hikyo/upgrade-keys", Recipient: "age1recipient"}); err == nil {
+		t.Fatal("accepted private output")
+	}
+}

--- a/internal/hostupgrade/platform_linux.go
+++ b/internal/hostupgrade/platform_linux.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package hostupgrade
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func fileOwner(info os.FileInfo) int {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return -1
+	}
+	return int(stat.Uid)
+}
+
+func runCommand(ctx context.Context, request command) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, request.path, request.args...)
+	cmd.Env = request.env
+	cmd.Dir = request.directory
+	if request.runtime {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: request.uid, Gid: request.gid, Groups: []uint32{request.gid}}}
+		key, err := runtimeCredential(request.rootKey, request.uid, request.gid)
+		if err != nil {
+			return nil, err
+		}
+		defer key.Close()
+		cmd.ExtraFiles = []*os.File{key}
+	}
+	// Error output can contain operational configuration. The adapter returns
+	// stdout only; callers get the bounded operation and exit status on failure.
+	var output boundedOutput
+	cmd.Stdout = &output
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return output.bytes, nil
+}
+
+func runtimeCredential(path string, uid, gid uint32) (*os.File, error) {
+	if err := trustedFile(path); err != nil {
+		return nil, err
+	}
+	source, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer source.Close()
+	info, err := source.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return nil, errors.New("runtime root key must be mode 0600 or stricter")
+	}
+	fd, err := unix.MemfdCreate("hikyo-runtime-root-key", unix.MFD_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), "hikyo-runtime-root-key")
+	if err = f.Chmod(0600); err == nil {
+		err = f.Chown(int(uid), int(gid))
+	}
+	if err == nil {
+		var n int64
+		n, err = io.Copy(f, io.LimitReader(source, 4097))
+		if n > 4096 {
+			err = errors.New("runtime root key exceeds 4096 bytes")
+		}
+	}
+	if err == nil {
+		_, err = f.Seek(0, io.SeekStart)
+	}
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}

--- a/internal/hostupgrade/platform_other.go
+++ b/internal/hostupgrade/platform_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package hostupgrade
+
+import (
+	"context"
+	"errors"
+	"os"
+)
+
+func fileOwner(os.FileInfo) int { return -1 }
+func runCommand(context.Context, command) ([]byte, error) {
+	return nil, errors.New("automatic host upgrades require Linux systemd")
+}

--- a/internal/hostupgrade/public.go
+++ b/internal/hostupgrade/public.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 var publicName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$`)
@@ -128,4 +129,41 @@ func (h *Host) PreparePublicOutput(name string) (string, error) {
 		return "", err
 	}
 	return path, syncDirectory(h.config.PublicDirectory)
+}
+
+// PrunePublic removes the bundle-*, evidence-* and backup-* directories that
+// earlier upgrade runs left under the public directory, keeping only the
+// entries the given evidence still references. The caller passes the journal
+// of the run that just completed, so the retained encrypted backup is always
+// the one taken before the current schema. Other names are never touched.
+func (h *Host) PrunePublic(keep RuntimeEvidence) error {
+	if err := trustedDirectory(h.config.PublicDirectory); err != nil {
+		return err
+	}
+	retained := map[string]bool{}
+	for _, path := range []string{keep.BundleDirectory, keep.EvidenceDirectory, keep.CiphertextPath} {
+		if path == "" {
+			continue
+		}
+		if !safePath(path) || !within(h.config.PublicDirectory, path) || path == h.config.PublicDirectory {
+			return errors.New("retained upgrade evidence must be inside the public upgrade directory")
+		}
+		rel := strings.TrimPrefix(path, h.config.PublicDirectory+string(filepath.Separator))
+		retained[strings.SplitN(rel, string(filepath.Separator), 2)[0]] = true
+	}
+	entries, err := os.ReadDir(h.config.PublicDirectory)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		generated := strings.HasPrefix(name, "bundle-") || strings.HasPrefix(name, "evidence-") || strings.HasPrefix(name, "backup-")
+		if !generated || retained[name] || !entry.IsDir() {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(h.config.PublicDirectory, name)); err != nil {
+			return err
+		}
+	}
+	return syncDirectory(h.config.PublicDirectory)
 }

--- a/internal/hostupgrade/public.go
+++ b/internal/hostupgrade/public.go
@@ -1,0 +1,131 @@
+package hostupgrade
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var publicName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$`)
+
+// StagePublicBundle copies a verified private cache into a new root-owned
+// public directory. It never reuses a directory writable by the runtime user.
+// The caller must verify the published bytes before admitting a migration.
+func (h *Host) StagePublicBundle(source string) (string, error) {
+	if err := trustedDirectory(source); err != nil {
+		return "", err
+	}
+	if err := trustedDirectory(h.config.PublicDirectory); err != nil {
+		return "", err
+	}
+	destination, err := os.MkdirTemp(h.config.PublicDirectory, "bundle-")
+	if err != nil {
+		return "", err
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			os.RemoveAll(destination)
+		}
+	}()
+	var total int64
+	count := 0
+	directories := []string{destination}
+	err = filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == source {
+			return nil
+		}
+		count++
+		if count > 200000 {
+			return errors.New("upgrade bundle exceeds 200000 entries")
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, rel)
+		if entry.Type()&os.ModeSymlink != 0 {
+			return errors.New("upgrade bundle contains a symbolic link")
+		}
+		if entry.IsDir() {
+			if err = trustedDirectory(path); err != nil {
+				return err
+			}
+			if err = os.Mkdir(target, 0755); err != nil {
+				return err
+			}
+			directories = append(directories, target)
+			return nil
+		}
+		if err = trustedFile(path); err != nil {
+			return err
+		}
+		input, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer input.Close()
+		output, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if err != nil {
+			return err
+		}
+		n, copyErr := io.Copy(output, io.LimitReader(input, (8<<30)-total+1))
+		total += n
+		if err = errors.Join(copyErr, output.Sync(), output.Close()); err != nil {
+			return err
+		}
+		if total > 8<<30 {
+			return errors.New("upgrade bundle exceeds 8 GiB")
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if err = os.Chmod(destination, 0755); err != nil {
+		return "", err
+	}
+	for i := len(directories) - 1; i >= 0; i-- {
+		if err = syncDirectory(directories[i]); err != nil {
+			return "", err
+		}
+	}
+	if err = syncDirectory(h.config.PublicDirectory); err != nil {
+		return "", err
+	}
+	complete = true
+	return destination, nil
+}
+
+func (h *Host) PublishPublicEvidence(name string, raw []byte) (string, error) {
+	if !publicName.MatchString(name) || len(raw) == 0 || len(raw) > 1<<20 {
+		return "", errors.New("invalid public evidence name or size")
+	}
+	path := filepath.Join(h.config.PublicDirectory, name)
+	return path, atomicWrite(path, raw, 0644)
+}
+
+// PreparePublicOutput gives the runtime an empty leaf for backup export. Its
+// root-owned parent prevents renaming another upgrade's evidence into place.
+func (h *Host) PreparePublicOutput(name string) (string, error) {
+	if !publicName.MatchString(name) {
+		return "", errors.New("invalid output directory name")
+	}
+	if err := trustedDirectory(h.config.PublicDirectory); err != nil {
+		return "", err
+	}
+	path := filepath.Join(h.config.PublicDirectory, name)
+	if err := os.Mkdir(path, 0700); err != nil {
+		return "", fmt.Errorf("create fresh backup output: %w", err)
+	}
+	if err := os.Chown(path, int(h.uid), int(h.gid)); err != nil {
+		return "", err
+	}
+	return path, syncDirectory(h.config.PublicDirectory)
+}

--- a/internal/hostupgrade/real_systemd_linux_test.go
+++ b/internal/hostupgrade/real_systemd_linux_test.go
@@ -1,0 +1,165 @@
+//go:build linux
+
+package hostupgrade
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This test must run in the disposable PID-1 systemd container created by
+// scripts/ci/test-host-upgrade-systemd.sh. It never substitutes systemctl.
+func TestRealSystemdUpgrade(t *testing.T) {
+	if os.Getenv("HIKYO_REAL_SYSTEMD_ACCEPTANCE") != "1" {
+		t.Skip("requires the isolated real-systemd acceptance container")
+	}
+	pidOne, err := os.ReadFile("/proc/1/comm")
+	if err != nil || strings.TrimSpace(string(pidOne)) != "systemd" {
+		t.Fatal("acceptance requires actual systemd as PID 1")
+	}
+	ctx := t.Context()
+	c := DefaultConfig()
+	h, err := New(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(path, value string, mode os.FileMode) { t.Helper(); must(os.WriteFile(path, []byte(value), mode)) }
+	must(os.MkdirAll("/etc/hikyo", 0755))
+	must(os.MkdirAll(c.WorkingDirectory, 0700))
+	must(os.Chown(c.WorkingDirectory, int(h.uid), int(h.gid)))
+	must(os.MkdirAll("/var/backups/hikyo", 0700))
+	write(c.EnvironmentFile, "HIKYO_DB=sqlite:hikyo.db\n", 0600)
+	write(c.RootKeyFile, strings.Repeat("a", 64), 0600)
+	write(filepath.Join(c.WorkingDirectory, "hikyo.db"), "adapter-only database sentinel", 0600)
+	write(filepath.Join(c.WorkingDirectory, "ready"), "ready", 0644)
+	must(h.PrepareDirectories())
+	write(filepath.Join(c.CustodyDirectory, "operator.age"), "operator-only encrypted fixture", 0600)
+	digest, err := fileDigest("/host-upgrade-helper")
+	must(err)
+	must(copyBinary("/host-upgrade-helper", c.Binary, digest))
+	unit := `[Unit]
+Description=Hikyo adapter acceptance
+[Service]
+Type=simple
+User=hikyo
+Group=hikyo
+WorkingDirectory=/var/lib/hikyo
+EnvironmentFile=/etc/hikyo/hikyo.env
+LoadCredential=hikyo-root-key:/etc/hikyo/root.key
+ExecStart=/usr/bin/hikyo server --root-key-file=%d/hikyo-root-key
+Restart=on-failure
+RestartSec=1s
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectKernelLogs=true
+ProtectClock=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadWritePaths=/var/lib/hikyo /var/backups/hikyo
+[Install]
+WantedBy=multi-user.target
+`
+	write("/etc/systemd/system/hikyo.service", unit, 0644)
+	ctl := func(args ...string) { t.Helper(); _, err := h.systemctl(ctx, args...); must(err) }
+	ctl("daemon-reload")
+	ctl("start", c.Unit)
+	serialized, err := h.systemctl(ctx, "show", "--all", "--property=LoadCredential,ExecStartPre,ExecStartPost,ExecStop,ExecStopPost,DropInPaths,RootDirectory,RootImage,KillMode", c.Unit)
+	must(err)
+	t.Logf("systemd optional property serialization: %s", serialized)
+	t.Cleanup(func() { _, _ = h.systemctl(context.Background(), "stop", c.Unit) })
+	must(h.Preflight(ctx))
+	if h.cgroup == "" {
+		t.Fatal("real service has no cgroup")
+	}
+	initialDeadline := time.Now().Add(5 * time.Second)
+	for err = h.checkCandidate(ctx, digest, true); err != nil && time.Now().Before(initialDeadline); err = h.checkCandidate(ctx, digest, true) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	must(err)
+	t.Log("original hardened unit passed preflight with real systemd and a service cgroup")
+	must(h.FenceAndStop(ctx))
+	candidate, err := h.StageCandidate("/host-upgrade-helper", digest)
+	must(err)
+	pub, err := h.PublishPublicEvidence("operator.pub", []byte("public verification fixture"))
+	must(err)
+	evidence := RuntimeEvidence{BundleDirectory: c.PublicDirectory, OperatorPublicKey: pub}
+	t.Setenv("OPERATOR_PASSPHRASE", "must-not-reach-runtime")
+	output, err := h.Migrate(ctx, candidate, evidence)
+	must(err)
+	if !strings.Contains(string(output), `"credential":"verified"`) {
+		t.Fatal("runtime child did not verify descriptor custody")
+	}
+	outdir, err := h.PreparePublicOutput("export-test")
+	must(err)
+	_, err = h.Export(ctx, candidate, ExportRequest{OutputDirectory: outdir, Recipient: "fixture", Runtime: evidence})
+	must(err)
+	t.Log("real unprivileged migration/export children read memfd credential and could not read operator custody")
+	must(h.InstallBinary(ctx, candidate, digest))
+	must(h.ConfigureRuntime(ctx, evidence))
+	serialized, err = h.systemctl(ctx, "show", "--all", "--property=EnvironmentFiles,ExecStart", c.Unit)
+	must(err)
+	t.Logf("systemd generated runtime serialization: %s", serialized)
+	// A second preflight reads the actual systemd serialization of both files.
+	must(h.Preflight(ctx))
+	write(filepath.Join(c.WorkingDirectory, "ready"), "maintenance", 0644)
+	must(h.StartCandidate(ctx, digest, false, 5*time.Second))
+	must(h.FenceAndStop(ctx))
+	write(filepath.Join(c.WorkingDirectory, "ready"), "ready", 0644)
+	must(h.StartCandidate(ctx, digest, true, 5*time.Second))
+	t.Log("generated runtime and fence drop-ins passed intermediate 503 and final 200 readiness")
+	// A reboot discards /run. Reproduce that loss without restarting the test
+	// process, then ask the real manager to start the enabled service.
+	ctl("stop", c.Unit)
+	must(os.RemoveAll(filepath.Dir(h.startPermission())))
+	ctl("daemon-reload")
+	ctl("start", c.Unit)
+	must(h.verifyStopped(ctx))
+	if active, err := h.Maintenance(); err != nil || !active {
+		t.Fatal("transient-directory loss removed persistent maintenance")
+	}
+	t.Log("actual systemd refused start after loss of transient /run permission")
+	must(h.StartCandidate(ctx, digest, true, 5*time.Second))
+	must(h.Complete(ctx))
+	ctl("restart", c.Unit)
+	// StartCandidate cannot run after Complete; check the restarted process
+	// directly with the same digest and HTTP identity proof.
+	deadline := time.Now().Add(5 * time.Second)
+	for err = h.checkCandidate(ctx, digest, true); err != nil && time.Now().Before(deadline); err = h.checkCandidate(ctx, digest, true) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	must(err)
+	t.Log("completed upgrade restarted through real systemd without temporary permission")
+	must(h.FenceAndStop(ctx))
+	write(filepath.Join(c.WorkingDirectory, "ready"), "failed", 0644)
+	if err := h.StartCandidate(ctx, digest, true, 300*time.Millisecond); err == nil {
+		t.Fatal("failed readiness was accepted")
+	}
+	must(h.verifyStopped(ctx))
+	if _, err := os.Lstat(h.startPermission()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("failed readiness retained transient start permission")
+	}
+	ctl("start", c.Unit)
+	must(h.verifyStopped(ctx))
+	t.Log("failed final readiness stopped the real cgroup and blocked subsequent systemd start")
+}

--- a/internal/releasetrust/nightly.go
+++ b/internal/releasetrust/nightly.go
@@ -85,7 +85,7 @@ func VerifyNightly(snapshot Snapshot, material NightlyMaterial) (VerifiedRelease
 		return VerifiedRelease{}, err
 	}
 	manifestDigest := releaseidentity.Hash(material.Manifest)
-	if slices.Contains(policy.RevokedManifests, manifestDigest) {
+	if slices.Contains(policy.RevokedManifests, manifestDigest) || slices.Contains(snapshot.state.nightlyRevoked, manifestDigest) {
 		return VerifiedRelease{}, errors.New("nightly manifest revoked by current policy")
 	}
 	if err := verifyNightlyEnvelope(policy, material.TrustedRoot, material.Bundle, material.Manifest, manifest.SourceCommit); err != nil {

--- a/internal/releasetrust/nightly_test.go
+++ b/internal/releasetrust/nightly_test.go
@@ -51,7 +51,14 @@ func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
 			case "wrong root":
 				m.TrustedRoot = append(m.TrustedRoot, ' ')
 			case "policy revoked":
-				f.Catalog.NightlyPolicies = []releaseidentity.Digest{}
+				// The current policy moved on; the release still bundles the old one.
+				var current releasetrust.NightlyPolicy
+				if err := json.Unmarshal(m.Policy, &current); err != nil {
+					t.Fatal(err)
+				}
+				current.RevokedManifests = append(current.RevokedManifests, releaseidentity.Hash([]byte("unrelated manifest")))
+				f.NightlyPolicy = testfixture.JSON(t, current)
+				f.Catalog.NightlyPolicies = []releaseidentity.Digest{releaseidentity.Hash(f.NightlyPolicy)}
 			case "wrong issuer", "wrong repository", "wrong owner", "wrong workflow", "wrong ref", "wrong log", "wrong checkpoint origin", "manifest revoked", "required SCT missing", "SCT choice omitted":
 				var policy releasetrust.NightlyPolicy
 				if err := json.Unmarshal(m.Policy, &policy); err != nil {
@@ -81,7 +88,9 @@ func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
 					policy.RequireSCT = nil
 				}
 				m.Policy = testfixture.JSON(t, policy)
-				f.Catalog.NightlyPolicies = []releaseidentity.Digest{releaseidentity.Hash(m.Policy)}
+				// The mutated bundled policy is catalog-authorized; the valid current
+				// policy stays served so the refusal comes from release verification.
+				f.Catalog.NightlyPolicies = []releaseidentity.Digest{releaseidentity.Hash(m.Policy), releaseidentity.Hash(f.NightlyPolicy)}
 			}
 			if name == "missing promise" || name == "missing proof" || name == "bad checkpoint" || name == "wrong tree size" || name == "wrong entry index" || name == "wrong global index" {
 				var err error
@@ -92,6 +101,38 @@ func TestNightlyOfflineCompleteProofAndExactInventory(t *testing.T) {
 			}
 			if _, err := releasetrust.VerifyNightly(f.Snapshot(t), m); err == nil {
 				t.Fatal("invalid nightly evidence accepted")
+			}
+		})
+	}
+}
+
+func TestNightlyCurrentPolicyRevocationAppliesToEarlierAuthorizedPolicies(t *testing.T) {
+	f, m, _ := testfixture.Nightly(t, []byte("signed compatibility fixture"), false)
+	var current releasetrust.NightlyPolicy
+	if err := json.Unmarshal(m.Policy, &current); err != nil {
+		t.Fatal(err)
+	}
+	current.RevokedManifests = append(current.RevokedManifests, releaseidentity.Hash(m.Manifest))
+	revoking := testfixture.JSON(t, current)
+	// Both the bundled policy and the newer revoking policy stay authorized so
+	// other releases from the earlier policy period keep verifying.
+	f.Catalog.NightlyPolicies = append(f.Catalog.NightlyPolicies, releaseidentity.Hash(revoking))
+	f.NightlyPolicy = revoking
+	if _, err := releasetrust.VerifyNightly(f.Snapshot(t), m); err == nil || !strings.Contains(err.Error(), "revoked") {
+		t.Fatalf("release bundling a clean earlier policy escaped the current revocation: %v", err)
+	}
+	f.NightlyPolicy = nil
+	if _, err := releasetrust.VerifyNightly(f.Snapshot(t), m); err != nil {
+		t.Fatalf("offline verification without a current policy must still use the bundled one: %v", err)
+	}
+	for name, policy := range map[string][]byte{"unauthorized": append([]byte(nil), revoking[:len(revoking)-1]...), "empty": {}, "malformed but listed": []byte("{}")} {
+		t.Run(name, func(t *testing.T) {
+			f.NightlyPolicy = policy
+			if name == "malformed but listed" {
+				f.Catalog.NightlyPolicies = append(f.Catalog.NightlyPolicies, releaseidentity.Hash(policy))
+			}
+			if _, err := releasetrust.VerifySnapshot(f.Pinned, f.Material(t), releasetrust.SnapshotFloor{}); err == nil {
+				t.Fatal("snapshot accepted an unusable current nightly policy")
 			}
 		})
 	}

--- a/internal/releasetrust/snapshot.go
+++ b/internal/releasetrust/snapshot.go
@@ -22,6 +22,11 @@ type SnapshotMaterial struct {
 	PrimaryKeys       map[string][]byte
 	Catalog           []byte
 	CatalogSignature  []byte
+	// NightlyPolicy is the currently published nightly policy. Online
+	// verifiers must supply it so a revocation applies to every nightly,
+	// including releases that bundled an earlier still-authorized policy.
+	// Offline verifiers with only embedded material leave it nil.
+	NightlyPolicy []byte
 }
 
 // SnapshotFloor is persisted by the installer/gate. The offline verifier
@@ -47,6 +52,9 @@ type snapshotState struct {
 	floor        SnapshotFloor
 	id           releaseidentity.Digest
 	stablePolicy releaseidentity.Digest
+	// nightlyRevoked comes from the current published nightly policy, not
+	// from any policy copy bundled with a release under verification.
+	nightlyRevoked []releaseidentity.Digest
 }
 
 // Snapshot can only be created by successful signature and policy validation.
@@ -161,10 +169,24 @@ func VerifySnapshot(pinned PinnedTrust, material SnapshotMaterial, floor Snapsho
 	if err := checkFloor(catalog.Sequence, catalogDigest, floor.CatalogSequence, floor.CatalogSHA256); err != nil {
 		return Snapshot{}, fmt.Errorf("upgrade catalog: %w", err)
 	}
+	var nightlyRevoked []releaseidentity.Digest
+	if material.NightlyPolicy != nil {
+		if len(material.NightlyPolicy) > MaxDocumentBytes || !slices.Contains(catalog.NightlyPolicies, releaseidentity.Hash(material.NightlyPolicy)) {
+			return Snapshot{}, errors.New("current nightly policy is not recovery-authorized")
+		}
+		var policy NightlyPolicy
+		if err := decodeDocument(material.NightlyPolicy, &policy); err != nil {
+			return Snapshot{}, err
+		}
+		if err := policy.Validate(); err != nil {
+			return Snapshot{}, err
+		}
+		nightlyRevoked = slices.Clone(policy.RevokedManifests)
+	}
 	nextFloor := SnapshotFloor{MetadataSequence: metadata.Sequence, MetadataSHA256: metadataDigest, HighestReleaseSequence: highest, CatalogSequence: catalog.Sequence, CatalogSHA256: catalogDigest}
 	stablePolicy := releaseidentity.Hash(pinned.Root)
 	identityBytes := []byte(string(stablePolicy) + ":" + string(metadataDigest) + ":" + string(catalogDigest))
-	return Snapshot{state: &snapshotState{root: root, metadata: metadata, keys: keys, recoveryKey: bytes.Clone(pinned.RecoveryPublicKey), catalog: catalog, floor: nextFloor, id: releaseidentity.Hash(identityBytes), stablePolicy: stablePolicy}}, nil
+	return Snapshot{state: &snapshotState{root: root, metadata: metadata, keys: keys, recoveryKey: bytes.Clone(pinned.RecoveryPublicKey), catalog: catalog, floor: nextFloor, id: releaseidentity.Hash(identityBytes), stablePolicy: stablePolicy, nightlyRevoked: nightlyRevoked}}, nil
 }
 
 func checkFloor(sequence int64, digest releaseidentity.Digest, known int64, knownDigest releaseidentity.Digest) error {

--- a/internal/releasetrust/testfixture/nightly.go
+++ b/internal/releasetrust/testfixture/nightly.go
@@ -92,6 +92,7 @@ func NightlyWithPayloads(t testing.TB, compatibility []byte, wrongCommit bool, p
 	policyRaw = JSON(t, policy)
 	f := New(t)
 	f.Catalog.NightlyPolicies = append(f.Catalog.NightlyPolicies, releaseidentity.Hash(policyRaw))
+	f.NightlyPolicy = policyRaw
 	sign := func(compatibility []byte, version string, sequence uint64, payloads map[string][]byte, artifacts []releasetrust.Artifact) (releasetrust.NightlyMaterial, *protobundle.Bundle) {
 		commit := strings.Repeat("a", 40)
 		if payloads == nil {

--- a/internal/releasetrust/testfixture/stable.go
+++ b/internal/releasetrust/testfixture/stable.go
@@ -23,10 +23,13 @@ import (
 // and demonstrate that the real verifier refuses it.
 type Fixture struct {
 	// SignNightly reuses the same test-local OIDC policy for subsequent releases.
-	SignNightly    func([]byte, string, uint64) releasetrust.NightlyMaterial
-	Pinned         releasetrust.PinnedTrust
-	Metadata       releasetrust.Metadata
-	Catalog        releasetrust.Catalog
+	SignNightly func([]byte, string, uint64) releasetrust.NightlyMaterial
+	Pinned      releasetrust.PinnedTrust
+	Metadata    releasetrust.Metadata
+	Catalog     releasetrust.Catalog
+	// NightlyPolicy is the currently published nightly policy served from the
+	// trust tree; nil for stable-only fixtures.
+	NightlyPolicy  []byte
 	PrimaryPublic  []byte
 	RecoverySigner signature.Signer
 	PrimarySigner  signature.Signer
@@ -113,7 +116,7 @@ func (f *Fixture) Material(t testing.TB) releasetrust.SnapshotMaterial {
 	catalog := f.Catalog
 	catalog.StableMetadataSHA256 = releaseidentity.Hash(metadata)
 	rawCatalog := JSON(t, catalog)
-	return releasetrust.SnapshotMaterial{Metadata: metadata, MetadataSignature: Sign(t, f.RecoverySigner, metadata), Catalog: rawCatalog, CatalogSignature: Sign(t, f.RecoverySigner, rawCatalog), PrimaryKeys: map[string][]byte{"test-primary": bytes.Clone(f.PrimaryPublic)}}
+	return releasetrust.SnapshotMaterial{Metadata: metadata, MetadataSignature: Sign(t, f.RecoverySigner, metadata), Catalog: rawCatalog, CatalogSignature: Sign(t, f.RecoverySigner, rawCatalog), PrimaryKeys: map[string][]byte{"test-primary": bytes.Clone(f.PrimaryPublic)}, NightlyPolicy: bytes.Clone(f.NightlyPolicy)}
 }
 
 func (f *Fixture) Snapshot(t testing.TB) releasetrust.Snapshot {

--- a/internal/selfupdate/nightly.go
+++ b/internal/selfupdate/nightly.go
@@ -20,10 +20,13 @@ import (
 // StagedNightly reports a verified manual-upgrade download, never replacement
 // of the running executable. Installing a server also requires its local gate,
 // backup/drill evidence and complete runtime bundle.
-type StagedNightly struct{ Directory string }
+type StagedNightly struct {
+	Directory       string
+	BundleDirectory string
+}
 
 func (s *StagedNightly) Error() string {
-	return fmt.Sprintf("Signed nightly verified at %s. Follow https://hikyo.app/docs/upgrades/ to assemble the bundle and complete the server upgrade; current binary preserved.", s.Directory)
+	return fmt.Sprintf("Signed nightly verified at %s. Runtime bundle assembled at %s. Follow https://hikyo.app/docs/upgrades/ to complete the server upgrade; current binary preserved.", s.Directory, s.BundleDirectory)
 }
 
 type nightlyVerificationState struct {
@@ -31,7 +34,15 @@ type nightlyVerificationState struct {
 	Release releaseidentity.Identity      `json:"release"`
 }
 
-func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status) (err error) {
+func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status) error {
+	var prepared PreparedNightly
+	if err := i.prepareNightly(ctx, status, nil, false, &prepared); err != nil {
+		return err
+	}
+	return &StagedNightly{Directory: prepared.Directory, BundleDirectory: prepared.BundleDirectory}
+}
+
+func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Status, expected *releaseidentity.Identity, extract bool, prepared *PreparedNightly) (err error) {
 	if !status.Immutable {
 		return errors.New("selfupdate: nightly release is not immutable")
 	}
@@ -52,6 +63,9 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 	if err := os.MkdirAll(i.config.StateDir, 0700); err != nil {
 		return err
 	}
+	if err := realNightlyDirectory(i.config.StateDir); err != nil {
+		return err
+	}
 	lock := flock.New(filepath.Join(i.config.StateDir, "nightly-trust.lock"))
 	locked, err := lock.TryLock()
 	if err != nil {
@@ -68,45 +82,12 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 		}
 	}()
 	statePath := filepath.Join(i.config.StateDir, "nightly-trust.json")
-	var known nightlyVerificationState
-	if info, statErr := os.Lstat(statePath); statErr == nil {
-		if !info.Mode().IsRegular() || info.Size() > maxTrustBytes {
-			return errors.New("selfupdate: invalid nightly trust state")
-		}
-		raw, readErr := os.ReadFile(statePath)
-		if readErr != nil {
-			return readErr
-		}
-		if definitions.DecodeStrict(raw, &known) != nil || known.Floor.Validate() != nil || known.Release.Validate() != nil || known.Release.Profile != releaseidentity.NightlyV1 {
-			return errors.New("selfupdate: invalid nightly trust state")
-		}
-	} else if !errors.Is(statErr, os.ErrNotExist) {
-		return statErr
-	}
-	material := releasetrust.SnapshotMaterial{PrimaryKeys: map[string][]byte{}}
-	for name, target := range map[string]*[]byte{"metadata.json": &material.Metadata, "metadata.sigstore.json": &material.MetadataSignature, "catalog.json": &material.Catalog, "catalog.sigstore.json": &material.CatalogSignature} {
-		*target, err = i.downloadURL(ctx, trustURL(name), maxTrustBytes)
-		if err != nil {
-			return err
-		}
-	}
-	var metadata releasetrust.Metadata
-	if err := definitions.DecodeStrict(material.Metadata, &metadata); err != nil {
+	known, err := readNightlyState(statePath)
+	if err != nil {
 		return err
 	}
-	if len(metadata.PrimaryKeys) > 256 {
-		return errors.New("selfupdate: primary inventory exceeds bound")
-	}
-	for _, key := range metadata.PrimaryKeys {
-		if !safeName(key.PublicKey) {
-			return errors.New("selfupdate: unsafe public key locator")
-		}
-		material.PrimaryKeys[key.ID], err = i.downloadURL(ctx, trustURL(key.PublicKey), maxTrustBytes)
-		if err != nil {
-			return err
-		}
-	}
-	snapshot, err := releasetrust.VerifySnapshot(releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}, material, known.Floor)
+	pinned := releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}
+	material, snapshot, err := i.nightlySnapshot(ctx, pinned, known.Floor)
 	if err != nil {
 		return err
 	}
@@ -115,6 +96,22 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 		return err
 	}
 	defer os.RemoveAll(stage)
+	// A target handoff and exact historical route reads reuse immutable cached
+	// bytes. They still match every discovery digest and re-run full signature
+	// verification against the fresh snapshot below before granting authority.
+	cacheIdentity := known.Release
+	if expected != nil {
+		cacheIdentity = *expected
+	}
+	cachedDirectory := ""
+	if cacheIdentity.Validate() == nil && cacheIdentity.Version == status.LatestVersion {
+		candidate := filepath.Join(i.config.StateDir, "nightly-"+string(cacheIdentity.ManifestSHA256))
+		if err := realNightlyDirectory(candidate); err == nil {
+			cachedDirectory = candidate
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
 	var total int64
 	for _, candidate := range status.Assets {
 		if !safeName(candidate.Name) {
@@ -128,7 +125,15 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 		if asset.Size > maxArchiveBytes || total > 8<<30 {
 			return errors.New("selfupdate: nightly payload inventory exceeds byte bound")
 		}
-		raw, err := i.download(ctx, asset, maxArchiveBytes)
+		var raw []byte
+		if cachedDirectory == "" {
+			raw, err = i.download(ctx, asset, maxArchiveBytes)
+		} else {
+			raw, err = readNightlyFile(filepath.Join(cachedDirectory, asset.Name), maxArchiveBytes)
+			if err == nil && (int64(len(raw)) != asset.Size || "sha256:"+string(releaseidentity.Hash(raw)) != asset.Digest) {
+				err = errors.New("selfupdate: cached nightly differs from immutable release asset inventory")
+			}
+		}
 		if err != nil {
 			return err
 		}
@@ -149,7 +154,10 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 	if identity.Version != status.LatestVersion {
 		return errors.New("selfupdate: nightly manifest differs from selected release")
 	}
-	if known.Release.Sequence > identity.Sequence || (known.Release.Sequence == identity.Sequence && known.Release != identity) {
+	if expected != nil && identity != *expected {
+		return errors.New("selfupdate: nightly manifest differs from exact requested evidence")
+	}
+	if (expected == nil && known.Release.Sequence > identity.Sequence) || (known.Release.Sequence == identity.Sequence && known.Release != identity) {
 		return errors.New("selfupdate: nightly rollback or equivocation refused")
 	}
 	if err := filedurability.SyncDirectory(stage); err != nil {
@@ -157,23 +165,60 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 	}
 	destination := filepath.Join(i.config.StateDir, "nightly-"+string(identity.ManifestSHA256))
 	if _, statErr := os.Lstat(destination); statErr == nil {
+		if err := realNightlyDirectory(destination); err != nil {
+			return err
+		}
 		verified, err := upgradebundle.VerifyNightlyDirectory(ctx, destination, snapshot)
 		if err != nil || verified.Identity() != identity {
 			return errors.New("selfupdate: existing nightly staging differs from verified release")
 		}
 	} else if !errors.Is(statErr, os.ErrNotExist) {
 		return statErr
-	} else if err := os.Rename(stage, destination); err != nil {
+	} else if err := publishNightlyDirectory(stage, destination); err != nil {
 		return err
 	}
 	if err := filedurability.SyncDirectory(i.config.StateDir); err != nil {
 		return err
 	}
-	raw, err := json.Marshal(nightlyVerificationState{Floor: snapshot.Floor(), Release: identity})
+	bundleDirectory, err := i.assembleNightlyBundle(ctx, destination, material, snapshot, releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}, identity)
+	if err != nil {
+		return fmt.Errorf("selfupdate: assemble runtime bundle: %w", err)
+	}
+	prepared.Identity, prepared.Directory, prepared.BundleDirectory = identity, destination, bundleDirectory
+	if extract {
+		prepared.BinaryPath, prepared.BinarySHA256, err = i.extractPreparedBinary(ctx, destination, release)
+		if err != nil {
+			return err
+		}
+	}
+	highest := identity
+	if known.Release.Sequence > highest.Sequence {
+		highest = known.Release
+	}
+	return saveNightlyState(statePath, nightlyVerificationState{Floor: snapshot.Floor(), Release: highest})
+}
+
+func readNightlyState(statePath string) (nightlyVerificationState, error) {
+	var known nightlyVerificationState
+	raw, err := readNightlyFile(statePath, maxTrustBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return known, nil
+	}
+	if err != nil {
+		return known, err
+	}
+	if definitions.DecodeStrict(raw, &known) != nil || known.Floor.Validate() != nil || known.Release.Validate() != nil || known.Release.Profile != releaseidentity.NightlyV1 {
+		return known, errors.New("selfupdate: invalid nightly trust state")
+	}
+	return known, nil
+}
+
+func saveNightlyState(statePath string, state nightlyVerificationState) error {
+	raw, err := json.Marshal(state)
 	if err != nil {
 		return err
 	}
-	file, err := os.CreateTemp(i.config.StateDir, ".nightly-trust-")
+	file, err := os.CreateTemp(filepath.Dir(statePath), ".nightly-trust-")
 	if err != nil {
 		return err
 	}
@@ -185,8 +230,40 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 	if err := os.Rename(file.Name(), statePath); err != nil {
 		return err
 	}
-	if err := filedurability.SyncDirectory(i.config.StateDir); err != nil {
+	if err := filedurability.SyncDirectory(filepath.Dir(statePath)); err != nil {
 		return err
 	}
-	return &StagedNightly{Directory: destination}
+	return nil
+}
+
+func (i *Installer) nightlySnapshot(ctx context.Context, pinned releasetrust.PinnedTrust, floor releaseidentity.SnapshotFloor) (releasetrust.SnapshotMaterial, releasetrust.Snapshot, error) {
+	var err error
+	material := releasetrust.SnapshotMaterial{PrimaryKeys: map[string][]byte{}}
+	for name, target := range map[string]*[]byte{"metadata.json": &material.Metadata, "metadata.sigstore.json": &material.MetadataSignature, "catalog.json": &material.Catalog, "catalog.sigstore.json": &material.CatalogSignature} {
+		*target, err = i.downloadURL(ctx, trustURL(name), maxTrustBytes)
+		if err != nil {
+			return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, err
+		}
+	}
+	var metadata releasetrust.Metadata
+	if err := definitions.DecodeStrict(material.Metadata, &metadata); err != nil {
+		return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, err
+	}
+	if len(metadata.PrimaryKeys) > 256 {
+		return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, errors.New("selfupdate: primary inventory exceeds bound")
+	}
+	for _, key := range metadata.PrimaryKeys {
+		if !safeName(key.PublicKey) {
+			return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, errors.New("selfupdate: unsafe public key locator")
+		}
+		material.PrimaryKeys[key.ID], err = i.downloadURL(ctx, trustURL(key.PublicKey), maxTrustBytes)
+		if err != nil {
+			return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, err
+		}
+	}
+	snapshot, err := releasetrust.VerifySnapshot(pinned, material, floor)
+	if err != nil {
+		return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, err
+	}
+	return material, snapshot, nil
 }

--- a/internal/selfupdate/nightly.go
+++ b/internal/selfupdate/nightly.go
@@ -239,7 +239,7 @@ func saveNightlyState(statePath string, state nightlyVerificationState) error {
 func (i *Installer) nightlySnapshot(ctx context.Context, pinned releasetrust.PinnedTrust, floor releaseidentity.SnapshotFloor) (releasetrust.SnapshotMaterial, releasetrust.Snapshot, error) {
 	var err error
 	material := releasetrust.SnapshotMaterial{PrimaryKeys: map[string][]byte{}}
-	for name, target := range map[string]*[]byte{"metadata.json": &material.Metadata, "metadata.sigstore.json": &material.MetadataSignature, "catalog.json": &material.Catalog, "catalog.sigstore.json": &material.CatalogSignature} {
+	for name, target := range map[string]*[]byte{"metadata.json": &material.Metadata, "metadata.sigstore.json": &material.MetadataSignature, "catalog.json": &material.Catalog, "catalog.sigstore.json": &material.CatalogSignature, "nightly/policy.json": &material.NightlyPolicy} {
 		*target, err = i.downloadURL(ctx, trustURL(name), maxTrustBytes)
 		if err != nil {
 			return releasetrust.SnapshotMaterial{}, releasetrust.Snapshot{}, err

--- a/internal/selfupdate/nightly_bundle.go
+++ b/internal/selfupdate/nightly_bundle.go
@@ -1,0 +1,126 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/upgradeassembly"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+)
+
+// assembleNightlyBundle retains the already authenticated snapshot and fetches
+// its complete bridge inventory. Discovery URLs cannot introduce new authority:
+// the shared assembler independently verifies every staged byte before publish.
+func (i *Installer) assembleNightlyBundle(ctx context.Context, nightly string, material releasetrust.SnapshotMaterial, snapshot releasetrust.Snapshot, pinned releasetrust.PinnedTrust, identity releaseidentity.Identity) (string, error) {
+	return i.assembleNightlyEvidence(ctx, []PreparedNightly{{Directory: nightly, Identity: identity}}, material, snapshot, pinned)
+}
+
+func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []PreparedNightly, material releasetrust.SnapshotMaterial, snapshot releasetrust.Snapshot, pinned releasetrust.PinnedTrust) (string, error) {
+	if len(evidence) == 0 || len(evidence) > upgradecompat.MaxReleases {
+		return "", errors.New("selfupdate: nightly route exceeds release bound")
+	}
+	identities := make([]string, 0, len(evidence))
+	seen := map[releaseidentity.Digest]bool{}
+	for _, item := range evidence {
+		if item.Identity.Validate() != nil || item.Identity.Profile != releaseidentity.NightlyV1 || seen[item.Identity.ManifestSHA256] {
+			return "", errors.New("selfupdate: invalid or duplicate route release")
+		}
+		seen[item.Identity.ManifestSHA256] = true
+		if err := realNightlyDirectory(item.Directory); err != nil {
+			return "", err
+		}
+		verified, err := upgradebundle.VerifyNightlyDirectory(ctx, item.Directory, snapshot)
+		if err != nil {
+			return "", err
+		}
+		if verified.Identity() != item.Identity {
+			return "", errors.New("selfupdate: route directory differs from requested identity")
+		}
+		identities = append(identities, string(item.Identity.ManifestSHA256))
+	}
+	slices.Sort(identities)
+	routeDigest := releaseidentity.Hash([]byte(strings.Join(identities, "\n")))
+	destination := filepath.Join(i.config.StateDir, "bundle-"+string(routeDigest)+"-"+string(snapshot.Digest()))
+	if _, err := os.Lstat(destination); err == nil {
+		if err := realNightlyDirectory(destination); err != nil {
+			return "", err
+		}
+		bundle, err := upgradebundle.Load(ctx, destination, pinned, snapshot.Floor())
+		if err != nil {
+			return "", err
+		}
+		for _, item := range evidence {
+			if _, err := bundle.Release(item.Identity); err != nil {
+				return "", err
+			}
+		}
+		return destination, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	stage, err := os.MkdirTemp(i.config.StateDir, ".nightly-bundle-inputs-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(stage)
+	write := func(name string, raw []byte) error {
+		path := filepath.Join(stage, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return err
+		}
+		return os.WriteFile(path, raw, 0600)
+	}
+	for name, raw := range map[string][]byte{"metadata.json": material.Metadata, "metadata.sigstore.json": material.MetadataSignature, "catalog.json": material.Catalog, "catalog.sigstore.json": material.CatalogSignature} {
+		if err := write("snapshot/"+name, raw); err != nil {
+			return "", err
+		}
+	}
+	var metadata releasetrust.Metadata
+	if err := definitions.DecodeStrict(material.Metadata, &metadata); err != nil {
+		return "", err
+	}
+	for _, key := range metadata.PrimaryKeys {
+		if !safeName(key.PublicKey) {
+			return "", errors.New("unsafe primary public key locator")
+		}
+		if err := write("keys/"+key.PublicKey, material.PrimaryKeys[key.ID]); err != nil {
+			return "", err
+		}
+	}
+	options := upgradeassembly.Options{Pinned: pinned, Floor: snapshot.Floor(), SnapshotDirectory: filepath.Join(stage, "snapshot"), KeysDirectory: filepath.Join(stage, "keys"), OutputDirectory: destination}
+	for _, item := range evidence {
+		options.Nightlies = append(options.Nightlies, item.Directory)
+	}
+	var bridgeBytes int
+	for _, digest := range snapshot.BridgeDigests() {
+		// VerifySnapshot has already validated each digest's closed encoding.
+		directory := "bridges/" + string(digest)
+		for _, name := range []string{"statement.json", "statement.sigstore.json"} {
+			raw, err := i.downloadURL(ctx, trustURL(directory+"/"+name), maxTrustBytes)
+			if err != nil {
+				return "", fmt.Errorf("download bridge %s: %w", digest, err)
+			}
+			bridgeBytes += len(raw)
+			if bridgeBytes > 64<<20 {
+				return "", errors.New("bridge inventory exceeds byte bound")
+			}
+			if err := write(directory+"/"+name, raw); err != nil {
+				return "", err
+			}
+		}
+		options.Bridges = append(options.Bridges, filepath.Join(stage, filepath.FromSlash(directory)))
+	}
+	if err := upgradeassembly.Assemble(ctx, options); err != nil {
+		return "", err
+	}
+	return destination, nil
+}

--- a/internal/selfupdate/nightly_bundle.go
+++ b/internal/selfupdate/nightly_bundle.go
@@ -96,7 +96,7 @@ func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []Prep
 			return "", err
 		}
 	}
-	options := upgradeassembly.Options{Pinned: pinned, Floor: snapshot.Floor(), SnapshotDirectory: filepath.Join(stage, "snapshot"), KeysDirectory: filepath.Join(stage, "keys"), OutputDirectory: destination}
+	options := upgradeassembly.Options{Pinned: pinned, Floor: snapshot.Floor(), SnapshotDirectory: filepath.Join(stage, "snapshot"), KeysDirectory: filepath.Join(stage, "keys"), OutputDirectory: destination, NightlyPolicy: material.NightlyPolicy}
 	for _, item := range evidence {
 		options.Nightlies = append(options.Nightlies, item.Directory)
 	}

--- a/internal/selfupdate/nightly_extract.go
+++ b/internal/selfupdate/nightly_extract.go
@@ -1,0 +1,107 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"strings"
+)
+
+// Extract only flat, regular archive members. Even signed archives cannot cause
+// path traversal, link extraction, unbounded expansion or duplicate executables.
+func extractNightlyBinary(name string, raw []byte) ([]byte, error) {
+	if strings.HasSuffix(name, ".zip") {
+		return extractNightlyZip(raw)
+	}
+	if !strings.HasSuffix(name, ".tar.gz") {
+		return nil, errors.New("selfupdate: unsupported nightly archive")
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	limited := &io.LimitedReader{R: gz, N: maxBinaryBytes + (16 << 20)}
+	reader := tar.NewReader(limited)
+	seen := map[string]bool{}
+	var binary []byte
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !safeName(header.Name) || seen[header.Name] || len(seen) >= 32 || (header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA) || header.Size < 0 || header.Size > maxBinaryBytes {
+			return nil, errors.New("selfupdate: unsafe nightly archive member")
+		}
+		seen[header.Name] = true
+		if header.Name == "hikyo" {
+			binary, err = io.ReadAll(io.LimitReader(reader, maxBinaryBytes+1))
+			if err != nil || int64(len(binary)) != header.Size || len(binary) == 0 {
+				return nil, errors.New("selfupdate: unreadable nightly executable")
+			}
+		}
+	}
+	// Consume the bounded gzip tail too so its checksum is verified.
+	if _, err := io.Copy(io.Discard, limited); err != nil {
+		return nil, err
+	}
+	if limited.N <= 0 {
+		return nil, errors.New("selfupdate: nightly archive exceeds expansion bound")
+	}
+	if binary == nil {
+		return nil, errors.New("selfupdate: nightly archive has no executable")
+	}
+	return binary, nil
+}
+
+func extractNightlyZip(raw []byte) ([]byte, error) {
+	reader, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		return nil, err
+	}
+	if len(reader.File) > 32 {
+		return nil, errors.New("selfupdate: nightly archive member bound exceeded")
+	}
+	seen := map[string]bool{}
+	var binary []byte
+	var total uint64
+	for _, file := range reader.File {
+		if !safeName(file.Name) || seen[file.Name] || !file.Mode().IsRegular() || file.UncompressedSize64 > maxBinaryBytes {
+			return nil, errors.New("selfupdate: unsafe nightly archive member")
+		}
+		seen[file.Name] = true
+		total += file.UncompressedSize64
+		if total > maxBinaryBytes+(16<<20) {
+			return nil, errors.New("selfupdate: nightly archive exceeds expansion bound")
+		}
+		input, err := file.Open()
+		if err != nil {
+			return nil, err
+		}
+		if file.Name == "hikyo.exe" {
+			binary, err = io.ReadAll(io.LimitReader(input, maxBinaryBytes+1))
+			if err == nil && (len(binary) == 0 || uint64(len(binary)) != file.UncompressedSize64) {
+				err = errors.New("selfupdate: unreadable nightly executable")
+			}
+		} else {
+			var count int64
+			count, err = io.Copy(io.Discard, io.LimitReader(input, maxBinaryBytes+1))
+			if err == nil && uint64(count) != file.UncompressedSize64 {
+				err = errors.New("selfupdate: unreadable nightly archive member")
+			}
+		}
+		if err := errors.Join(err, input.Close()); err != nil {
+			return nil, err
+		}
+	}
+	if binary == nil {
+		return nil, errors.New("selfupdate: nightly archive has no executable")
+	}
+	return binary, nil
+}

--- a/internal/selfupdate/nightly_files_darwin.go
+++ b/internal/selfupdate/nightly_files_darwin.go
@@ -1,0 +1,15 @@
+package selfupdate
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openNightlyFile(root *os.Root, name string) (*os.File, error) {
+	return root.OpenFile(name, os.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+}
+
+func publishNightlyDirectory(stage, output string) error {
+	return unix.RenamexNp(stage, output, unix.RENAME_EXCL)
+}

--- a/internal/selfupdate/nightly_files_linux.go
+++ b/internal/selfupdate/nightly_files_linux.go
@@ -1,4 +1,4 @@
-package main
+package selfupdate
 
 import (
 	"os"
@@ -6,10 +6,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func openDocument(root *os.Root, name string) (*os.File, error) {
+func openNightlyFile(root *os.Root, name string) (*os.File, error) {
 	return root.OpenFile(name, os.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
 }
 
-func publishDirectory(stage, output string) error {
+func publishNightlyDirectory(stage, output string) error {
 	return unix.Renameat2(unix.AT_FDCWD, stage, unix.AT_FDCWD, output, unix.RENAME_NOREPLACE)
 }

--- a/internal/selfupdate/nightly_files_other.go
+++ b/internal/selfupdate/nightly_files_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !linux
+
+package selfupdate
+
+import (
+	"errors"
+	"os"
+)
+
+func openNightlyFile(_ *os.Root, _ string) (*os.File, error) {
+	return nil, errors.New("offline bundle assembly requires Linux or macOS filesystem semantics")
+}
+
+func publishNightlyDirectory(_, _ string) error {
+	return errors.New("offline bundle assembly requires atomic no-replace rename")
+}

--- a/internal/selfupdate/nightly_prepare.go
+++ b/internal/selfupdate/nightly_prepare.go
@@ -1,0 +1,170 @@
+package selfupdate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/Hikyo-Org/hikyo/internal/filedurability"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Masterminds/semver/v3"
+)
+
+// PreparedNightly is authenticated public evidence and a separately extracted
+// executable. Preparation never replaces the installed executable or admits a
+// database upgrade; the host controller and runtime gate perform those steps.
+type PreparedNightly struct {
+	Identity        releaseidentity.Identity
+	Directory       string
+	BundleDirectory string
+	BinaryPath      string
+	BinarySHA256    releaseidentity.Digest
+}
+
+// PrepareNightly authenticates a selected immutable nightly, assembles its
+// runtime evidence and extracts this platform's binary without installing it.
+// A target older than the highest observed nightly is refused.
+func (i *Installer) PrepareNightly(ctx context.Context, status updatecheck.Status) (PreparedNightly, error) {
+	return i.prepareSelectedNightly(ctx, status, nil)
+}
+
+// PrepareNightlySource fetches an exact source or route-hop identity selected
+// from authenticated compatibility evidence. Older evidence is allowed, but
+// the durable highest observed nightly and snapshot floor never decrease.
+// The caller must still prove a route before executing any prepared binary.
+func (i *Installer) PrepareNightlySource(ctx context.Context, status updatecheck.Status, expected releaseidentity.Identity) (PreparedNightly, error) {
+	if expected.Validate() != nil || expected.Profile != releaseidentity.NightlyV1 {
+		return PreparedNightly{}, errors.New("selfupdate: exact nightly source identity is required")
+	}
+	return i.prepareSelectedNightly(ctx, status, &expected)
+}
+
+func (i *Installer) prepareSelectedNightly(ctx context.Context, status updatecheck.Status, expected *releaseidentity.Identity) (PreparedNightly, error) {
+	if i == nil || i.client == nil {
+		return PreparedNightly{}, errors.New("selfupdate: installer is not configured")
+	}
+	version, err := semver.StrictNewVersion(status.LatestVersion)
+	if err != nil || version.Prerelease() == "" || !status.Prerelease || status.Channel != updatecheck.ChannelNightly || (expected == nil && !status.Available) {
+		return PreparedNightly{}, errors.New("selfupdate: select an available nightly release")
+	}
+	var prepared PreparedNightly
+	if err := i.prepareNightly(ctx, status, expected, true, &prepared); err != nil {
+		return PreparedNightly{}, err
+	}
+	return prepared, nil
+}
+
+func (i *Installer) extractPreparedBinary(ctx context.Context, directory string, release releasetrust.VerifiedRelease) (string, releaseidentity.Digest, error) {
+	name, err := archiveName(release.Identity().Version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return "", "", err
+	}
+	matched := false
+	for _, artifact := range release.Artifacts() {
+		if artifact.Name == name && artifact.Kind == "binary" && artifact.Platform == runtime.GOOS+"/"+runtime.GOARCH {
+			matched = true
+		}
+	}
+	if !matched {
+		return "", "", errors.New("selfupdate: no authenticated binary for this platform")
+	}
+	archive, err := readNightlyFile(filepath.Join(directory, name), maxArchiveBytes)
+	if err != nil {
+		return "", "", err
+	}
+	if err := release.VerifyArtifact(name, bytes.NewReader(archive)); err != nil {
+		return "", "", err
+	}
+	binary, err := extractNightlyBinary(name, archive)
+	if err != nil {
+		return "", "", err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", err
+	}
+	digest := releaseidentity.Hash(binary)
+	destination := filepath.Join(i.config.StateDir, "executable-"+string(release.Identity().ManifestSHA256)+"-"+runtime.GOOS+"-"+runtime.GOARCH)
+	if _, err := os.Lstat(destination); err == nil {
+		raw, err := readNightlyFile(destination, maxBinaryBytes)
+		if err != nil || releaseidentity.Hash(raw) != digest {
+			return "", "", errors.New("selfupdate: cached executable differs from authenticated archive")
+		}
+		return destination, digest, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", "", err
+	}
+	file, err := os.CreateTemp(i.config.StateDir, ".nightly-executable-")
+	if err != nil {
+		return "", "", err
+	}
+	defer os.Remove(file.Name())
+	_, err = file.Write(binary)
+	if err = errors.Join(err, file.Chmod(0700), file.Sync(), file.Close()); err != nil {
+		return "", "", err
+	}
+	if err := os.Link(file.Name(), destination); err != nil {
+		return "", "", err
+	}
+	if err := filedurability.SyncDirectory(i.config.StateDir); err != nil {
+		return "", "", err
+	}
+	return destination, digest, nil
+}
+
+func readNightlyFile(path string, limit int64) ([]byte, error) {
+	directory := filepath.Dir(path)
+	info, err := os.Lstat(directory)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("selfupdate: expected real nightly directory")
+	}
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	opened, err := root.Stat(".")
+	if err != nil || !os.SameFile(info, opened) {
+		return nil, errors.New("selfupdate: nightly directory changed while opening")
+	}
+	file, err := openNightlyFile(root, filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err = file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > limit {
+		return nil, errors.New("selfupdate: expected bounded regular nightly file")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 || int64(len(raw)) > limit {
+		return nil, fmt.Errorf("selfupdate: nightly file exceeds %d byte bound", limit)
+	}
+	return raw, nil
+}
+
+func realNightlyDirectory(path string) error {
+	info, err := os.Lstat(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("selfupdate: expected real nightly directory")
+	}
+	return nil
+}

--- a/internal/selfupdate/nightly_prepare_test.go
+++ b/internal/selfupdate/nightly_prepare_test.go
@@ -1,0 +1,307 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/buildcompat"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
+	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+func preparedNightlyFixture(t *testing.T, archive []byte) (*Installer, updatecheck.Status, string, *testfixture.Fixture, releaseidentity.Identity, map[string][]byte) {
+	t.Helper()
+	const version = "1.1.0-nightly.1"
+	installer, status, installed, responses := installerFixtureForVersion(t, version, true, "")
+	status.Immutable = true
+	installer.config.StateDir = t.TempDir()
+	_, declaration, err := buildcompat.Development()
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaration.Profile, declaration.Version, declaration.Sequence, declaration.Commit = releaseidentity.NightlyV1, version, 2, strings.Repeat("a", 40)
+	claim := testfixture.JSON(t, declaration)
+	base := "https://github.com/Hikyo-Org/Hikyo/releases/download/v" + version + "/"
+	name := mustArchiveName(t, version)
+	if archive == nil {
+		archive = responses[base+name]
+	}
+	payloads := map[string][]byte{name: archive, "checksums.txt": responses[base+"checksums.txt"], "binary-provenance.json": []byte("{}"), "upgrade-compatibility.json": claim}
+	artifacts := []releasetrust.Artifact{{Name: name, Kind: "binary", Platform: runtime.GOOS + "/" + runtime.GOARCH}, {Name: "checksums.txt", Kind: "checksum"}, {Name: "binary-provenance.json", Kind: "binary-provenance"}, {Name: "upgrade-compatibility.json", Kind: "upgrade-compatibility"}}
+	trust, material, _ := testfixture.NightlyWithPayloads(t, claim, false, payloads, artifacts)
+	installer.config.TrustRootBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.Root)
+	installer.config.RecoveryKeyBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.RecoveryPublicKey)
+	snapshot := trust.Material(t)
+	for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature, "primary.pub": trust.PrimaryPublic} {
+		responses[trustURL(name)] = raw
+	}
+	status.Assets = nil
+	add := func(name string, raw []byte) {
+		responses[base+name] = raw
+		status.Assets = append(status.Assets, updatecheck.Asset{Name: name, URL: base + name, Size: int64(len(raw)), Digest: "sha256:" + string(releaseidentity.Hash(raw))})
+	}
+	for name, reader := range material.Artifacts {
+		raw, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		add(name, raw)
+	}
+	add("release-manifest.json", material.Manifest)
+	add("release-manifest.sigstore.json", material.Bundle)
+	identity := releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)}
+	return installer, status, installed, trust, identity, responses
+}
+
+func TestPrepareNightlyExtractsExactExecutableWithoutInstalling(t *testing.T) {
+	installer, status, installed, trust, expected, _ := preparedNightlyFixture(t, nil)
+	prepared, err := installer.PrepareNightly(t.Context(), status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := readNightlyFile(prepared.BinaryPath, maxBinaryBytes)
+	if err != nil || len(raw) == 0 || prepared.Identity != expected || prepared.BinarySHA256 != releaseidentity.Hash(raw) {
+		t.Fatalf("prepared executable identity differs: %+v %v", prepared, err)
+	}
+	original, err := os.ReadFile(installed)
+	if err != nil || string(original) != "old hikyo binary\n" {
+		t.Fatalf("installed binary changed: %v", err)
+	}
+	bundle, err := upgradebundle.Load(t.Context(), prepared.BundleDirectory, trust.Pinned, releaseidentity.SnapshotFloor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bundle.Release(expected); err != nil {
+		t.Fatal(err)
+	}
+	again, err := installer.PrepareNightly(t.Context(), status)
+	if err != nil || again != prepared {
+		t.Fatalf("preparation was not idempotent: %v", err)
+	}
+	if err := os.WriteFile(prepared.BinaryPath, []byte("modified"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.PrepareNightly(t.Context(), status); err == nil {
+		t.Fatal("modified cached executable accepted")
+	}
+}
+
+func TestPreparedNightlyReusesCacheAndRechecksImmutableInventory(t *testing.T) {
+	installer, status, _, _, _, _ := preparedNightlyFixture(t, nil)
+	if _, err := installer.PrepareNightly(t.Context(), status); err != nil {
+		t.Fatal(err)
+	}
+	transport := installer.client.Transport
+	installer.client.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if strings.Contains(request.URL.Path, "/releases/download/") {
+			t.Fatal("cached handoff downloaded release payloads again")
+		}
+		return transport.RoundTrip(request)
+	})
+	if _, err := installer.PrepareNightly(t.Context(), status); err != nil {
+		t.Fatal(err)
+	}
+	status.Assets[0].Digest = "sha256:" + strings.Repeat("f", 64)
+	if _, err := installer.PrepareNightly(t.Context(), status); err == nil {
+		t.Fatal("changed immutable inventory accepted cached bytes")
+	}
+}
+
+func TestPrepareExactOlderNightlyPreservesHighestAndChecksIdentity(t *testing.T) {
+	installer, status, _, _, expected, _ := preparedNightlyFixture(t, nil)
+	if _, err := installer.PrepareNightly(t.Context(), status); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(installer.config.StateDir, "nightly-trust.json")
+	known, err := readNightlyState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	known.Release.Sequence++
+	known.Release.Version = "1.1.0-nightly.2"
+	known.Release.ManifestSHA256 = releaseidentity.Hash([]byte("later observed nightly"))
+	if err := saveNightlyState(statePath, known); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.PrepareNightly(t.Context(), status); err == nil {
+		t.Fatal("older target accepted")
+	}
+	status.Available = false // Historical discovery need not claim a new update.
+	prepared, err := installer.PrepareNightlySource(t.Context(), status, expected)
+	if err != nil || prepared.Identity != expected {
+		t.Fatalf("exact older evidence rejected: %v", err)
+	}
+	after, err := readNightlyState(statePath)
+	if err != nil || after != known {
+		t.Fatalf("source evidence lowered durable trust: %+v %v", after, err)
+	}
+	wrong := expected
+	wrong.ManifestSHA256 = releaseidentity.Hash([]byte("not the requested source"))
+	if _, err := installer.PrepareNightlySource(t.Context(), status, wrong); err == nil {
+		t.Fatal("wrong exact source accepted")
+	}
+}
+
+func TestNightlyRouteReauthenticatesAllExactEvidence(t *testing.T) {
+	installer, status, _, trust, _, _ := preparedNightlyFixture(t, nil)
+	target, err := installer.PrepareNightly(t.Context(), status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, declaration, err := buildcompat.Development()
+	if err != nil {
+		t.Fatal(err)
+	}
+	declaration.Profile, declaration.Version, declaration.Sequence, declaration.Commit = releaseidentity.NightlyV1, "1.0.0-nightly.1", 1, strings.Repeat("a", 40)
+	claim := testfixture.JSON(t, declaration)
+	material := trust.SignNightly(claim, declaration.Version, declaration.Sequence)
+	source := PreparedNightly{Directory: t.TempDir(), Identity: releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)}}
+	for name, reader := range material.Artifacts {
+		raw, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(source.Directory, name), raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, raw := range map[string][]byte{"release-manifest.json": material.Manifest, "release-manifest.sigstore.json": material.Bundle} {
+		if err := os.WriteFile(filepath.Join(source.Directory, name), raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	directory, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{source})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := upgradebundle.Load(t.Context(), directory, trust.Pinned, releaseidentity.SnapshotFloor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, identity := range []releaseidentity.Identity{target.Identity, source.Identity} {
+		if _, err := bundle.Release(identity); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{target}); err == nil {
+		t.Fatal("duplicate route inventory accepted")
+	}
+	if _, err := installer.AssembleNightlyRoute(t.Context(), target, make([]PreparedNightly, upgradecompat.MaxReleases)); err == nil {
+		t.Fatal("unbounded route accepted")
+	}
+	if err := os.WriteFile(filepath.Join(source.Directory, "checksums.txt"), []byte("tampered"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{source}); err == nil {
+		t.Fatal("modified source accepted through cached route")
+	}
+}
+
+func TestNightlyExtractorRejectsUnsafeArchiveMembers(t *testing.T) {
+	for _, name := range []string{"../escape", "/escape", "nested/hikyo", "hikyo"} {
+		t.Run(name, func(t *testing.T) {
+			var out bytes.Buffer
+			gz := gzip.NewWriter(&out)
+			writer := tar.NewWriter(gz)
+			if err := writer.WriteHeader(&tar.Header{Name: "hikyo", Mode: 0700, Typeflag: tar.TypeReg, Size: 2}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := writer.Write([]byte("ok")); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.WriteHeader(&tar.Header{Name: name, Mode: 0700, Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := errors.Join(writer.Close(), gz.Close()); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := extractNightlyBinary("release.tar.gz", out.Bytes()); err == nil {
+				t.Fatal("unsafe tar archive accepted")
+			}
+		})
+	}
+	var out bytes.Buffer
+	writer := zip.NewWriter(&out)
+	header := &zip.FileHeader{Name: "hikyo.exe"}
+	header.SetMode(os.ModeSymlink | 0700)
+	file, err := writer.CreateHeader(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte("/etc/passwd")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := extractNightlyBinary("release.zip", out.Bytes()); err == nil {
+		t.Fatal("zip executable symlink accepted")
+	}
+}
+
+func TestPreparationRefusesSymlinkedExecutableAndTrustState(t *testing.T) {
+	for _, which := range []string{"executable", "trust state"} {
+		t.Run(which, func(t *testing.T) {
+			installer, status, _, _, _, _ := preparedNightlyFixture(t, nil)
+			prepared, err := installer.PrepareNightly(t.Context(), status)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := prepared.BinaryPath
+			if which == "trust state" {
+				path = filepath.Join(installer.config.StateDir, "nightly-trust.json")
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			outside := filepath.Join(t.TempDir(), "unchanged")
+			if err := os.WriteFile(outside, raw, 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outside, path); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installer.PrepareNightly(t.Context(), status); err == nil {
+				t.Fatal("symlinked preparation state accepted")
+			}
+			after, err := os.ReadFile(outside)
+			if err != nil || !bytes.Equal(raw, after) {
+				t.Fatal("symlink target changed")
+			}
+		})
+	}
+}
+
+func TestNightlyExtractorRejectsHardlinks(t *testing.T) {
+	var out bytes.Buffer
+	gz := gzip.NewWriter(&out)
+	writer := tar.NewWriter(gz)
+	if err := writer.WriteHeader(&tar.Header{Name: "hikyo", Typeflag: tar.TypeLink, Linkname: "outside", Mode: 0700}); err != nil {
+		t.Fatal(err)
+	}
+	if err := errors.Join(writer.Close(), gz.Close()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := extractNightlyBinary("release.tar.gz", out.Bytes()); err == nil {
+		t.Fatal("hardlink accepted as regular executable")
+	}
+}

--- a/internal/selfupdate/nightly_prepare_test.go
+++ b/internal/selfupdate/nightly_prepare_test.go
@@ -47,7 +47,7 @@ func preparedNightlyFixture(t *testing.T, archive []byte) (*Installer, updateche
 	installer.config.TrustRootBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.Root)
 	installer.config.RecoveryKeyBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.RecoveryPublicKey)
 	snapshot := trust.Material(t)
-	for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature, "primary.pub": trust.PrimaryPublic} {
+	for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature, "nightly/policy.json": snapshot.NightlyPolicy, "primary.pub": trust.PrimaryPublic} {
 		responses[trustURL(name)] = raw
 	}
 	status.Assets = nil

--- a/internal/selfupdate/nightly_route.go
+++ b/internal/selfupdate/nightly_route.go
@@ -1,0 +1,81 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+	"github.com/gofrs/flock"
+)
+
+// AssembleNightlyRoute combines exact prepared source/route releases with the
+// target under the current authenticated snapshot. Every flat directory is
+// independently reverified. It does not infer edges or authorize execution; the
+// caller must ask the resulting runtime bundle to plan the actual DB source.
+func (i *Installer) AssembleNightlyRoute(ctx context.Context, target PreparedNightly, sources []PreparedNightly) (_ string, err error) {
+	if i == nil || i.client == nil || i.config.StateDir == "" {
+		return "", errors.New("selfupdate: installer is not configured")
+	}
+	if len(sources) >= upgradecompat.MaxReleases {
+		return "", errors.New("selfupdate: nightly route exceeds release bound")
+	}
+	if err := realNightlyDirectory(i.config.StateDir); err != nil {
+		return "", err
+	}
+	lock := flock.New(filepath.Join(i.config.StateDir, "nightly-trust.lock"))
+	locked, err := lock.TryLock()
+	if err != nil {
+		return "", err
+	}
+	if !locked {
+		return "", errors.New("selfupdate: another nightly verification is running")
+	}
+	defer func() { err = errors.Join(err, lock.Unlock()) }()
+	statePath := filepath.Join(i.config.StateDir, "nightly-trust.json")
+	known, err := readNightlyState(statePath)
+	if err != nil {
+		return "", err
+	}
+	root, err := decodeStamped("trust root", i.config.TrustRootBase64)
+	if err != nil {
+		return "", err
+	}
+	recovery, err := decodeStamped("recovery public key", i.config.RecoveryKeyBase64)
+	if err != nil {
+		return "", err
+	}
+	pinned := releasetrust.PinnedTrust{Root: root, RecoveryPublicKey: recovery}
+	material, snapshot, err := i.nightlySnapshot(ctx, pinned, known.Floor)
+	if err != nil {
+		return "", err
+	}
+	evidence := make([]PreparedNightly, 0, len(sources)+1)
+	evidence = append(evidence, target)
+	evidence = append(evidence, sources...)
+	highest := known.Release
+	sequences := map[uint64]releaseidentity.Identity{}
+	for _, item := range evidence {
+		if previous, ok := sequences[item.Identity.Sequence]; ok && previous != item.Identity {
+			return "", errors.New("selfupdate: route contains nightly equivocation")
+		}
+		sequences[item.Identity.Sequence] = item.Identity
+		if highest.Sequence == item.Identity.Sequence && highest != item.Identity {
+			return "", errors.New("selfupdate: nightly equivocation refused")
+		}
+		if item.Identity.Sequence > highest.Sequence {
+			highest = item.Identity
+		}
+	}
+	directory, err := i.assembleNightlyEvidence(ctx, evidence, material, snapshot, pinned)
+	if err != nil {
+		return "", fmt.Errorf("selfupdate: assemble nightly route: %w", err)
+	}
+	if err := saveNightlyState(statePath, nightlyVerificationState{Floor: snapshot.Floor(), Release: highest}); err != nil {
+		return "", err
+	}
+	return directory, nil
+}

--- a/internal/selfupdate/nightly_test.go
+++ b/internal/selfupdate/nightly_test.go
@@ -16,10 +16,11 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
 )
 
 func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T) {
-	for _, mutation := range []string{"none", "extra", "signature", "wrong workflow commit", "missing", "rollback", "trust rollback"} {
+	for _, mutation := range []string{"none", "extra", "signature", "wrong workflow commit", "missing", "rollback", "trust rollback", "bridge signature", "bridge missing"} {
 		t.Run(mutation, func(t *testing.T) {
 			const version = "1.1.0-nightly.1"
 			installer, status, target, responses := installerFixtureForVersion(t, version, true, "")
@@ -36,6 +37,18 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 			payloads := map[string][]byte{archiveName: responses[base+archiveName], "checksums.txt": responses[base+"checksums.txt"], "binary-provenance.json": []byte("{}"), "upgrade-compatibility.json": claim}
 			artifacts := []releasetrust.Artifact{{Name: archiveName, Kind: "binary", Platform: runtime.GOOS + "/" + runtime.GOARCH}, {Name: "checksums.txt", Kind: "checksum"}, {Name: "binary-provenance.json", Kind: "binary-provenance"}, {Name: "upgrade-compatibility.json", Kind: "upgrade-compatibility"}}
 			trust, material, _ := testfixture.NightlyWithPayloads(t, claim, mutation == "wrong workflow commit", payloads, artifacts)
+			identity := releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)}
+			engine := declaration.Engines[0]
+			bridge := trust.AddBridge(t, releasetrust.BridgeStatement{Schema: "hikyo.dev/legacy-nightly-bridge/v1", SourceGenesis: releaseidentity.LegacyGenesisV1, Target: identity, TargetPolicySHA256: releaseidentity.Hash(material.Policy), SourceMigrations: engine.Migrations, TargetMigrations: engine.Migrations, SourceSchemaSHA256: engine.SchemaSHA256, TargetSchemaSHA256: engine.SchemaSHA256, Mode: "maintenance"})
+			bridgePath := "bridges/" + string(releaseidentity.Hash(bridge.Statement)) + "/"
+			responses[trustURL(bridgePath+"statement.json")] = bridge.Statement
+			responses[trustURL(bridgePath+"statement.sigstore.json")] = bridge.Signature
+			if mutation == "bridge signature" {
+				responses[trustURL(bridgePath+"statement.sigstore.json")] = []byte("{}")
+			}
+			if mutation == "bridge missing" {
+				delete(responses, trustURL(bridgePath+"statement.json"))
+			}
 			installer.config.TrustRootBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.Root)
 			installer.config.RecoveryKeyBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.RecoveryPublicKey)
 			snapshot := trust.Material(t)
@@ -87,9 +100,22 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 				if _, err := os.Stat(filepath.Join(staged.Directory, archiveName)); err != nil {
 					t.Fatal(err)
 				}
+				bundle, err := upgradebundle.Load(t.Context(), staged.BundleDirectory, trust.Pinned, releaseidentity.SnapshotFloor{})
+				if err != nil || !bundle.Valid() {
+					t.Fatalf("runtime bundle was not assembled: %v", err)
+				}
+				if len(bundle.Snapshot().BridgeDigests()) != 1 {
+					t.Fatal("runtime bundle omitted legacy bridge")
+				}
 				// Same-release download is idempotent and reauthenticates disk bytes.
 				if err := installer.Apply(t.Context(), status); !errors.As(err, &staged) {
 					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(staged.BundleDirectory, "catalog.json"), []byte("{}"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				if err := installer.Apply(t.Context(), status); err == nil || errors.As(err, &staged) {
+					t.Fatal("modified cached runtime bundle accepted")
 				}
 			} else if err == nil || errors.As(err, &staged) {
 				t.Fatalf("unsafe %s accepted: %v", mutation, err)
@@ -100,6 +126,14 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 			}
 			if paths, _ := filepath.Glob(filepath.Join(installer.config.StateDir, ".nightly-download-*")); len(paths) != 0 {
 				t.Fatal(fmt.Sprint("private staging leaked", paths))
+			}
+			if paths, _ := filepath.Glob(filepath.Join(installer.config.StateDir, ".nightly-bundle-inputs-*")); len(paths) != 0 {
+				t.Fatal("bundle inputs leaked", paths)
+			}
+			if strings.HasPrefix(mutation, "bridge ") {
+				if _, err := os.Stat(filepath.Join(installer.config.StateDir, "nightly-trust.json")); !errors.Is(err, os.ErrNotExist) {
+					t.Fatal("failed bundle assembly advanced trust floor", err)
+				}
 			}
 		})
 	}

--- a/internal/selfupdate/nightly_test.go
+++ b/internal/selfupdate/nightly_test.go
@@ -2,6 +2,7 @@ package selfupdate
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,7 +21,7 @@ import (
 )
 
 func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T) {
-	for _, mutation := range []string{"none", "extra", "signature", "wrong workflow commit", "missing", "rollback", "trust rollback", "bridge signature", "bridge missing"} {
+	for _, mutation := range []string{"none", "extra", "signature", "wrong workflow commit", "missing", "rollback", "trust rollback", "bridge signature", "bridge missing", "current policy revocation", "current policy missing"} {
 		t.Run(mutation, func(t *testing.T) {
 			const version = "1.1.0-nightly.1"
 			installer, status, target, responses := installerFixtureForVersion(t, version, true, "")
@@ -51,9 +52,23 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 			}
 			installer.config.TrustRootBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.Root)
 			installer.config.RecoveryKeyBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.RecoveryPublicKey)
+			if mutation == "current policy revocation" {
+				// The release bundles a clean, still-authorized policy; only the
+				// currently published policy revokes its manifest.
+				var current releasetrust.NightlyPolicy
+				if err := json.Unmarshal(material.Policy, &current); err != nil {
+					t.Fatal(err)
+				}
+				current.RevokedManifests = append(current.RevokedManifests, releaseidentity.Hash(material.Manifest))
+				trust.NightlyPolicy = testfixture.JSON(t, current)
+				trust.Catalog.NightlyPolicies = append(trust.Catalog.NightlyPolicies, releaseidentity.Hash(trust.NightlyPolicy))
+			}
 			snapshot := trust.Material(t)
-			for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature, "primary.pub": trust.PrimaryPublic} {
+			for name, raw := range map[string][]byte{"metadata.json": snapshot.Metadata, "metadata.sigstore.json": snapshot.MetadataSignature, "catalog.json": snapshot.Catalog, "catalog.sigstore.json": snapshot.CatalogSignature, "nightly/policy.json": snapshot.NightlyPolicy, "primary.pub": trust.PrimaryPublic} {
 				responses[trustURL(name)] = raw
+			}
+			if mutation == "current policy missing" {
+				delete(responses, trustURL("nightly/policy.json"))
 			}
 			status.Assets = nil
 			add := func(name string, raw []byte) {
@@ -119,6 +134,8 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 				}
 			} else if err == nil || errors.As(err, &staged) {
 				t.Fatalf("unsafe %s accepted: %v", mutation, err)
+			} else if mutation == "current policy revocation" && !strings.Contains(err.Error(), "revoked") {
+				t.Fatalf("revocation refused for another reason: %v", err)
 			}
 			raw, err := os.ReadFile(target)
 			if err != nil || string(raw) != "old hikyo binary\n" {

--- a/internal/selfupdate/nightly_test.go
+++ b/internal/selfupdate/nightly_test.go
@@ -48,7 +48,7 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 				responses[trustURL(bridgePath+"statement.sigstore.json")] = []byte("{}")
 			}
 			if mutation == "bridge missing" {
-				delete(responses, trustURL(bridgePath+"statement.json"))
+				responses[trustURL(bridgePath+"statement.json")] = nil
 			}
 			installer.config.TrustRootBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.Root)
 			installer.config.RecoveryKeyBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.RecoveryPublicKey)
@@ -68,7 +68,7 @@ func TestSignedNightlyStagesVerifiedInventoryWithoutReplacingServer(t *testing.T
 				responses[trustURL(name)] = raw
 			}
 			if mutation == "current policy missing" {
-				delete(responses, trustURL("nightly/policy.json"))
+				responses[trustURL("nightly/policy.json")] = nil
 			}
 			status.Assets = nil
 			add := func(name string, raw []byte) {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -93,8 +93,12 @@ func installerFixtureForVersion(t *testing.T, version string, prerelease bool, c
 	}
 	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		body, ok := responses[request.URL.String()]
-		code := http.StatusOK
 		if !ok {
+			t.Fatalf("unexpected download %s", request.URL)
+		}
+		// A nil body models a published tree that lacks the document.
+		code := http.StatusOK
+		if body == nil {
 			code = http.StatusNotFound
 		}
 		return &http.Response{

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -93,11 +93,12 @@ func installerFixtureForVersion(t *testing.T, version string, prerelease bool, c
 	}
 	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		body, ok := responses[request.URL.String()]
+		code := http.StatusOK
 		if !ok {
-			t.Fatalf("unexpected download %s", request.URL)
+			code = http.StatusNotFound
 		}
 		return &http.Response{
-			StatusCode: http.StatusOK,
+			StatusCode: code,
 			Body:       io.NopCloser(bytes.NewReader(body)),
 			Header:     make(http.Header),
 		}, nil

--- a/internal/service/recovery_auto_proof.go
+++ b/internal/service/recovery_auto_proof.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	"github.com/Hikyo-Org/hikyo/internal/store/tx"
+)
+
+var errNoDrillCandidate = errors.New("scratch principal has no eligible existing credential-management grant")
+
+// AutoCredentialProof selects one existing principal in the restored scratch
+// database, reconciles it and exercises the normal credential lifecycle. No
+// method on the live Restore surface performs automatic reconciliation.
+func (s *Recovery) AutoCredentialProof(ctx context.Context, kr *crypto.Keyring) error {
+	if s == nil || s.DB == nil {
+		return errors.New("automatic credential proof requires authenticated scratch custody")
+	}
+	if err := s.DB.CheckScratch(ctx); err != nil {
+		return err
+	}
+	status, err := s.Status(ctx)
+	if err != nil {
+		return err
+	}
+	if len(status.Pending) == 0 || len(status.Pending) > 1024 {
+		return errors.New("automatic scratch credential proof requires 1 to 1024 pending principals")
+	}
+	slices.SortFunc(status.Pending, func(a, b authz.PrincipalRef) int { return strings.Compare(string(a.ID), string(b.ID)) })
+	for _, candidate := range status.Pending {
+		var scope domain.Scope
+		// Reconciliation makes grants readable. If the principal is unsuitable,
+		// rollback its reconciliation and audit event in this same transaction.
+		_, err := restoreReconcile(ctx, func(ctx context.Context, fn tx.RestoreFn) error {
+			return tx.RecoveryWrite(ctx, s.DB, func(ctx context.Context, r store.Repos, az *authz.TxAuthorizer) error {
+				if err := fn(ctx, az); err != nil {
+					return err
+				}
+				grants, err := az.GrantsOf(ctx, candidate.ID)
+				if err != nil {
+					return err
+				}
+				if len(grants) > 4096 {
+					return errors.New("scratch principal grant inventory exceeds automatic proof bound")
+				}
+				eligible := make([]domain.Scope, 0)
+				for _, grant := range grants {
+					// Instance-only authority does not invent an org enumeration.
+					if grant.Capability == domain.CapManageIdentities && grant.Scope.Org != "" && grant.Scope.Env == "" {
+						eligible = append(eligible, grant.Scope)
+					}
+				}
+				if len(eligible) == 0 {
+					return errNoDrillCandidate
+				}
+				slices.SortFunc(eligible, func(a, b domain.Scope) int {
+					// Existing project scopes avoid requesting broader navigation.
+					if (a.Project == "") != (b.Project == "") {
+						if a.Project != "" {
+							return -1
+						}
+						return 1
+					}
+					if c := strings.Compare(string(a.Org), string(b.Org)); c != 0 {
+						return c
+					}
+					return strings.Compare(string(a.Project), string(b.Project))
+				})
+				caller, err := LocalPrincipal(candidate.ID).resolve(ctx, az, time.Now().UTC())
+				if err != nil {
+					return err
+				}
+				for _, grantScope := range eligible {
+					resolved, found, err := automaticDrillProject(ctx, r.Projects(), az, caller, grantScope)
+					if err != nil {
+						return err
+					}
+					if found {
+						scope = resolved
+						return nil
+					}
+				}
+				return errNoDrillCandidate
+			})
+		}, candidate.ID)
+		if errors.Is(err, errNoDrillCandidate) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("select scratch credential principal: %w", err)
+		}
+		return s.MintAndRevoke(ctx, kr, candidate.ID, scope)
+	}
+	return errNoDrillCandidate
+}
+
+// Resolve project eligibility before committing the candidate's reconciliation.
+// Empty or unauthorized scopes are candidates to skip; operational errors abort
+// the drill. The ordinary authorizer and proof-gated repository own every read.
+func automaticDrillProject(ctx context.Context, projects store.ProjectReader, az *authz.TxAuthorizer, caller authz.Identity, scope domain.Scope) (domain.Scope, bool, error) {
+	if scope.Project != "" {
+		held, err := az.CallerHolds(ctx, caller, authz.OpServiceAccountCreate, scope)
+		return scope, held, err
+	}
+	canList, err := az.CallerHolds(ctx, caller, authz.OpProjectList, scope)
+	if err != nil || !canList {
+		return domain.Scope{}, false, err
+	}
+	proof, err := az.Authorize(ctx, caller, authz.OpProjectList, scope)
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.Scope{}, false, nil
+	}
+	if err != nil {
+		return domain.Scope{}, false, err
+	}
+	rows, err := projects.List(ctx, proof)
+	if err != nil {
+		return domain.Scope{}, false, err
+	}
+	if len(rows) > 4096 {
+		return domain.Scope{}, false, errors.New("scratch project inventory exceeds automatic proof bound")
+	}
+	slices.SortFunc(rows, func(a, b store.Project) int { return strings.Compare(a.ID, b.ID) })
+	for _, project := range rows {
+		candidate := domain.Scope{Org: scope.Org, Project: domain.ProjectID(project.ID)}
+		held, err := az.CallerHolds(ctx, caller, authz.OpServiceAccountCreate, candidate)
+		if err != nil {
+			return domain.Scope{}, false, err
+		}
+		if held {
+			return candidate, true, nil
+		}
+	}
+	return domain.Scope{}, false, nil
+}

--- a/internal/store/recovery.go
+++ b/internal/store/recovery.go
@@ -30,6 +30,19 @@ func OpenRecovery(ctx context.Context, cfg Config, authority upgrade.RecoveryAdm
 }
 func (r *RecoveryDB) Close() error   { return r.db.Close() }
 func (r *RecoveryDB) Engine() Engine { return r.db.engine }
+
+// CheckScratch authorizes automatic drill behavior only on a currently guarded
+// authenticated scratch restore, never on the operator's live data recovery.
+func (r *RecoveryDB) CheckScratch(ctx context.Context) error {
+	if r == nil {
+		return upgrade.ErrConflict
+	}
+	if err := r.authority.CheckScratch(); err != nil {
+		return err
+	}
+	return r.authority.Check(ctx, upgradeConfig(r.config))
+}
+
 func (r *RecoveryDB) BeginSQLite(ctx context.Context, readonly bool) (*RecoverySQLiteTransaction, error) {
 	if r == nil || r.Engine() != EngineSQLite {
 		return nil, upgrade.ErrConflict

--- a/internal/store/upgrade/recovery_admission.go
+++ b/internal/store/upgrade/recovery_admission.go
@@ -88,6 +88,15 @@ func (a RecoveryAdmission) CheckOwner() error {
 	return a.state.preparation.state.session.check()
 }
 
+// CheckScratch excludes operator recovery of a live restored database. Only
+// an authenticated disposable drill may select a reconciliation automatically.
+func (a RecoveryAdmission) CheckScratch() error {
+	if a.state == nil || a.state.kind != authenticatedScratch {
+		return ErrConflict
+	}
+	return a.CheckOwner()
+}
+
 // CheckPostgresOwner rejects a lost physical migration owner before commit.
 func (a RecoveryAdmission) CheckPostgresOwner(ctx context.Context) error {
 	if err := a.CheckOwner(); err != nil {

--- a/internal/store/upgrade/recovery_scratch_test.go
+++ b/internal/store/upgrade/recovery_scratch_test.go
@@ -1,0 +1,11 @@
+package upgrade
+
+import "testing"
+
+func TestAutomaticDrillRefusesLiveRecoveryAuthority(t *testing.T) {
+	for _, admission := range []RecoveryAdmission{{}, {state: &recoveryState{kind: restoredData, epoch: 1}}} {
+		if err := admission.CheckScratch(); err == nil {
+			t.Fatal("automatic drill admitted non-scratch recovery")
+		}
+	}
+}

--- a/internal/updatecheck/source.go
+++ b/internal/updatecheck/source.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/netpolicy"
+	"github.com/Masterminds/semver/v3"
 )
 
 const (
@@ -158,6 +159,35 @@ func (s *GitHubSource) Releases(ctx context.Context) ([]Release, error) {
 		})
 	}
 	return releases, nil
+}
+
+// ReleaseByVersion resolves an exact authenticated graph reference even after
+// that release has left the first discovery page. The returned record is still
+// discovery only; the caller must verify its signed identity and full inventory.
+func (s *GitHubSource) ReleaseByVersion(ctx context.Context, version string) (Release, error) {
+	if s == nil || s.client == nil {
+		return Release{}, errors.New("updatecheck: HTTP client is required")
+	}
+	if _, err := semver.StrictNewVersion(version); err != nil {
+		return Release{}, errors.New("updatecheck: exact release version is invalid")
+	}
+	tag := "v" + version
+	var record githubRelease
+	if _, err := s.getJSON(ctx, "https://api.github.com/repos/Hikyo-Org/Hikyo/releases/tags/"+url.PathEscape(tag), &record, false); err != nil {
+		return Release{}, err
+	}
+	if record.Draft || record.TagName != tag {
+		return Release{}, errors.New("updatecheck: exact release response differs from requested published tag")
+	}
+	published, err := time.Parse(time.RFC3339, record.PublishedAt)
+	if err != nil {
+		return Release{}, errors.New("updatecheck: exact release has invalid publication time")
+	}
+	assets, err := releaseAssets(tag, record.Assets)
+	if err != nil {
+		return Release{}, err
+	}
+	return Release{Version: version, URL: githubReleasePageBase + url.PathEscape(tag), Prerelease: record.Prerelease, Immutable: record.Immutable, PublishedAt: published, Assets: assets}, nil
 }
 
 func releaseAssets(tag string, records []githubAsset) ([]Asset, error) {

--- a/internal/updatecheck/source_exact_test.go
+++ b/internal/updatecheck/source_exact_test.go
@@ -1,0 +1,50 @@
+package updatecheck
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestExactReleaseLookupDoesNotDependOnDiscoveryPage(t *testing.T) {
+	for _, tc := range []struct {
+		name, tag, draft, published string
+		valid                       bool
+	}{
+		{"published", "v1.1.0-nightly.1", "false", "2026-09-06T00:00:00Z", true},
+		{"wrong tag", "v1.1.0-nightly.2", "false", "2026-09-06T00:00:00Z", false},
+		{"draft", "v1.1.0-nightly.1", "true", "2026-09-06T00:00:00Z", false},
+		{"invalid timestamp", "v1.1.0-nightly.1", "false", "unknown", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if request.URL.String() != "https://api.github.com/repos/Hikyo-Org/Hikyo/releases/tags/v1.1.0-nightly.1" {
+					t.Fatalf("unexpected request: %s", request.URL)
+				}
+				raw := `{"tag_name":"` + tc.tag + `","draft":` + tc.draft + `,"prerelease":true,"immutable":true,"published_at":"` + tc.published + `","assets":[]}`
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(raw))}, nil
+			})}
+			release, err := NewGitHubSource(client).ReleaseByVersion(context.Background(), "1.1.0-nightly.1")
+			if (err == nil) != tc.valid {
+				t.Fatalf("lookup: %v", err)
+			}
+			if tc.valid && (release.Version != "1.1.0-nightly.1" || !release.Immutable) {
+				t.Fatalf("wrong release: %+v", release)
+			}
+		})
+	}
+}
+
+func TestExactReleaseLookupRejectsInvalidVersionBeforeNetwork(t *testing.T) {
+	source := NewGitHubSource(&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("invalid version reached network")
+		return nil, nil
+	})})
+	for _, version := range []string{"", "../../main", "v1.0.0", "1.0.0?draft=true"} {
+		if _, err := source.ReleaseByVersion(t.Context(), version); err == nil {
+			t.Fatalf("accepted %q", version)
+		}
+	}
+}

--- a/internal/upgradeassembly/assembly.go
+++ b/internal/upgradeassembly/assembly.go
@@ -1,0 +1,242 @@
+// Package upgradeassembly authenticates public release evidence and durably
+// publishes the exact offline bundle consumed by the mandatory runtime gate.
+package upgradeassembly
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/filedurability"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+// Options identifies a closed set of public evidence directories. Pinned must
+// come from an independently trusted source. Floor is the installation's durable
+// trust floor; assembly never advances it. OutputDirectory must not exist and its
+// parent must already exist. Inputs are read with bounded, no-follow semantics.
+type Options struct {
+	Pinned            releasetrust.PinnedTrust
+	Floor             releaseidentity.SnapshotFloor
+	SnapshotDirectory string
+	KeysDirectory     string
+	OutputDirectory   string
+	Releases          []string
+	Nightlies         []string
+	Bridges           []string
+}
+
+// Assemble verifies all input evidence before atomically publishing a new
+// runtime bundle. It never signs evidence, replaces output or changes trust state.
+func Assemble(ctx context.Context, o Options) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if o.SnapshotDirectory == "" || o.KeysDirectory == "" || o.OutputDirectory == "" || len(o.Releases)+len(o.Nightlies) == 0 || len(o.Releases)+len(o.Nightlies) > upgradecompat.MaxReleases || len(o.Bridges) > upgradecompat.MaxEdges {
+		return errors.New("require snapshot, keys, output and releases with bounded inventories")
+	}
+	pinned, floor := o.Pinned, o.Floor
+	snapshotFiles, err := readExact(o.SnapshotDirectory, []string{"metadata.json", "metadata.sigstore.json", "catalog.json", "catalog.sigstore.json"})
+	if err != nil {
+		return err
+	}
+	var metadata releasetrust.Metadata
+	if err := definitions.DecodeStrict(snapshotFiles["metadata.json"], &metadata); err != nil {
+		return err
+	}
+	if len(metadata.PrimaryKeys) == 0 || len(metadata.PrimaryKeys) > 256 {
+		return errors.New("invalid primary key count")
+	}
+	names := []string{}
+	index := upgradebundle.Index{Format: upgradebundle.IndexFormat, PrimaryKeyIDs: []string{}, Releases: []upgradebundle.ReleaseEntry{}, Bridges: []releaseidentity.Digest{}}
+	idPattern := regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+	for _, key := range metadata.PrimaryKeys {
+		if !safeName(key.PublicKey) || !idPattern.MatchString(key.ID) {
+			return errors.New("unsafe primary key locator")
+		}
+		names = append(names, key.PublicKey)
+		index.PrimaryKeyIDs = append(index.PrimaryKeyIDs, key.ID)
+	}
+	keyFiles, err := readExact(o.KeysDirectory, names)
+	if err != nil {
+		return err
+	}
+	keys := map[string][]byte{}
+	for _, key := range metadata.PrimaryKeys {
+		keys[key.ID] = keyFiles[key.PublicKey]
+	}
+	material := releasetrust.SnapshotMaterial{Metadata: snapshotFiles["metadata.json"], MetadataSignature: snapshotFiles["metadata.sigstore.json"], Catalog: snapshotFiles["catalog.json"], CatalogSignature: snapshotFiles["catalog.sigstore.json"], PrimaryKeys: keys}
+	snapshot, err := releasetrust.VerifySnapshot(pinned, material, floor)
+	if err != nil {
+		return fmt.Errorf("authenticate trust snapshot: %w", err)
+	}
+	output, err := filepath.Abs(o.OutputDirectory)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(output); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("output already exists or cannot be inspected")
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(output))
+	if err != nil {
+		return err
+	}
+	output = filepath.Join(parent, filepath.Base(output))
+	stage, err := os.MkdirTemp(parent, ".hikyo-upgrade-assembly-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(stage)
+	var stagedBytes int
+	write := func(name string, raw []byte) error {
+		stagedBytes += len(raw)
+		if stagedBytes > 64<<20 {
+			return errors.New("bundle exceeds aggregate document bound")
+		}
+		return writeDocument(stage, name, raw)
+	}
+	for name, raw := range snapshotFiles {
+		if err := write(name, raw); err != nil {
+			return err
+		}
+	}
+	for id, raw := range keys {
+		if err := write("keys/"+id+".pub", raw); err != nil {
+			return err
+		}
+	}
+	seen := map[releaseidentity.Digest]bool{}
+	for _, directory := range o.Releases {
+		release, files, err := readRelease(ctx, directory, snapshot)
+		if err != nil {
+			return err
+		}
+		digest := release.Identity().ManifestSHA256
+		if seen[digest] {
+			return errors.New("duplicate release manifest")
+		}
+		seen[digest] = true
+		index.Releases = append(index.Releases, upgradebundle.ReleaseEntry{Profile: releaseidentity.StableV1, ManifestSHA256: digest})
+		for name, raw := range files {
+			if err := write("releases/"+string(digest)+"/"+name, raw); err != nil {
+				return err
+			}
+		}
+	}
+	for _, directory := range o.Nightlies {
+		release, err := upgradebundle.CopyNightlyRelease(ctx, directory, filepath.Join(stage, "releases"), snapshot)
+		if err != nil {
+			return err
+		}
+		digest := release.Identity().ManifestSHA256
+		if seen[digest] {
+			return errors.New("duplicate release manifest")
+		}
+		seen[digest] = true
+		index.Releases = append(index.Releases, upgradebundle.ReleaseEntry{Profile: releaseidentity.NightlyV1, ManifestSHA256: digest})
+	}
+	seen = map[releaseidentity.Digest]bool{}
+	for _, directory := range o.Bridges {
+		files, err := readExact(directory, []string{"statement.json", "statement.sigstore.json"})
+		if err != nil {
+			return err
+		}
+		digest := releaseidentity.Hash(files["statement.json"])
+		if seen[digest] {
+			return errors.New("duplicate bridge statement")
+		}
+		seen[digest] = true
+		index.Bridges = append(index.Bridges, digest)
+		for name, raw := range files {
+			if err := write("bridges/"+string(digest)+"/"+name, raw); err != nil {
+				return err
+			}
+		}
+	}
+	slices.Sort(index.PrimaryKeyIDs)
+	slices.Sort(index.Bridges)
+	slices.SortFunc(index.Releases, func(a, b upgradebundle.ReleaseEntry) int {
+		return strings.Compare(string(a.ManifestSHA256), string(b.ManifestSHA256))
+	})
+	raw, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+	if err := write("index.json", raw); err != nil {
+		return err
+	}
+	// This final pass authenticates the exact staged bytes and requires every
+	// bridge in the current catalog, using the same reader as production boot.
+	if _, err := upgradebundle.Load(ctx, stage, pinned, floor); err != nil {
+		return fmt.Errorf("validate assembled runtime bundle: %w", err)
+	}
+	if err := syncTree(stage); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := publishDirectory(stage, output); err != nil {
+		return err
+	}
+	ancestry, err := filedurability.DirectoryAncestry(parent)
+	if err != nil {
+		return fmt.Errorf("bundle published at %s; durability unconfirmed: %w", output, err)
+	}
+	for _, directory := range ancestry {
+		if err := filedurability.SyncDirectory(directory); err != nil {
+			return fmt.Errorf("bundle published at %s; durability unconfirmed: %w", output, err)
+		}
+	}
+	return nil
+}
+
+func safeName(name string) bool {
+	return name != "" && name != "." && !strings.Contains(name, "..") && !strings.ContainsAny(name, `/\`)
+}
+
+func writeDocument(directory, name string, raw []byte) error {
+	path := filepath.Join(directory, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.Write(raw)
+	return errors.Join(writeErr, file.Sync(), file.Close())
+}
+
+func syncTree(directory string) error {
+	var directories []string
+	err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			directories = append(directories, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	slices.Reverse(directories)
+	for _, path := range directories {
+		if err := filedurability.SyncDirectory(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/upgradeassembly/assembly.go
+++ b/internal/upgradeassembly/assembly.go
@@ -34,6 +34,9 @@ type Options struct {
 	Releases          []string
 	Nightlies         []string
 	Bridges           []string
+	// NightlyPolicy is the currently published nightly policy when the caller
+	// obtained one online; its revocations then apply to every nightly input.
+	NightlyPolicy []byte
 }
 
 // Assemble verifies all input evidence before atomically publishing a new
@@ -75,7 +78,7 @@ func Assemble(ctx context.Context, o Options) error {
 	for _, key := range metadata.PrimaryKeys {
 		keys[key.ID] = keyFiles[key.PublicKey]
 	}
-	material := releasetrust.SnapshotMaterial{Metadata: snapshotFiles["metadata.json"], MetadataSignature: snapshotFiles["metadata.sigstore.json"], Catalog: snapshotFiles["catalog.json"], CatalogSignature: snapshotFiles["catalog.sigstore.json"], PrimaryKeys: keys}
+	material := releasetrust.SnapshotMaterial{Metadata: snapshotFiles["metadata.json"], MetadataSignature: snapshotFiles["metadata.sigstore.json"], Catalog: snapshotFiles["catalog.json"], CatalogSignature: snapshotFiles["catalog.sigstore.json"], PrimaryKeys: keys, NightlyPolicy: o.NightlyPolicy}
 	snapshot, err := releasetrust.VerifySnapshot(pinned, material, floor)
 	if err != nil {
 		return fmt.Errorf("authenticate trust snapshot: %w", err)

--- a/internal/upgradeassembly/assembly_test.go
+++ b/internal/upgradeassembly/assembly_test.go
@@ -1,0 +1,62 @@
+//go:build darwin || linux
+
+package upgradeassembly
+
+import (
+	"context"
+	"errors"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPublicationNeverReplacesAnOutput(t *testing.T) {
+	// An empty existing directory must not be overwritten either, even when it
+	// appears between the initial absence check and the final atomic rename.
+	stage, output := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(stage, "sentinel"), []byte("preserve"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishDirectory(stage, output); err == nil {
+		t.Fatal("replaced existing directory")
+	}
+	if _, err := os.Stat(filepath.Join(stage, "sentinel")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAssemblyRejectsUnboundedInventoriesBeforeReadingInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name                         string
+		releases, nightlies, bridges int
+	}{
+		{"missing release", 0, 0, 0},
+		{"too many releases", upgradecompat.MaxReleases + 1, 0, 0},
+		{"combined releases exceed bound", upgradecompat.MaxReleases, 1, 0},
+		{"too many bridges", 1, 0, upgradecompat.MaxEdges + 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := Options{
+				SnapshotDirectory: "does-not-exist", KeysDirectory: "does-not-exist",
+				OutputDirectory: filepath.Join(t.TempDir(), "bundle"),
+				Releases:        make([]string, tc.releases), Nightlies: make([]string, tc.nightlies), Bridges: make([]string, tc.bridges),
+			}
+			err := Assemble(t.Context(), opts)
+			if err == nil || errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("inventory bound was not enforced before file reads: %v", err)
+			}
+			if _, err := os.Lstat(opts.OutputDirectory); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("invalid inventory published: %v", err)
+			}
+		})
+	}
+}
+
+func TestAssemblyReturnsCancellationBeforeReadingInputs(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := Assemble(ctx, Options{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation: %v", err)
+	}
+}

--- a/internal/upgradeassembly/files_darwin.go
+++ b/internal/upgradeassembly/files_darwin.go
@@ -1,4 +1,4 @@
-package main
+package upgradeassembly
 
 import (
 	"os"

--- a/internal/upgradeassembly/files_linux.go
+++ b/internal/upgradeassembly/files_linux.go
@@ -1,0 +1,15 @@
+package upgradeassembly
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openDocument(root *os.Root, name string) (*os.File, error) {
+	return root.OpenFile(name, os.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+}
+
+func publishDirectory(stage, output string) error {
+	return unix.Renameat2(unix.AT_FDCWD, stage, unix.AT_FDCWD, output, unix.RENAME_NOREPLACE)
+}

--- a/internal/upgradeassembly/files_other.go
+++ b/internal/upgradeassembly/files_other.go
@@ -1,6 +1,6 @@
 //go:build !darwin && !linux
 
-package main
+package upgradeassembly
 
 import (
 	"errors"

--- a/internal/upgradeassembly/read.go
+++ b/internal/upgradeassembly/read.go
@@ -1,4 +1,4 @@
-package main
+package upgradeassembly
 
 import (
 	"context"
@@ -60,7 +60,9 @@ func readMember(root *os.Root, name string) ([]byte, error) {
 	return raw, nil
 }
 
-func readPath(path string) ([]byte, error) {
+// ReadDocument reads a bounded, regular public document without following a
+// final symlink. This is intended for independently pinned roots and trust floors.
+func ReadDocument(path string) ([]byte, error) {
 	root, err := openDirectory(filepath.Dir(path))
 	if err != nil {
 		return nil, err

--- a/internal/upgradebundle/bundle.go
+++ b/internal/upgradebundle/bundle.go
@@ -271,5 +271,22 @@ func (b Bundle) Sources(engine releaseidentity.Engine) []upgradecompat.Installed
 		}
 		candidates = append(candidates, upgradecompat.InstalledSource{Identity: releaseidentity.Source{Release: node.Identity()}, Migrations: manifest, SchemaSHA256: schema})
 	}
+	for _, bridge := range b.bridges {
+		statement := bridge.Statement()
+		if statement.SourceMigrations.Engine != engine {
+			continue
+		}
+		candidate := upgradecompat.InstalledSource{Identity: statement.SourceIdentity(), Migrations: statement.SourceMigrations, SchemaSHA256: statement.SourceSchemaSHA256}
+		duplicate := false
+		for _, existing := range candidates {
+			if existing.Identity == candidate.Identity && existing.SchemaSHA256 == candidate.SchemaSHA256 && slices.Equal(existing.Migrations.Entries, candidate.Migrations.Entries) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			candidates = append(candidates, candidate)
+		}
+	}
 	return candidates
 }

--- a/internal/upgradebundle/nightly_test.go
+++ b/internal/upgradebundle/nightly_test.go
@@ -75,6 +75,21 @@ func TestNightlyOfflineBundleAuthenticatesActualClosedPayloadDirectory(t *testin
 			if err != nil {
 				t.Fatal(err)
 			}
+			refs, err := bundle.ReferencedReleases(releaseidentity.SQLite)
+			if err != nil || len(refs) != 1 || refs[0] != node.Identity() {
+				t.Fatalf("legacy bridge target reference missing: %+v %v", refs, err)
+			}
+			// A bridge can identify a source schema even when no loaded target
+			// declaration repeats its legacy genesis. Keep that candidate usable
+			// for inspection, without inventing a signed legacy release identity.
+			bridgeOnly := Bundle{snapshot: bundle.snapshot, bridges: bundle.bridges}
+			candidates := bridgeOnly.Sources(releaseidentity.SQLite)
+			if len(candidates) != 1 || candidates[0].Identity != source.Identity || candidates[0].SchemaSHA256 != source.SchemaSHA256 {
+				t.Fatalf("bridge source inspection missing: %+v", candidates)
+			}
+			if candidates := bridgeOnly.Sources(releaseidentity.Postgres); len(candidates) != 0 {
+				t.Fatal("bridge source leaked across engines")
+			}
 			plan, err := bundle.Plan(source, node.Identity())
 			if err != nil || !plan.Valid() || !plan.RequiresOperatorAttestation() {
 				t.Fatal("recovery-authorized nightly route refused or lost operator proof", err)

--- a/internal/upgradebundle/references.go
+++ b/internal/upgradebundle/references.go
@@ -1,0 +1,62 @@
+package upgradebundle
+
+import (
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+// ReferencedReleases returns a bounded, deterministic set of exact release
+// identities named by authenticated source edges and recovery bridges for this
+// engine. References are discovery hints, not authenticated release envelopes or
+// an execution route. Fetch exact matching proofs and call Plan after inspection.
+func (b Bundle) ReferencedReleases(engine releaseidentity.Engine) ([]releaseidentity.Identity, error) {
+	if !b.Valid() || engine.Validate() != nil {
+		return nil, errors.New("release discovery requires an authenticated bundle and supported engine")
+	}
+	seen := map[releaseidentity.Identity]bool{}
+	manifests := map[releaseidentity.Digest]releaseidentity.Identity{}
+	add := func(identity releaseidentity.Identity) error {
+		if previous, ok := manifests[identity.ManifestSHA256]; ok && previous != identity {
+			return errors.New("conflicting identities for referenced release manifest")
+		}
+		manifests[identity.ManifestSHA256] = identity
+		seen[identity] = true
+		if len(seen) > upgradecompat.MaxReleases {
+			return errors.New("referenced release inventory exceeds bound")
+		}
+		return nil
+	}
+	for _, node := range b.nodes {
+		for _, identity := range node.ReferencedReleases(engine) {
+			if err := add(identity); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, bridge := range b.bridges {
+		statement := bridge.Statement()
+		if statement.TargetMigrations.Engine != engine {
+			continue
+		}
+		if err := add(statement.Target); err != nil {
+			return nil, err
+		}
+		if statement.SourceIdentity().IsRelease() {
+			if err := add(statement.Source); err != nil {
+				return nil, err
+			}
+		}
+	}
+	result := make([]releaseidentity.Identity, 0, len(seen))
+	for identity := range seen {
+		result = append(result, identity)
+	}
+	slices.SortFunc(result, func(a, b releaseidentity.Identity) int {
+		return strings.Compare(string(a.ManifestSHA256), string(b.ManifestSHA256))
+	})
+	return result, nil
+}

--- a/internal/upgradebundle/references_bound_test.go
+++ b/internal/upgradebundle/references_bound_test.go
@@ -1,0 +1,51 @@
+package upgradebundle
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+func TestReferencesRefuseOversizedOrConflictingSignedDiscovery(t *testing.T) {
+	for _, conflict := range []bool{false, true} {
+		t.Run(fmt.Sprintf("conflict=%t", conflict), func(t *testing.T) {
+			f := newBundleFixture(t)
+			count := upgradecompat.MaxReleases + 1
+			if conflict {
+				count = 2
+			}
+			edges := make([]upgradecompat.SourceEdge, 0, count)
+			for n := range count {
+				manifest := releaseidentity.Hash([]byte(fmt.Sprintf("source %d", n)))
+				if conflict {
+					manifest = releaseidentity.Hash([]byte("same manifest"))
+				}
+				identity := releaseidentity.Identity{Profile: releaseidentity.StableV1, Version: fmt.Sprintf("1.%d.0", n), Sequence: uint64(n + 1), Commit: strings.Repeat("a", 40), CompatibilitySHA256: releaseidentity.Hash([]byte("compatibility")), ManifestSHA256: manifest}
+				edges = append(edges, upgradecompat.SourceEdge{Source: releaseidentity.Source{Release: identity}, Migrations: f.source.Migrations, SchemaSHA256: f.source.SchemaSHA256, Mode: upgradecompat.Maintenance})
+			}
+			declaration := upgradecompat.Declaration{Schema: upgradecompat.Schema, Profile: releaseidentity.StableV1, Version: "10.0.0", Sequence: 1000, Commit: strings.Repeat("b", 40), Engines: []upgradecompat.EngineDeclaration{{Migrations: f.source.Migrations, SchemaSHA256: f.source.SchemaSHA256, Sources: edges}}}
+			signed := f.signer.AddStable(t, declaration.Version, int64(declaration.Sequence), declaration.Commit, testfixture.JSON(t, declaration))
+			snapshot, err := releasetrust.VerifySnapshot(f.signer.Pinned, f.signer.Material(t), releaseidentity.SnapshotFloor{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			release, err := releasetrust.VerifyStable(snapshot, signed.Material)
+			if err != nil {
+				t.Fatal(err)
+			}
+			node, err := upgradecompat.Bind(release, signed.Material.Compatibility)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bundle := Bundle{snapshot: snapshot, nodes: []upgradecompat.VerifiedNode{node}}
+			if refs, err := bundle.ReferencedReleases(releaseidentity.SQLite); err == nil || refs != nil {
+				t.Fatalf("unsafe signed discovery accepted: %d references, %v", len(refs), err)
+			}
+		})
+	}
+}

--- a/internal/upgradebundle/references_test.go
+++ b/internal/upgradebundle/references_test.go
@@ -1,0 +1,37 @@
+package upgradebundle_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle/testfixture"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
+)
+
+func TestReferencesExposeExactAuthenticatedPredecessorWithoutInventingGenesisRelease(t *testing.T) {
+	migrations := releaseidentity.MigrationManifest{Engine: releaseidentity.SQLite, Entries: []releaseidentity.Migration{{Version: 1, SHA256: releaseidentity.Hash([]byte("SQL"))}}}
+	schema := releaseidentity.Hash([]byte("catalog"))
+	source := upgradecompat.InstalledSource{Identity: releaseidentity.Source{Genesis: releaseidentity.LegacyGenesisV1}, Migrations: migrations, SchemaSHA256: schema}
+	fixture := testfixture.Write(t, source, []testfixture.Target{
+		{Version: "1.0.0", Sequence: 1, Commit: strings.Repeat("a", 40), Migrations: migrations, SchemaSHA256: schema},
+		{Version: "1.1.0", Sequence: 2, Commit: strings.Repeat("b", 40), Migrations: migrations, SchemaSHA256: schema},
+	})
+	refs, err := fixture.Bundle.ReferencedReleases(releaseidentity.SQLite)
+	if err != nil || len(refs) != 1 || refs[0] != fixture.Identities[0] {
+		t.Fatalf("exact predecessor unavailable: %+v %v", refs, err)
+	}
+	refs[0].ManifestSHA256 = releaseidentity.Hash([]byte("mutated caller copy"))
+	again, err := fixture.Bundle.ReferencedReleases(releaseidentity.SQLite)
+	if err != nil || again[0] != fixture.Identities[0] {
+		t.Fatal("reference accessor mutated authenticated evidence")
+	}
+	other, err := fixture.Bundle.ReferencedReleases(releaseidentity.Postgres)
+	if err != nil || len(other) != 0 {
+		t.Fatalf("references leaked across engines: %+v %v", other, err)
+	}
+	if _, err := (upgradebundle.Bundle{}).ReferencedReleases(releaseidentity.SQLite); err == nil {
+		t.Fatal("unverified bundle supplied discovery references")
+	}
+}

--- a/internal/upgradecompat/declaration.go
+++ b/internal/upgradecompat/declaration.go
@@ -223,3 +223,23 @@ func nodeKey(source releaseidentity.Source) string {
 	i := source.Release
 	return fmt.Sprintf("%s:%d:%s:%s:%s:%s", i.Profile, i.Sequence, i.Version, i.Commit, i.CompatibilitySHA256, i.ManifestSHA256)
 }
+
+// ReferencedReleases returns exact signed source references for evidence
+// discovery. The referenced envelopes must still be authenticated independently.
+func (n VerifiedNode) ReferencedReleases(engine releaseidentity.Engine) []releaseidentity.Identity {
+	result := []releaseidentity.Identity{}
+	if !n.Valid() {
+		return result
+	}
+	for _, declaration := range n.state.declaration.Engines {
+		if declaration.Migrations.Engine != engine {
+			continue
+		}
+		for _, edge := range declaration.Sources {
+			if edge.Source.IsRelease() {
+				result = append(result, edge.Source.Release)
+			}
+		}
+	}
+	return result
+}

--- a/internal/upgradecustody/files_other.go
+++ b/internal/upgradecustody/files_other.go
@@ -1,0 +1,18 @@
+//go:build !unix
+
+package upgradecustody
+
+import (
+	"errors"
+	"os"
+)
+
+func custodyDirectory(string, bool, int) (*os.File, error) {
+	return nil, errors.New("local operator custody is unsupported on this platform")
+}
+func publish(*os.File, []byte) error {
+	return errors.New("local operator custody is unsupported on this platform")
+}
+func read(*os.File, int) ([]byte, error) {
+	return nil, errors.New("local operator custody is unsupported on this platform")
+}

--- a/internal/upgradecustody/files_unix.go
+++ b/internal/upgradecustody/files_unix.go
@@ -1,0 +1,112 @@
+//go:build unix
+
+package upgradecustody
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// Walk from / with directory descriptors and O_NOFOLLOW. Every ancestor must
+// be controlled by root (or the injected owner in tests). Root-owned sticky
+// temporary directories are safe because each next component is also checked.
+func custodyDirectory(path string, create bool, owner int) (*os.File, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || path == "/" || os.Geteuid() != owner {
+		return nil, errors.New("operator custody requires an absolute clean path and root privileges")
+	}
+	fd, err := unix.Open("/", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, errors.New("open operator custody root")
+	}
+	current := os.NewFile(uintptr(fd), "/")
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	for i, part := range parts {
+		last := i == len(parts)-1
+		child, err := unix.Openat(int(current.Fd()), part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if errors.Is(err, unix.ENOENT) && last && create {
+			if err = unix.Mkdirat(int(current.Fd()), part, 0700); err == nil {
+				err = current.Sync()
+			}
+			if err == nil {
+				child, err = unix.Openat(int(current.Fd()), part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+			}
+		}
+		current.Close()
+		if err != nil {
+			return nil, errors.New("operator custody path must contain safe real directories")
+		}
+		current = os.NewFile(uintptr(child), part)
+		var st unix.Stat_t
+		err = unix.Fstat(child, &st)
+		safe := err == nil && (st.Uid == 0 || st.Uid == uint32(owner)) && (st.Mode&0022 == 0 || st.Uid == 0 && st.Mode&unix.S_ISVTX != 0)
+		if last {
+			safe = err == nil && st.Uid == uint32(owner) && st.Mode&07777 == 0700
+		}
+		if !safe {
+			current.Close()
+			return nil, errors.New("operator custody directory has unsafe ownership or permissions")
+		}
+	}
+	return current, nil
+}
+
+func publish(dir *os.File, ciphertext []byte) error {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return errors.New("create encrypted custody temporary name")
+	}
+	name := ".operator-" + hex.EncodeToString(nonce[:])
+	fd, err := unix.Openat(int(dir.Fd()), name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0600)
+	if err != nil {
+		return errors.New("create encrypted operator custody")
+	}
+	f := os.NewFile(uintptr(fd), name)
+	defer f.Close()
+	defer unix.Unlinkat(int(dir.Fd()), name, 0)
+	if _, err := f.Write(ciphertext); err != nil {
+		return errors.New("write encrypted operator custody")
+	}
+	if err := f.Sync(); err != nil {
+		return errors.New("sync encrypted operator custody")
+	}
+	if err := f.Close(); err != nil {
+		return errors.New("close encrypted operator custody")
+	}
+	// linkat is the atomic no-overwrite publication point. A crash may leave an
+	// encrypted temporary file, never a plaintext secret or a partial final file.
+	if err := unix.Linkat(int(dir.Fd()), name, int(dir.Fd()), fileName, 0); err != nil {
+		return errors.New("publish operator custody: existing custody is never replaced")
+	}
+	if err := unix.Unlinkat(int(dir.Fd()), name, 0); err != nil {
+		return errors.New("remove encrypted operator custody temporary link")
+	}
+	if err := dir.Sync(); err != nil {
+		return errors.New("sync operator custody directory")
+	}
+	return nil
+}
+
+func read(dir *os.File, owner int) ([]byte, error) {
+	fd, err := unix.Openat(int(dir.Fd()), fileName, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, errors.New("open encrypted operator custody")
+	}
+	f := os.NewFile(uintptr(fd), fileName)
+	defer f.Close()
+	var st unix.Stat_t
+	if unix.Fstat(fd, &st) != nil || st.Mode&unix.S_IFMT != unix.S_IFREG || st.Mode&07777 != 0600 || st.Uid != uint32(owner) || st.Nlink != 1 || st.Size <= 0 || st.Size > maxCiphertext {
+		return nil, errors.New("operator custody file has unsafe type, ownership, permissions, links, or size")
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxCiphertext+1))
+	if err != nil || len(raw) > maxCiphertext {
+		return nil, errors.New("read encrypted operator custody")
+	}
+	return raw, nil
+}

--- a/internal/upgradecustody/vault.go
+++ b/internal/upgradecustody/vault.go
@@ -1,0 +1,260 @@
+// Package upgradecustody owns encrypted, operator-only installation custody.
+// Only the interactive operator process may open a Vault. Its private material
+// must never enter server configuration, deployment adapters, or child argv/env.
+package upgradecustody
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"filippo.io/age"
+	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
+	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
+	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+const (
+	fileName      = "operator.age"
+	vaultFormat   = "hikyo.operator-custody/v1"
+	maxCiphertext = 16 << 10
+	maxPlaintext  = 8 << 10
+	workFactor    = 18 // Maintained age default; cap hostile decrypt requests here too.
+)
+
+// Vault holds unlocked material in memory until Close. Callers own and must
+// clear the copies returned by RootKey. Go and age may retain temporary secret
+// strings until garbage collection; Close is best effort, not locked memory.
+type Vault struct {
+	mu        sync.Mutex
+	key       *ecdsa.PrivateKey
+	identity  []byte
+	root      []byte
+	public    []byte
+	recipient string
+	pin       backupreceipt.PinnedOperator
+}
+
+type record struct {
+	Format     string `json:"format"`
+	Instance   string `json:"instance"`
+	Identity   []byte `json:"backup_identity"`
+	PrivateKey []byte `json:"attestation_private_key"`
+	RootKey    []byte `json:"root_escrow"`
+}
+
+func (r *record) clear() {
+	clear(r.Identity)
+	clear(r.PrivateKey)
+	clear(r.RootKey)
+}
+
+// Create initializes operator.age without replacing existing custody. The
+// parent directory must already exist; directory is created with mode 0700.
+// passphrase is borrowed and never persisted. The caller must clear it.
+func Create(directory string, passphrase, rootKey []byte, instance string) (*Vault, error) {
+	return create(directory, passphrase, rootKey, instance, 0)
+}
+
+func create(directory string, passphrase, rootKey []byte, instance string, owner int) (*Vault, error) {
+	if len(rootKey) != 32 || len(passphrase) == 0 || len(passphrase) > 1024 {
+		return nil, errors.New("operator custody requires a 32-byte root escrow and a nonempty bounded passphrase")
+	}
+	dir, err := custodyDirectory(directory, true, owner)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		return nil, errors.New("generate operator backup identity")
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, errors.New("generate operator signing key")
+	}
+	defer func() { clear(key.D.Bits()); key.D.SetInt64(0) }()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, errors.New("encode operator signing key")
+	}
+	r := record{Format: vaultFormat, Instance: instance, Identity: []byte(identity.String()), PrivateKey: der, RootKey: bytes.Clone(rootKey)}
+	defer r.clear()
+	vault, err := decodeRecord(r, instance)
+	if err != nil {
+		return nil, err
+	}
+	ok := false
+	defer func() {
+		if !ok {
+			vault.Close()
+		}
+	}()
+	plain, err := json.Marshal(r)
+	if err != nil {
+		return nil, errors.New("encode operator custody")
+	}
+	defer clear(plain)
+	recipient, err := age.NewScryptRecipient(string(passphrase))
+	if err != nil {
+		return nil, errors.New("invalid operator passphrase")
+	}
+	recipient.SetWorkFactor(workFactor)
+	var ciphertext bytes.Buffer
+	w, err := age.Encrypt(&ciphertext, recipient)
+	if err != nil {
+		return nil, errors.New("encrypt operator custody")
+	}
+	if _, err = w.Write(plain); err != nil {
+		return nil, errors.New("encrypt operator custody")
+	}
+	if err = w.Close(); err != nil {
+		return nil, errors.New("finish encrypted operator custody")
+	}
+	if err := publish(dir, ciphertext.Bytes()); err != nil {
+		return nil, err
+	}
+	ok = true
+	return vault, nil
+}
+
+// Open decrypts custody only after checking directory/file ownership and modes.
+// instance must come from inspection of the installation, never from an archive.
+func Open(directory string, passphrase []byte, instance string) (*Vault, error) {
+	return open(directory, passphrase, instance, 0)
+}
+
+func open(directory string, passphrase []byte, instance string, owner int) (*Vault, error) {
+	if len(passphrase) == 0 || len(passphrase) > 1024 {
+		return nil, errors.New("invalid operator passphrase")
+	}
+	dir, err := custodyDirectory(directory, false, owner)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+	ciphertext, err := read(dir, owner)
+	if err != nil {
+		return nil, err
+	}
+	identity, err := age.NewScryptIdentity(string(passphrase))
+	if err != nil {
+		return nil, errors.New("invalid operator passphrase")
+	}
+	identity.SetMaxWorkFactor(workFactor)
+	reader, err := age.Decrypt(bytes.NewReader(ciphertext), identity)
+	if err != nil {
+		return nil, errors.New("operator custody unlock failed")
+	}
+	plain, err := io.ReadAll(io.LimitReader(reader, maxPlaintext+1))
+	defer clear(plain)
+	if err != nil || len(plain) > maxPlaintext {
+		return nil, errors.New("operator custody unlock failed")
+	}
+	var r record
+	defer r.clear()
+	if definitions.DecodeStrict(plain, &r) != nil {
+		return nil, errors.New("invalid encrypted operator custody")
+	}
+	return decodeRecord(r, instance)
+}
+
+func decodeRecord(r record, instance string) (*Vault, error) {
+	if r.Format != vaultFormat || r.Instance != instance || len(r.RootKey) != 32 || len(r.Identity) > 256 || len(r.PrivateKey) > 1024 {
+		return nil, errors.New("operator custody does not match installation")
+	}
+	identity, err := age.ParseX25519Identity(string(r.Identity))
+	if err != nil {
+		return nil, errors.New("invalid operator backup identity")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(r.PrivateKey)
+	if err != nil {
+		return nil, errors.New("invalid operator signing key")
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok || key.Curve != elliptic.P256() {
+		return nil, errors.New("operator signing key must use P-256")
+	}
+	publicDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		key.D.SetInt64(0)
+		return nil, errors.New("invalid operator public key")
+	}
+	public := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER})
+	pin, err := backupreceipt.PinOperator(instance, public)
+	if err != nil {
+		key.D.SetInt64(0)
+		return nil, errors.New("invalid operator installation pin")
+	}
+	return &Vault{key: key, identity: bytes.Clone(r.Identity), root: bytes.Clone(r.RootKey), public: public, recipient: identity.Recipient().String(), pin: pin}, nil
+}
+
+// PublicKey returns a copy of the public attestation key, safe for the runtime.
+func (v *Vault) PublicKey() []byte                 { v.mu.Lock(); defer v.mu.Unlock(); return bytes.Clone(v.public) }
+func (v *Vault) Recipient() string                 { v.mu.Lock(); defer v.mu.Unlock(); return v.recipient }
+func (v *Vault) Pin() backupreceipt.PinnedOperator { v.mu.Lock(); defer v.mu.Unlock(); return v.pin }
+func (v *Vault) RootKey() []byte                   { v.mu.Lock(); defer v.mu.Unlock(); return bytes.Clone(v.root) }
+
+// BackupUnlock is operator-only; never hand this to the server or host adapter.
+func (v *Vault) BackupUnlock() backup.Unlock {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return backup.Unlock{Identity: string(v.identity)}
+}
+
+// SignAttestation signs only a validated, currently usable statement bound to
+// this vault's instance and operator key. Drill proof remains the caller's job.
+func (v *Vault) SignAttestation(raw []byte, now time.Time) ([]byte, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(raw) > backupreceipt.MaxArtifactBytes {
+		return nil, errors.New("operator attestation exceeds size bound")
+	}
+	raw = bytes.Clone(raw)
+	a, err := backupreceipt.ParseAttestation(raw)
+	if err != nil || v.key == nil || a.InstanceID != v.pin.InstanceID() || a.OperatorKeyID != v.pin.KeyID() || now.Before(a.IssuedAt) || !now.Before(a.ExpiresAt) {
+		return nil, errors.New("operator attestation does not match unlocked custody or validity window")
+	}
+	signer, err := signature.LoadSigner(v.key, crypto.SHA256)
+	if err != nil {
+		return nil, errors.New("load operator attestation signer")
+	}
+	sig, err := signer.SignMessage(bytes.NewReader(raw))
+	if err != nil {
+		return nil, errors.New("sign operator attestation")
+	}
+	bundle, err := json.Marshal(releasetrust.LegacyBundle{Base64Signature: base64.StdEncoding.EncodeToString(sig)})
+	if err != nil || backupreceipt.CheckOperatorSignature(v.pin, bundle, raw) != nil {
+		return nil, errors.New("verify generated operator attestation signature")
+	}
+	return bundle, nil
+}
+
+func (v *Vault) String() string   { return "[operator custody]" }
+func (v *Vault) GoString() string { return v.String() }
+
+// Close clears owned secret buffers and disables signing. It is idempotent.
+func (v *Vault) Close() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	clear(v.identity)
+	clear(v.root)
+	v.identity, v.root = nil, nil
+	if v.key != nil {
+		clear(v.key.D.Bits())
+		v.key.D.SetInt64(0)
+		v.key = nil
+	}
+}

--- a/internal/upgradecustody/vault_test.go
+++ b/internal/upgradecustody/vault_test.go
@@ -1,0 +1,269 @@
+//go:build unix
+
+package upgradecustody
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+)
+
+const instance = "ins_22222222222222222222222222222222"
+
+func testDirectory(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "custody")
+}
+
+func testVault(t *testing.T) (string, *Vault) {
+	t.Helper()
+	dir := testDirectory(t)
+	v, err := create(dir, []byte("correct horse battery staple"), bytes.Repeat([]byte{0x7b}, 32), instance, os.Geteuid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(v.Close)
+	return dir, v
+}
+
+func TestEncryptedCustodyRoundTripAndClose(t *testing.T) {
+	dir, v := testVault(t)
+	raw, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range [][]byte{v.RootKey(), v.identity, []byte(base64.StdEncoding.EncodeToString(v.RootKey())), []byte("correct horse battery staple"), []byte("root_escrow")} {
+		if bytes.Contains(raw, secret) {
+			t.Fatal("plaintext secret present in encrypted custody")
+		}
+	}
+	files, err := os.ReadDir(dir)
+	if err != nil || len(files) != 1 || files[0].Name() != fileName {
+		t.Fatalf("unexpected custody files: %v %v", files, err)
+	}
+	got, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Close()
+	if !bytes.Equal(got.RootKey(), v.RootKey()) || !bytes.Equal(got.PublicKey(), v.PublicKey()) || got.Recipient() != v.Recipient() || got.Pin().KeyID() != v.Pin().KeyID() {
+		t.Fatal("reopened custody identity changed")
+	}
+	backupIdentity, err := age.ParseX25519Identity(got.BackupUnlock().Identity)
+	if err != nil || backupIdentity.Recipient().String() != got.Recipient() {
+		t.Fatal("backup unlock differs from recipient")
+	}
+	rootCopy, pubCopy := got.RootKey(), got.PublicKey()
+	clear(rootCopy)
+	clear(pubCopy)
+	if !bytes.Equal(got.RootKey(), v.RootKey()) || !bytes.Equal(got.PublicKey(), v.PublicKey()) {
+		t.Fatal("accessors exposed owned buffers")
+	}
+	if fmt.Sprintf("%v", got) != "[operator custody]" || fmt.Sprintf("%#v", got) != "[operator custody]" {
+		t.Fatal("formatted vault can expose private fields")
+	}
+	ownedIdentity, ownedRoot, key := got.identity, got.root, got.key
+	got.Close()
+	got.Close()
+	if len(got.RootKey()) != 0 || got.BackupUnlock().Identity != "" || key.D.Sign() != 0 || !bytes.Equal(ownedIdentity, make([]byte, len(ownedIdentity))) || !bytes.Equal(ownedRoot, make([]byte, len(ownedRoot))) {
+		t.Fatal("Close left owned secret material usable")
+	}
+}
+
+func TestUnlockRejectsWrongPassphraseInstanceCorruptionAndCost(t *testing.T) {
+	dir, _ := testVault(t)
+	path := filepath.Join(dir, fileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, password, instance string
+		raw                      []byte
+	}{
+		{"wrong password", "wrong", instance, raw},
+		{"wrong installation", "correct horse battery staple", "ins_33333333333333333333333333333333", raw},
+		{"truncated ciphertext", "correct horse battery staple", instance, raw[:len(raw)-1]},
+		{"excessive work", "correct horse battery staple", instance, bytes.Replace(raw, []byte(" 18\n"), []byte(" 30\n"), 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(path, tc.raw, 0600); err != nil {
+				t.Fatal(err)
+			}
+			v, err := open(dir, []byte(tc.password), tc.instance, os.Geteuid())
+			if err == nil {
+				v.Close()
+				t.Fatal("invalid custody unlocked")
+			}
+			if strings.Contains(err.Error(), tc.password) {
+				t.Fatal("unlock error revealed passphrase")
+			}
+		})
+	}
+}
+
+func validAttestation(v *Vault, now time.Time) backupreceipt.Attestation {
+	return backupreceipt.Attestation{
+		Authority: backupreceipt.LedgerAuthority, Format: backupreceipt.AttestationFormat,
+		ReceiptSHA256: releaseidentity.Hash([]byte("receipt")), RouteSHA256: releaseidentity.Hash([]byte("route")), BridgeSHA256: []releaseidentity.Digest{},
+		TargetIdentity: releaseidentity.Identity{Profile: releaseidentity.StableV1, Version: "1.0.0", Sequence: 1, Commit: strings.Repeat("a", 40), CompatibilitySHA256: releaseidentity.Hash([]byte("compatibility")), ManifestSHA256: releaseidentity.Hash([]byte("manifest"))},
+		InstanceID:     instance, RecoveryIncarnation: backupreceipt.Nonce(strings.Repeat("3", 64)), SourceGeneration: 1, RouteGeneration: 2,
+		OperatorKeyID: v.Pin().KeyID(), IssuedAt: now, ExpiresAt: now.Add(time.Hour), Nonce: backupreceipt.Nonce(strings.Repeat("4", 64)),
+	}
+}
+
+func TestAttestationSigningBindsInstallationKeyAndWindow(t *testing.T) {
+	_, v := testVault(t)
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	a := validAttestation(v, now)
+	raw, err := json.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := v.SignAttestation(raw, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := releasetrust.VerifyOperatorSignature(v.PublicKey(), sig, raw); err != nil {
+		t.Fatal(err)
+	}
+	tampered := bytes.Replace(raw, []byte("\"restore_epoch\":0"), []byte("\"restore_epoch\":1"), 1)
+	if err := releasetrust.VerifyOperatorSignature(v.PublicKey(), sig, tampered); err == nil {
+		t.Fatal("modified statement verified")
+	}
+	for _, tc := range []struct {
+		name  string
+		alter func(*backupreceipt.Attestation)
+		at    time.Time
+	}{
+		{"wrong instance", func(a *backupreceipt.Attestation) { a.InstanceID = "ins_33333333333333333333333333333333" }, now},
+		{"wrong key", func(a *backupreceipt.Attestation) { a.OperatorKeyID = releaseidentity.Hash([]byte("other key")) }, now},
+		{"invalid statement", func(a *backupreceipt.Attestation) { a.ReceiptSHA256 = "bad" }, now},
+		{"future", func(*backupreceipt.Attestation) {}, now.Add(-time.Second)},
+		{"expired", func(*backupreceipt.Attestation) {}, now.Add(time.Hour)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := a
+			tc.alter(&changed)
+			raw, err := json.Marshal(changed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := v.SignAttestation(raw, tc.at); err == nil {
+				t.Fatal("unbound or unusable attestation signed")
+			}
+		})
+	}
+	v.Close()
+	if _, err := v.SignAttestation(raw, now); err == nil {
+		t.Fatal("closed custody signed")
+	}
+}
+
+func TestCustodyNeverReplacesExistingKeys(t *testing.T) {
+	dir, v := testVault(t)
+	before, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := create(dir, []byte("different password"), bytes.Repeat([]byte{0x21}, 32), instance, os.Geteuid()); err == nil {
+		t.Fatal("existing custody replaced")
+	}
+	after, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatal("failed create changed existing custody")
+	}
+	if !v.Pin().Valid() {
+		t.Fatal("existing pin invalidated")
+	}
+}
+
+func TestCustodyRefusesUnsafePathsAndFiles(t *testing.T) {
+	dir, _ := testVault(t)
+	path := filepath.Join(dir, fileName)
+	for _, mode := range []os.FileMode{0644, 0400, 0660} {
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+			t.Fatal("unsafe custody file permissions accepted")
+		}
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+		t.Fatal("unsafe custody directory permissions accepted")
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(filepath.Dir(dir), "linked-custody")
+	if err := os.Symlink(dir, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(link, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+		t.Fatal("symlink directory accepted")
+	}
+	if err := os.Rename(path, path+".saved"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(path+".saved", path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+		t.Fatal("symlink file accepted")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(path+".saved", path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+		t.Fatal("hardlinked custody accepted")
+	}
+	if os.Geteuid() != 0 {
+		if _, err := Create(testDirectory(t), []byte("passphrase"), make([]byte, 32), instance); err == nil {
+			t.Fatal("non-root production custody accepted")
+		}
+	}
+}
+
+func TestCustodyRefusesUnsafeAncestorAndOversizedFile(t *testing.T) {
+	dir, _ := testVault(t)
+	parent := filepath.Dir(dir)
+	if err := os.Chmod(parent, 0777); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+		t.Fatal("writable ancestor accepted")
+	}
+	if err := os.Chmod(parent, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, fileName), make([]byte, maxCiphertext+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
+		t.Fatal("oversized ciphertext accepted")
+	}
+}

--- a/scripts/ci/host-upgrade-helper/main.go
+++ b/scripts/ci/host-upgrade-helper/main.go
@@ -1,0 +1,58 @@
+// host-upgrade-helper exercises the deployment adapter against real systemd.
+// It deliberately does not implement Hikyo migration or release verification.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 || os.Geteuid() == 0 || os.Getegid() == 0 {
+		return fmt.Errorf("helper requires an unprivileged operation")
+	}
+	key := os.Getenv("HIKYO_ROOT_KEY_FILE")
+	for _, arg := range os.Args[2:] {
+		if strings.HasPrefix(arg, "--root-key-file=") {
+			key = strings.TrimPrefix(arg, "--root-key-file=")
+		}
+	}
+	raw, err := os.ReadFile(key)
+	if err != nil || string(raw) != strings.Repeat("a", 64) {
+		return fmt.Errorf("runtime credential unavailable at %s: %v", key, err)
+	}
+	if _, err := os.ReadFile("/etc/hikyo/upgrade-keys/operator.age"); !os.IsPermission(err) {
+		return fmt.Errorf("operator custody is not isolated from runtime")
+	}
+	if os.Getenv("OPERATOR_PASSPHRASE") != "" {
+		return fmt.Errorf("operator environment leaked")
+	}
+	switch os.Args[1] {
+	case "server":
+		return http.ListenAndServe("127.0.0.1:8081", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/readyz" {
+				ready, _ := os.ReadFile("ready")
+				if string(ready) != "ready" {
+					w.WriteHeader(http.StatusServiceUnavailable)
+				}
+			}
+		}))
+	case "migrate", "backup":
+		if key != "/proc/self/fd/3" {
+			return fmt.Errorf("child credential was not passed by descriptor")
+		}
+		fmt.Println(`{"credential":"verified","uid":"unprivileged"}`)
+		return nil
+	default:
+		return fmt.Errorf("unsupported helper operation")
+	}
+}

--- a/scripts/ci/host-upgrade-systemd.Dockerfile
+++ b/scripts/ci/host-upgrade-systemd.Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
+RUN apt-get update && apt-get install -y --no-install-recommends systemd systemd-sysv dbus && rm -rf /var/lib/apt/lists/* && useradd --system --user-group hikyo
+COPY hostupgrade.test /hostupgrade.test
+COPY host-upgrade-helper /host-upgrade-helper
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
+# Credential mounts must propagate between systemd's child mount namespaces.
+# /run is the container's own tmpfs, never a host bind mount.
+# https://github.com/systemd/systemd/issues/38103
+CMD ["/bin/sh", "-c", "mount --make-rshared /run && exec /sbin/init"]

--- a/scripts/ci/test-host-upgrade-systemd.sh
+++ b/scripts/ci/test-host-upgrade-systemd.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Actual systemd runs only inside a disposable container with private namespaces.
+set -eu
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+cd "$script_dir/../.."
+case "$(docker info --format '{{.Architecture}} {{.OSType}}')" in
+	'aarch64 linux' | 'arm64 linux') architecture=arm64 ;;
+	'x86_64 linux' | 'amd64 linux') architecture=amd64 ;;
+	*) printf 'systemd acceptance requires Linux amd64/arm64 Docker\n' >&2; exit 1 ;;
+esac
+work=$(mktemp -d)
+container_id=
+image_name="hikyo-systemd-acceptance:$$"
+cleanup() {
+	if [ -n "$container_id" ]; then docker rm -f "$container_id" >/dev/null; fi
+	docker image rm "$image_name" >/dev/null 2>&1 || true
+	rm -rf "$work"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+CGO_ENABLED=0 GOOS=linux GOARCH="$architecture" go test -c -o "$work/hostupgrade.test" ./internal/hostupgrade
+CGO_ENABLED=0 GOOS=linux GOARCH="$architecture" go build -o "$work/host-upgrade-helper" ./scripts/ci/host-upgrade-helper
+cp scripts/ci/host-upgrade-systemd.Dockerfile "$work/Dockerfile"
+docker build --quiet -t "$image_name" "$work"
+# systemd needs writable cgroups and mount namespaces to exercise the original
+# hardened unit. No host cgroup bind, Docker socket, or source mounts.
+container_id=$(docker run --detach --privileged --cgroupns=private --network=none \
+	--pids-limit=128 --memory=512m --tmpfs /run --tmpfs /run/lock --tmpfs /tmp \
+	"$image_name")
+attempt=0
+until docker exec "$container_id" systemctl show --property=Version >/dev/null 2>&1; do
+	attempt=$((attempt + 1))
+	if [ "$attempt" -ge 30 ]; then docker logs "$container_id"; exit 1; fi
+	sleep 1
+done
+if ! docker exec --env HIKYO_REAL_SYSTEMD_ACCEPTANCE=1 "$container_id" \
+	/hostupgrade.test -test.v -test.run '^TestRealSystemdUpgrade$' -test.timeout=2m; then
+	docker exec "$container_id" journalctl --unit hikyo.service --no-pager -n 100 || true
+	exit 1
+fi

--- a/scripts/ci/test-host-upgrade.sh
+++ b/scripts/ci/test-host-upgrade.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Root permission/credential/fencing acceptance in an isolated Linux container.
+set -eu
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+cd "$script_dir/../.."
+case "$(docker info --format '{{.Architecture}} {{.OSType}}')" in
+	'aarch64 linux' | 'arm64 linux') architecture=arm64 ;;
+	'x86_64 linux' | 'amd64 linux') architecture=amd64 ;;
+	*) printf 'host-upgrade tests require a Linux amd64/arm64 Docker engine\n' >&2; exit 1 ;;
+esac
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+CGO_ENABLED=0 GOOS=linux GOARCH="$architecture" go test -c -o "$work/hostupgrade.test" ./internal/hostupgrade
+docker run --rm --network=none --read-only --pids-limit=64 --memory=256m \
+	--tmpfs /root:mode=0700 --tmpfs /tmp:mode=1777 \
+	--mount "type=bind,source=$work/hostupgrade.test,target=/hostupgrade.test,readonly" \
+	alpine@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40 \
+	/hostupgrade.test -test.v -test.timeout=2m

--- a/scripts/release/assemble-upgrade/main.go
+++ b/scripts/release/assemble-upgrade/main.go
@@ -4,22 +4,17 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
-	"github.com/Hikyo-Org/hikyo/internal/filedurability"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
-	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradeassembly"
 	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
 )
 
@@ -76,18 +71,17 @@ func assemble(ctx context.Context, o options) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	root, err := readPath(o.root)
+	root, err := upgradeassembly.ReadDocument(o.root)
 	if err != nil {
 		return err
 	}
-	recovery, err := readPath(o.recovery)
+	recovery, err := upgradeassembly.ReadDocument(o.recovery)
 	if err != nil {
 		return err
 	}
-	pinned := releasetrust.PinnedTrust{Root: root, RecoveryPublicKey: recovery}
 	floor := releaseidentity.SnapshotFloor{}
 	if o.floor != "" {
-		raw, err := readPath(o.floor)
+		raw, err := upgradeassembly.ReadDocument(o.floor)
 		if err != nil {
 			return err
 		}
@@ -95,197 +89,9 @@ func assemble(ctx context.Context, o options) error {
 			return err
 		}
 	}
-	snapshotFiles, err := readExact(o.snapshot, []string{"metadata.json", "metadata.sigstore.json", "catalog.json", "catalog.sigstore.json"})
-	if err != nil {
-		return err
-	}
-	var metadata releasetrust.Metadata
-	if err := definitions.DecodeStrict(snapshotFiles["metadata.json"], &metadata); err != nil {
-		return err
-	}
-	if len(metadata.PrimaryKeys) == 0 || len(metadata.PrimaryKeys) > 256 {
-		return errors.New("invalid primary key count")
-	}
-	names := []string{}
-	index := upgradebundle.Index{Format: upgradebundle.IndexFormat, PrimaryKeyIDs: []string{}, Releases: []upgradebundle.ReleaseEntry{}, Bridges: []releaseidentity.Digest{}}
-	idPattern := regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
-	for _, key := range metadata.PrimaryKeys {
-		if !safeName(key.PublicKey) || !idPattern.MatchString(key.ID) {
-			return errors.New("unsafe primary key locator")
-		}
-		names = append(names, key.PublicKey)
-		index.PrimaryKeyIDs = append(index.PrimaryKeyIDs, key.ID)
-	}
-	keyFiles, err := readExact(o.keys, names)
-	if err != nil {
-		return err
-	}
-	keys := map[string][]byte{}
-	for _, key := range metadata.PrimaryKeys {
-		keys[key.ID] = keyFiles[key.PublicKey]
-	}
-	material := releasetrust.SnapshotMaterial{Metadata: snapshotFiles["metadata.json"], MetadataSignature: snapshotFiles["metadata.sigstore.json"], Catalog: snapshotFiles["catalog.json"], CatalogSignature: snapshotFiles["catalog.sigstore.json"], PrimaryKeys: keys}
-	snapshot, err := releasetrust.VerifySnapshot(pinned, material, floor)
-	if err != nil {
-		return fmt.Errorf("authenticate trust snapshot: %w", err)
-	}
-	output, err := filepath.Abs(o.output)
-	if err != nil {
-		return err
-	}
-	if _, err := os.Lstat(output); !errors.Is(err, os.ErrNotExist) {
-		return errors.New("output already exists or cannot be inspected")
-	}
-	parent, err := filepath.EvalSymlinks(filepath.Dir(output))
-	if err != nil {
-		return err
-	}
-	output = filepath.Join(parent, filepath.Base(output))
-	stage, err := os.MkdirTemp(parent, ".hikyo-upgrade-assembly-")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(stage)
-	var stagedBytes int
-	write := func(name string, raw []byte) error {
-		stagedBytes += len(raw)
-		if stagedBytes > 64<<20 {
-			return errors.New("bundle exceeds aggregate document bound")
-		}
-		return writeDocument(stage, name, raw)
-	}
-	for name, raw := range snapshotFiles {
-		if err := write(name, raw); err != nil {
-			return err
-		}
-	}
-	for id, raw := range keys {
-		if err := write("keys/"+id+".pub", raw); err != nil {
-			return err
-		}
-	}
-	seen := map[releaseidentity.Digest]bool{}
-	for _, directory := range o.releases {
-		release, files, err := readRelease(ctx, directory, snapshot)
-		if err != nil {
-			return err
-		}
-		digest := release.Identity().ManifestSHA256
-		if seen[digest] {
-			return errors.New("duplicate release manifest")
-		}
-		seen[digest] = true
-		index.Releases = append(index.Releases, upgradebundle.ReleaseEntry{Profile: releaseidentity.StableV1, ManifestSHA256: digest})
-		for name, raw := range files {
-			if err := write("releases/"+string(digest)+"/"+name, raw); err != nil {
-				return err
-			}
-		}
-	}
-	for _, directory := range o.nightlies {
-		release, err := upgradebundle.CopyNightlyRelease(ctx, directory, filepath.Join(stage, "releases"), snapshot)
-		if err != nil {
-			return err
-		}
-		digest := release.Identity().ManifestSHA256
-		if seen[digest] {
-			return errors.New("duplicate release manifest")
-		}
-		seen[digest] = true
-		index.Releases = append(index.Releases, upgradebundle.ReleaseEntry{Profile: releaseidentity.NightlyV1, ManifestSHA256: digest})
-	}
-	seen = map[releaseidentity.Digest]bool{}
-	for _, directory := range o.bridges {
-		files, err := readExact(directory, []string{"statement.json", "statement.sigstore.json"})
-		if err != nil {
-			return err
-		}
-		digest := releaseidentity.Hash(files["statement.json"])
-		if seen[digest] {
-			return errors.New("duplicate bridge statement")
-		}
-		seen[digest] = true
-		index.Bridges = append(index.Bridges, digest)
-		for name, raw := range files {
-			if err := write("bridges/"+string(digest)+"/"+name, raw); err != nil {
-				return err
-			}
-		}
-	}
-	slices.Sort(index.PrimaryKeyIDs)
-	slices.Sort(index.Bridges)
-	slices.SortFunc(index.Releases, func(a, b upgradebundle.ReleaseEntry) int {
-		return strings.Compare(string(a.ManifestSHA256), string(b.ManifestSHA256))
+	return upgradeassembly.Assemble(ctx, upgradeassembly.Options{
+		Pinned: releasetrust.PinnedTrust{Root: root, RecoveryPublicKey: recovery},
+		Floor:  floor, SnapshotDirectory: o.snapshot, KeysDirectory: o.keys,
+		OutputDirectory: o.output, Releases: o.releases, Nightlies: o.nightlies, Bridges: o.bridges,
 	})
-	raw, err := json.Marshal(index)
-	if err != nil {
-		return err
-	}
-	if err := write("index.json", raw); err != nil {
-		return err
-	}
-	// This final pass authenticates the exact staged bytes and requires every
-	// bridge in the current catalog, using the same reader as production boot.
-	if _, err := upgradebundle.Load(ctx, stage, pinned, floor); err != nil {
-		return fmt.Errorf("validate assembled runtime bundle: %w", err)
-	}
-	if err := syncTree(stage); err != nil {
-		return err
-	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if err := publishDirectory(stage, output); err != nil {
-		return err
-	}
-	ancestry, err := filedurability.DirectoryAncestry(parent)
-	if err != nil {
-		return fmt.Errorf("bundle published at %s; durability unconfirmed: %w", output, err)
-	}
-	for _, directory := range ancestry {
-		if err := filedurability.SyncDirectory(directory); err != nil {
-			return fmt.Errorf("bundle published at %s; durability unconfirmed: %w", output, err)
-		}
-	}
-	return nil
-}
-
-func safeName(name string) bool {
-	return name != "" && name != "." && !strings.Contains(name, "..") && !strings.ContainsAny(name, `/\`)
-}
-
-func writeDocument(directory, name string, raw []byte) error {
-	path := filepath.Join(directory, filepath.FromSlash(name))
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
-	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	_, writeErr := file.Write(raw)
-	return errors.Join(writeErr, file.Sync(), file.Close())
-}
-
-func syncTree(directory string) error {
-	var directories []string
-	err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			directories = append(directories, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	slices.Reverse(directories)
-	for _, path := range directories {
-		if err := filedurability.SyncDirectory(path); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/scripts/release/assemble-upgrade/main_test.go
+++ b/scripts/release/assemble-upgrade/main_test.go
@@ -216,16 +216,6 @@ func TestConcurrentAssemblyNeverReplacesAnOutput(t *testing.T) {
 	if _, err := upgradebundle.Load(context.Background(), f.opts.output, f.trust.Pinned, releaseidentity.SnapshotFloor{}); err != nil {
 		t.Fatal(err)
 	}
-	// An empty existing directory must not be overwritten either, even when it
-	// appears between the initial absence check and the final atomic rename.
-	stage, output := t.TempDir(), t.TempDir()
-	put(t, filepath.Join(stage, "sentinel"), []byte("preserve"))
-	if err := publishDirectory(stage, output); err == nil {
-		t.Fatal("replaced existing directory")
-	}
-	if _, err := os.Stat(filepath.Join(stage, "sentinel")); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestCanceledAssemblyDoesNotPublish(t *testing.T) {

--- a/scripts/release/nightly/main.go
+++ b/scripts/release/nightly/main.go
@@ -218,11 +218,12 @@ func loadTrust(directory string) (releasetrust.Snapshot, []byte, error) {
 			return snapshot, nil, err
 		}
 	}
-	snapshot, err = releasetrust.VerifySnapshot(releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}, material, releaseidentity.SnapshotFloor{})
+	policyRaw, err := read(filepath.Join(directory, "nightly", "policy.json"))
 	if err != nil {
 		return snapshot, nil, err
 	}
-	policyRaw, err := read(filepath.Join(directory, "nightly", "policy.json"))
+	material.NightlyPolicy = policyRaw
+	snapshot, err = releasetrust.VerifySnapshot(releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}, material, releaseidentity.SnapshotFloor{})
 	if err != nil {
 		return snapshot, nil, err
 	}


### PR DESCRIPTION
## Summary

Nightly 26 requires a signed release bundle, an approved migration route and backup/restore proof before it serves, so the old binary-only updater can no longer upgrade an existing installation. This adds one operator command for Linux systemd hosts with a local SQLite database:

```sh
sudo hikyo upgrade
```

The coordinator discovers the exact signed target and its authenticated route (including the recovery-signed legacy bridge for pre-ledger databases), assembles the public runtime bundle, stops writers behind a durable systemd startup fence, exports an encrypted backup, restores it to scratch and proves credential recovery, installs each hop's executable, runs migrations and health checks, and completes only after the final exact executable and database state are healthy. A durable journal lets an interrupted run resume from known states. No old binary or database is ever rolled back automatically.

Operator custody is an age-encrypted, root-owned vault under `/etc/hikyo/upgrade-keys`; the passphrase is interactive and never persisted. The signed-upgrade ADR records the operator-approved local custody exception for the nightly CLI flow.

Existing binaries lack the command, so `install/upgrade-nightly.sh` bootstraps the coordinator once after verifying the download with pinned Cosign, the OIDC certificate policy and the recovery-authorized catalog and policy.

## Stacked on #691

Base is `fix/production-ephemeral-listeners` (#691), which repairs main CI after #686. Retarget to `main` once #691 merges.

## Review fixes folded in

- `fix(release)`: online verifiers now also enforce revocations from the live `release/trust/nightly/policy.json`, so one nightly can be revoked without refusing every nightly of its policy period. Runbook documents the procedure.
- `fix(upgrade)`: completed runs prune earlier `bundle-*`/`evidence-*`/`backup-*` directories; lock release errors no longer hide a migration failure.

## Verification

- Go tests: app, hostupgrade, selfupdate, releasetrust, upgradecustody, upgradeassembly, upgradebundle, upgradegate, updatecheck, upgradecompat, store/upgrade, service, devupgrade, config, release and CI script packages.
- `scripts/ci/test-host-upgrade.sh` (root adapter in isolated Linux) and `scripts/ci/test-host-upgrade-systemd.sh` (real systemd in a disposable privileged container) pass locally.
- `install/upgrade-nightly_test.sh`, ShellCheck, actionlint, docs check/build/verify-docs pass.

Handoff: `docs/handoff/20260906-automatic-nightly-upgrade.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)