### PR TITLE
fix(upgrade): ignore caller umask for public evidence and save runtime error output

### DIFF
--- a/internal/hostupgrade/host.go
+++ b/internal/hostupgrade/host.go
@@ -24,6 +24,9 @@ type command struct {
 	runtime   bool
 	uid, gid  uint32
 	rootKey   string
+	// stderr receives the child's error output when set; otherwise it is
+	// discarded because it can contain operational configuration.
+	stderr io.Writer
 }
 
 type boundedOutput struct{ bytes []byte }
@@ -62,6 +65,7 @@ func New(c Config) (*Host, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
+	resetUmask()
 	u, err := user.Lookup(c.User)
 	if err != nil {
 		return nil, err
@@ -512,7 +516,18 @@ func (h *Host) runRuntime(ctx context.Context, candidate string, args []string, 
 	if err != nil {
 		return nil, err
 	}
-	return h.run(ctx, command{path: candidate, args: args, env: environmentList(values), directory: h.config.WorkingDirectory, runtime: true, uid: h.uid, gid: h.gid, rootKey: h.config.RootKeyFile})
+	var stderr boundedOutput
+	output, err := h.run(ctx, command{path: candidate, args: args, env: environmentList(values), directory: h.config.WorkingDirectory, runtime: true, uid: h.uid, gid: h.gid, rootKey: h.config.RootKeyFile, stderr: &stderr})
+	if err == nil {
+		return output, nil
+	}
+	// The operator must see why the runtime refused. Its stderr can name
+	// configuration, so it goes to a root-only file, never to the terminal.
+	log := filepath.Join(h.config.StateDirectory, "runtime-"+args[0]+"-"+time.Now().UTC().Format("20060102T150405Z")+".log")
+	if writeErr := atomicWrite(log, stderr.bytes, 0600); writeErr != nil {
+		return nil, fmt.Errorf("runtime %s failed: %w (its error output could not be saved: %v)", args[0], err, writeErr)
+	}
+	return nil, fmt.Errorf("runtime %s failed: %w; its error output is in %s", args[0], err, log)
 }
 
 func environmentList(values map[string]string) []string {

--- a/internal/hostupgrade/host_linux_test.go
+++ b/internal/hostupgrade/host_linux_test.go
@@ -5,12 +5,14 @@ package hostupgrade
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -306,5 +308,89 @@ func TestLinuxPrunePublicKeepsOnlyReferencedEvidence(t *testing.T) {
 	}
 	if err := h.PrunePublic(RuntimeEvidence{BundleDirectory: filepath.Join(h.config.StateDirectory, "bundle-x")}); err == nil {
 		t.Fatal("accepted retained evidence outside the public directory")
+	}
+}
+
+func TestLinuxPublicBundleIgnoresCallerUmask(t *testing.T) {
+	h := rootTestHost(t)
+	previous := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(previous) })
+	resetUmask()
+	source := filepath.Join(h.config.StateDirectory, "source")
+	if err := os.MkdirAll(filepath.Join(source, "releases"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "releases", "index.json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	staged, err := h.StagePublicBundle(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for path, want := range map[string]os.FileMode{staged: 0755, filepath.Join(staged, "releases"): 0755, filepath.Join(staged, "releases", "index.json"): 0644} {
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != want {
+			t.Fatalf("%s mode %o, want %o: runtime user could not read the bundle", path, info.Mode().Perm(), want)
+		}
+	}
+	output, err := h.PreparePublicOutput("backup-umask")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Lstat(output); err != nil || info.Mode().Perm() != 0700 {
+		t.Fatal("runtime-owned backup output must stay private", err)
+	}
+	evidence, err := h.PublishPublicEvidence("operator.pub", []byte("public key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Lstat(evidence); err != nil || info.Mode().Perm() != 0644 {
+		t.Fatal("public evidence must be world-readable", err)
+	}
+}
+
+func TestLinuxRuntimeFailureSavesErrorOutputForTheOperator(t *testing.T) {
+	h := rootTestHost(t)
+	h.run = func(_ context.Context, c command) ([]byte, error) {
+		if c.path == "/usr/bin/systemctl" {
+			if c.args[2] == "show" {
+				return []byte("ActiveState=inactive\nMainPID=0\nControlGroup=\n"), nil
+			}
+			return nil, nil
+		}
+		if c.stderr == nil {
+			t.Fatal("runtime child ran without an error sink")
+		}
+		if _, err := c.stderr.Write([]byte("hikyo backup: offline bundle member unavailable\n")); err != nil {
+			t.Fatal(err)
+		}
+		return nil, errors.New("exit status 1")
+	}
+	if err := h.FenceAndStop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	candidate := filepath.Join(h.config.CandidateDirectory, "hikyo-candidate")
+	if err := os.WriteFile(candidate, []byte("#!/bin/sh\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	evidence := RuntimeEvidence{BundleDirectory: filepath.Join(h.config.PublicDirectory, "bundle"), OperatorPublicKey: filepath.Join(h.config.PublicDirectory, "operator.pub")}
+	_, err := h.Migrate(context.Background(), candidate, evidence)
+	if err == nil || !strings.Contains(err.Error(), "runtime migrate failed") || !strings.Contains(err.Error(), "error output is in ") {
+		t.Fatalf("runtime failure hid its cause: %v", err)
+	}
+	logPath := err.Error()[strings.LastIndex(err.Error(), " ")+1:]
+	info, err := os.Lstat(logPath)
+	if err != nil || info.Mode().Perm() != 0600 || fileOwner(info) != 0 {
+		t.Fatal("runtime error log must be a root-only file", err)
+	}
+	raw, err := os.ReadFile(logPath)
+	if err != nil || !strings.Contains(string(raw), "offline bundle member unavailable") {
+		t.Fatal("runtime error log lost the child's message", err)
+	}
+	if strings.Contains(fmt.Sprint(err), "offline bundle member unavailable") {
+		t.Fatal("child error output must not reach the operator error string")
 	}
 }

--- a/internal/hostupgrade/platform_linux.go
+++ b/internal/hostupgrade/platform_linux.go
@@ -39,6 +39,9 @@ func runCommand(ctx context.Context, request command) ([]byte, error) {
 	var output boundedOutput
 	cmd.Stdout = &output
 	cmd.Stderr = io.Discard
+	if request.stderr != nil {
+		cmd.Stderr = request.stderr
+	}
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
@@ -85,3 +88,9 @@ func runtimeCredential(path string, uid, gid uint32) (*os.File, error) {
 	}
 	return f, nil
 }
+
+// resetUmask makes every mode this package requests effective. The first-use
+// bootstrap runs the coordinator under umask 077, which turned the public
+// bundle's 0755/0644 entries into 0700/0600 and hid them from the runtime user.
+// Root-only material still uses explicit 0700/0600 modes.
+func resetUmask() { syscall.Umask(0o022) }

--- a/internal/hostupgrade/platform_other.go
+++ b/internal/hostupgrade/platform_other.go
@@ -12,3 +12,4 @@ func fileOwner(os.FileInfo) int { return -1 }
 func runCommand(context.Context, command) ([]byte, error) {
 	return nil, errors.New("automatic host upgrades require Linux systemd")
 }
+func resetUmask() {}


### PR DESCRIPTION
## Summary

Found on the first real bootstrap of a nightly 23 server into nightly 27 (after #696):

1. **Bootstrap umask hid the public bundle from the runtime user.** `install/upgrade-nightly.sh` sets `umask 077` and execs the coordinator, which inherits it. `StagePublicBundle` requests `0755`/`0644` but the umask produced `0700`/`0600`, so the runtime's `backup upgrade-export` failed with `offline bundle member unavailable` after the service had been stopped and fenced. The host adapter now resets the umask to `022` in `New` (root only; private material keeps explicit `0700`/`0600`). New root Linux test stages a bundle under umask 077 and checks every mode.

2. **The failure was reported as a bare `exit status 1`.** Runtime children's stderr was discarded on purpose so configuration cannot leak to the terminal. A failing runtime command now writes its stderr to a root-only `runtime-<verb>-<timestamp>.log` under `/var/lib/hikyo-upgrader` and names the path in the error. New root Linux test proves the log exists, is `0600` root-owned, and that the child's text stays out of the error string.

Operator workaround until a nightly with this ships: run the staged coordinator under `umask 022` directly.

## Verification

- `scripts/ci/test-host-upgrade.sh` and `scripts/ci/test-host-upgrade-systemd.sh` pass locally.
- `go test ./internal/hostupgrade/ ./internal/app/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)