### PR TITLE
ci(nightly): fail when the signed predecessor release is missing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
+    inputs:
+      allow_missing_predecessor:
+        description: >-
+          Build without a signed predecessor release. Only for a deliberate
+          chain restart; installations below the gap need a recovery bridge.
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -155,6 +162,7 @@ jobs:
         if: steps.identity.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          ALLOW_MISSING_PREDECESSOR: ${{ inputs.allow_missing_predecessor == true }}
         run: |
           set -o pipefail
           previous_tag=$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases?per_page=100" | jq '
@@ -163,8 +171,15 @@ jobs:
           if [ -n "$previous_tag" ]; then
             gh release download "$previous_tag" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/previous-nightly"
             go run ./scripts/release/nightly sources --directory "$RUNNER_TEMP/previous-nightly" --out "$RUNNER_TEMP/nightly-sources.json"
-          else
+          elif [ "$ALLOW_MISSING_PREDECESSOR" = true ]; then
+            echo '::warning::Building without a signed predecessor by explicit request; installations below this release need a recovery bridge.'
             go run ./scripts/release/nightly sources --out "$RUNNER_TEMP/nightly-sources.json"
+          else
+            # Every nightly declares its signed predecessor as an upgrade source.
+            # No predecessor means the chain was cut, usually by deleting a
+            # release. A silent build here strands every installation below it.
+            echo '::error::No signed predecessor release is available. Revoke bad nightlies instead of deleting them; to restart the chain deliberately, dispatch with allow_missing_predecessor=true and publish a recovery bridge.'
+            exit 1
           fi
       - name: Generate nightly compatibility from both migrated engines
         id: compatibility
@@ -271,13 +286,18 @@ jobs:
             nightly-payloads/release-manifest.json
       - name: Verify exact signed inventory and assemble runtime evidence
         if: steps.identity.outputs.skip != 'true'
+        env:
+          ALLOW_MISSING_PREDECESSOR: ${{ inputs.allow_missing_predecessor == true }}
         run: |
           go run ./scripts/release/nightly verify --directory nightly-payloads
           if [ -d "$RUNNER_TEMP/previous-nightly" ]; then
             ./scripts/release/assemble-nightly.sh release/trust "$RUNNER_TEMP/nightly-bundle" \
               "$RUNNER_TEMP/previous-nightly" nightly-payloads
-          else
+          elif [ "$ALLOW_MISSING_PREDECESSOR" = true ]; then
             ./scripts/release/assemble-nightly.sh release/trust "$RUNNER_TEMP/nightly-bundle" nightly-payloads
+          else
+            echo '::error::Signed predecessor missing at bundle assembly'
+            exit 1
           fi
       - name: Require packaged production startup and restart on both engines
         if: steps.identity.outputs.skip != 'true'
@@ -291,7 +311,12 @@ jobs:
         if: steps.identity.outputs.skip != 'true'
         env:
           HIKYO_TEST_POSTGRES_DSN: postgres://hikyo:release-schema-fixture@127.0.0.1:5432/hikyo_release_schema?sslmode=disable
+          ALLOW_MISSING_PREDECESSOR: ${{ inputs.allow_missing_predecessor == true }}
         run: |
+          if [ ! -d "$RUNNER_TEMP/previous-nightly" ] && [ "$ALLOW_MISSING_PREDECESSOR" != true ]; then
+            echo '::error::Signed predecessor missing at the populated upgrade proof'
+            exit 1
+          fi
           if [ -d "$RUNNER_TEMP/previous-nightly" ]; then
             previous_version=$(jq -r '.version' "$RUNNER_TEMP/previous-nightly/release-manifest.json")
             mkdir "$RUNNER_TEMP/previous-binary"

--- a/docs/operations/signed-nightlies.md
+++ b/docs/operations/signed-nightlies.md
@@ -82,8 +82,13 @@ bundle and boots/restarts the packaged Linux binary in production mode on both
 engines. After the first signed nightly, it also runs the previous published
 binary, populates an encrypted secret, exports and drills a backup, signs local
 operator evidence, upgrades with the candidate binary, and checks readiness,
-secret readability and restart. The first signed release has no authenticated
-predecessor, so only its fresh-install route is automatically exercised.
+secret readability and restart. A run with no signed predecessor release fails
+before building: every nightly declares its predecessor as an upgrade source,
+so a missing one means the chain was cut and every installation below the gap
+would be stranded. Revoke a bad nightly through the policy instead of deleting
+its release. To restart the chain deliberately, dispatch the workflow with
+`allow_missing_predecessor=true` and publish a recovery bridge for the
+installations below the gap, as catalog 3 did after nightly 26 was deleted.
 
 ## Revoke one published nightly
 


### PR DESCRIPTION
## Summary

Nightly 27 built after the nightly 26 release object was deleted. The predecessor lookup returned nothing, the workflow fell through to a build with no predecessor edge, and the populated previous-nightly upgrade proof skipped on `if [ -d ... ]`. Every installation below the gap was stranded until #696 published a recovery bridge.

Now a missing signed predecessor fails the run at three points (resolution, bundle assembly, upgrade proof) with an error that says to revoke instead of delete. A new `workflow_dispatch` input `allow_missing_predecessor` permits a deliberate chain restart with a warning annotation. Runbook updated.

Trade-off stated: the scheduled run cannot pass the input, so a broken chain stops nightlies until a human restarts it. That is the intent.

## Verification

- actionlint passes.
- Behaviour is workflow-only; the next scheduled nightly has predecessor 27 available and takes the normal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)