### PR TITLE
test: bound Postgres fixture drops by checkpoint cost

### DIFF
--- a/internal/app/backup_upgrade_drill_test.go
+++ b/internal/app/backup_upgrade_drill_test.go
@@ -52,7 +52,10 @@ func upgradeDrillDatabase(t *testing.T, engine store.Engine) store.Config {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		cleanup, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// DROP DATABASE forces an immediate checkpoint; under a loaded CI
+		// runner its fsync alone took about 5 s (#694). Bound the drop far
+		// above that so cleanup fails only when the server is truly stuck.
+		cleanup, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		if _, err := admin.Exec(cleanup, "DROP DATABASE "+ident+" WITH (FORCE)"); err != nil {
 			t.Error(err)

--- a/internal/service/backup_preparation_test.go
+++ b/internal/service/backup_preparation_test.go
@@ -47,7 +47,10 @@ func preparationDatabase(t *testing.T, engine store.Engine) store.Config {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// DROP DATABASE forces an immediate checkpoint; under a loaded CI
+		// runner its fsync alone took about 5 s (#694). Bound the drop far
+		// above that so cleanup fails only when the server is truly stuck.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		if _, err := admin.Exec(ctx, "DROP DATABASE "+ident+" WITH (FORCE)"); err != nil {
 			t.Error(err)

--- a/internal/store/backup_snapshot_test.go
+++ b/internal/store/backup_snapshot_test.go
@@ -122,7 +122,10 @@ func TestExportPostgresManifestUsesCopySnapshotDuringMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		cleanup, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// DROP DATABASE forces an immediate checkpoint; under a loaded CI
+		// runner its fsync alone took about 5 s (#694). Bound the drop far
+		// above that so cleanup fails only when the server is truly stuck.
+		cleanup, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		if _, err := admin.Exec(cleanup, "DROP DATABASE "+ident+" WITH (FORCE)"); err != nil {
 			t.Error(err)


### PR DESCRIPTION
## Summary



Fixes #694 (the Postgres half). `DROP DATABASE ... WITH (FORCE)` forces an immediate checkpoint; on a loaded runner its fsync took 4.7 s (`sync=4.681 s, sync files=862` in the job's Postgres log), and the three fixtures with a 5 s cleanup deadline canceled the statement and failed after their assertions had passed. It hit PR #693's rerun and then main at b2388a99, which blocks the nightly.

The bound moves to one minute in the three fixtures with a comment citing the evidence. Cleanup still fails loudly when the server is stuck. Relaxing Postgres durability in CI is not an option because the store refuses `fsync=off` at boot.

The floor-bench margin half of #694 is untouched.
