### PR TITLE
feat(upgrade): run operator verbs through the systemd deployment as root

### DIFF
--- a/cmd/hikyo/main.go
+++ b/cmd/hikyo/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"slices"
 	"syscall"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/console"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
+	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
 	"github.com/Hikyo-Org/hikyo/internal/importer"
 	"github.com/Hikyo-Org/hikyo/internal/operator"
 	binaryupdate "github.com/Hikyo-Org/hikyo/internal/selfupdate"
@@ -304,6 +306,11 @@ func runOperator(ctx context.Context, name string, args []string,
 	if len(args) > 0 && args[0] == "--dev" {
 		configurationArgs, args = args[:1], args[1:]
 	}
+	if len(configurationArgs) == 0 && os.Getenv("HIKYO_DB") == "" {
+		if code, handled := runOperatorThroughDeployment(ctx, name, args); handled {
+			return code
+		}
+	}
 	cfg, warnings, err := config.LoadBootstrap(name, configurationArgs, os.Getenv, os.Environ())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hikyo %s: %v\n", name, err)
@@ -327,6 +334,40 @@ func runOperator(ctx context.Context, name string, args []string,
 		return 1
 	}
 	return 0
+}
+
+// runOperatorThroughDeployment lets a root shell on a systemd host run an
+// operator verb without hand-feeding the service's configuration. When the
+// root-owned deployment file that `hikyo upgrade` maintains exists, the verb
+// runs as the runtime user with the unit's exact environment and root key.
+// Without that file nothing is assumed; the ordinary environment path follows.
+func runOperatorThroughDeployment(ctx context.Context, name string, args []string) (int, bool) {
+	if runtime.GOOS != "linux" || os.Geteuid() != 0 {
+		return 0, false
+	}
+	if _, err := os.Lstat(hostupgrade.ConfigPath); err != nil {
+		return 0, false
+	}
+	c, err := hostupgrade.LoadConfig(hostupgrade.ConfigPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hikyo %s: %s: %v\n", name, hostupgrade.ConfigPath, err)
+		return 2, true
+	}
+	host, err := hostupgrade.New(c)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hikyo %s: %v\n", name, err)
+		return 2, true
+	}
+	err = host.RunOperator(ctx, append([]string{name}, args...), os.Stdin, os.Stdout, os.Stderr)
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		return exit.ExitCode(), true
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hikyo %s: %v\n", name, err)
+		return 2, true
+	}
+	return 0, true
 }
 
 func workdir() string {

--- a/docs/site/src/content/docs/docs/backup-and-restore.mdx
+++ b/docs/site/src/content/docs/docs/backup-and-restore.mdx
@@ -209,7 +209,15 @@ The root key and backup identity are read from files, used for the drill's
 duration only, and never persisted or logged. The scratch target is left for
 inspection unless `--cleanup` was requested and the drill passed.
 
-Include both readable restore and current root escrow verification in the quarterly runbook. A successful drill proves the archived hierarchy can be opened. To record verification against the current installation, recover a separate private root file from escrow and run this host-local command with the server's datastore, public upgrade bundle and operator pin configuration:
+Include both readable restore and current root escrow verification in the quarterly runbook. A successful drill proves the archived hierarchy can be opened. To record verification against the current installation, recover a separate private root file from escrow and run this host-local command.
+
+On a Linux systemd host that `hikyo upgrade` has set up, root runs it directly. The command finds the service's environment files and root key through `/etc/hikyo/upgrade.json`, runs as the service user, and hands the recovered file to that user on a descriptor, so the copy can stay root-owned:
+
+```sh
+sudo hikyo escrow verify --root-key-file /root/recovered-root --assert-separate-custody
+```
+
+Elsewhere, supply the server's datastore, public upgrade bundle and operator pin configuration yourself:
 
 ```sh
 HIKYO_ROOT_KEY_FILE=/run/hikyo-root/root-key \
@@ -217,7 +225,7 @@ HIKYO_ROOT_KEY_FILE=/run/hikyo-root/root-key \
   --assert-separate-custody
 ```
 
-`HIKYO_ROOT_KEY_FILE` identifies the actual configured server root file and is also supported by `hikyo server`; the server flag takes precedence. Verification refuses an unidentified or environment-only server root source. The command refuses the configured server root file, hardlink aliases, symlinks and files that are not private and operator-owned. It verifies the complete current key hierarchy and atomically binds the public timestamp to the finalized root epoch, installation and recovery incarnation. Root rotation or restore makes the old record stale; dual-wrapped root rotation must finish before verification. Private key bytes never enter an API or audit payload. The flag records the operator's separate-custody assertion: software cannot prove that a copy was physically offline. An export job alone is not a recovery test.
+`HIKYO_ROOT_KEY_FILE` identifies the actual configured server root file and is also supported by `hikyo server`; the server flag takes precedence. Verification refuses an unidentified or environment-only server root source. The command refuses the configured server root file, hardlink aliases, symlinks and files that are not private and owned by the operator or root. It verifies the complete current key hierarchy and atomically binds the public timestamp to the finalized root epoch, installation and recovery incarnation. Root rotation or restore makes the old record stale; dual-wrapped root rotation must finish before verification. Private key bytes never enter an API or audit payload. The flag records the operator's separate-custody assertion: software cannot prove that a copy was physically offline. An export job alone is not a recovery test.
 
 With `--cleanup`, SQLite scratch files are removed only after every drill step
 and its recovery-time check pass. A failed or refused drill retains the target

--- a/internal/crypto/escrow_file_unix.go
+++ b/internal/crypto/escrow_file_unix.go
@@ -27,8 +27,10 @@ func ReadEscrowRootKey(path, serverRootPath string) ([]byte, error) {
 	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
 		return nil, errors.New("escrow root must be a private regular file")
 	}
-	if st, ok := info.Sys().(*syscall.Stat_t); !ok || st.Uid != uint32(os.Geteuid()) {
-		return nil, errors.New("escrow root must be owned by the current operator")
+	// Root may hand a custody copy to the runtime user on a descriptor; a
+	// root-owned private file is at least as trustworthy as an owned one.
+	if st, ok := info.Sys().(*syscall.Stat_t); !ok || (st.Uid != uint32(os.Geteuid()) && st.Uid != 0) {
+		return nil, errors.New("escrow root must be owned by the current operator or root")
 	}
 	if serverRootPath != "" {
 		primary, err := os.Stat(serverRootPath)

--- a/internal/hostupgrade/host.go
+++ b/internal/hostupgrade/host.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,6 +28,13 @@ type command struct {
 	// stderr receives the child's error output when set; otherwise it is
 	// discarded because it can contain operational configuration.
 	stderr io.Writer
+	// stdin and stdout pass an operator's terminal through to an interactive
+	// child. stdout unset means bounded capture for coordinator parsing.
+	stdin  io.Reader
+	stdout io.Writer
+	// credential is an optional second private file handed to a runtime
+	// child as descriptor 4, owned by the runtime user like the root key.
+	credential string
 }
 
 type boundedOutput struct{ bytes []byte }
@@ -756,4 +764,52 @@ func (h *Host) show(ctx context.Context, properties ...string) (map[string]strin
 		}
 	}
 	return values, nil
+}
+
+// RunOperator executes one operator verb of the installed executable the way
+// the service itself runs: as the runtime user, in the working directory,
+// with the unit's environment files applied in order and the configured root
+// key on descriptor 3. Root-run host commands therefore need no hand-fed
+// configuration. A --root-key-file argument names a private file only root
+// can read; it is handed to the child on descriptor 4 so an escrow custody
+// copy never has to be re-owned. The verb keeps the operator's terminal.
+func (h *Host) RunOperator(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("operator command requires a verb")
+	}
+	if err := h.Preflight(ctx); err != nil {
+		return err
+	}
+	values := h.Environment()
+	runtimeEnv := filepath.Join(h.config.StateDirectory, "runtime.env")
+	if err := trustedFile(runtimeEnv); err == nil {
+		data, err := os.ReadFile(runtimeEnv)
+		if err != nil {
+			return err
+		}
+		extra, err := ParseEnvironmentFile(data)
+		if err != nil {
+			return fmt.Errorf("%s: %w", runtimeEnv, err)
+		}
+		for k, v := range extra {
+			values[k] = v
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	values["HIKYO_ROOT_KEY_FILE"] = "/proc/self/fd/3"
+	args = slices.Clone(args)
+	credential := ""
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--root-key-file" && i+1 < len(args) {
+			credential, args[i+1] = args[i+1], "/proc/self/fd/4"
+		} else if rest, ok := strings.CutPrefix(args[i], "--root-key-file="); ok {
+			credential, args[i] = rest, "--root-key-file=/proc/self/fd/4"
+		}
+	}
+	if credential != "" && (!safePath(credential) || !filepath.IsAbs(credential)) {
+		return errors.New("--root-key-file must be an absolute path")
+	}
+	_, err := h.run(ctx, command{path: h.config.Binary, args: args, env: environmentList(values), directory: h.config.WorkingDirectory, runtime: true, uid: h.uid, gid: h.gid, rootKey: h.config.RootKeyFile, credential: credential, stdin: stdin, stdout: stdout, stderr: stderr})
+	return err
 }

--- a/internal/hostupgrade/platform_linux.go
+++ b/internal/hostupgrade/platform_linux.go
@@ -33,6 +33,14 @@ func runCommand(ctx context.Context, request command) ([]byte, error) {
 		}
 		defer key.Close()
 		cmd.ExtraFiles = []*os.File{key}
+		if request.credential != "" {
+			extra, err := runtimeCredential(request.credential, request.uid, request.gid)
+			if err != nil {
+				return nil, err
+			}
+			defer extra.Close()
+			cmd.ExtraFiles = append(cmd.ExtraFiles, extra)
+		}
 	}
 	// Error output can contain operational configuration. The adapter returns
 	// stdout only; callers get the bounded operation and exit status on failure.
@@ -42,8 +50,15 @@ func runCommand(ctx context.Context, request command) ([]byte, error) {
 	if request.stderr != nil {
 		cmd.Stderr = request.stderr
 	}
+	if request.stdout != nil {
+		cmd.Stdout = request.stdout
+	}
+	cmd.Stdin = request.stdin
 	if err := cmd.Run(); err != nil {
 		return nil, err
+	}
+	if request.stdout != nil {
+		return nil, nil
 	}
 	return output.bytes, nil
 }

--- a/internal/hostupgrade/real_systemd_linux_test.go
+++ b/internal/hostupgrade/real_systemd_linux_test.go
@@ -98,6 +98,14 @@ WantedBy=multi-user.target
 	}
 	must(err)
 	t.Log("original hardened unit passed preflight with real systemd and a service cgroup")
+	write(filepath.Join(c.StateDirectory, "runtime.env"), "HIKYO_UPGRADE_BUNDLE=/var/lib/hikyo-upgrade/bundle-fixture\nHIKYO_ROOT_KEY_FILE=/proc/self/fd/3\n", 0600)
+	write("/root/custody.key", "custody copy", 0600)
+	var delegated strings.Builder
+	must(h.RunOperator(ctx, []string{"escrow", "verify", "--root-key-file", "/root/custody.key", "--assert-separate-custody"}, strings.NewReader("operator input\n"), &delegated, os.Stderr))
+	if !strings.Contains(delegated.String(), "escrow verified through delegation") {
+		t.Fatalf("operator delegation output: %q", delegated.String())
+	}
+	t.Log("root operator verb ran as the runtime user with merged unit environment, descriptor credentials and terminal passthrough")
 	must(h.FenceAndStop(ctx))
 	candidate, err := h.StageCandidate("/host-upgrade-helper", digest)
 	must(err)

--- a/scripts/ci/host-upgrade-helper/main.go
+++ b/scripts/ci/host-upgrade-helper/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -51,6 +52,31 @@ func run() error {
 			return fmt.Errorf("child credential was not passed by descriptor")
 		}
 		fmt.Println(`{"credential":"verified","uid":"unprivileged"}`)
+		return nil
+	case "escrow":
+		// Operator delegation: root key on descriptor 3, the root-owned custody
+		// copy on descriptor 4, both environment files merged, terminal kept.
+		if key != "/proc/self/fd/3" {
+			return fmt.Errorf("delegated root key was not passed by descriptor")
+		}
+		custody := ""
+		for i, arg := range os.Args {
+			if arg == "--root-key-file" && i+1 < len(os.Args) {
+				custody = os.Args[i+1]
+			}
+		}
+		copyRaw, err := os.ReadFile(custody)
+		if custody != "/proc/self/fd/4" || err != nil || string(copyRaw) != "custody copy" {
+			return fmt.Errorf("custody copy unavailable at %q: %v", custody, err)
+		}
+		if os.Getenv("HIKYO_DB") != "sqlite:hikyo.db" || os.Getenv("HIKYO_UPGRADE_BUNDLE") != "/var/lib/hikyo-upgrade/bundle-fixture" {
+			return fmt.Errorf("delegated environment incomplete: %q %q", os.Getenv("HIKYO_DB"), os.Getenv("HIKYO_UPGRADE_BUNDLE"))
+		}
+		line, err := io.ReadAll(io.LimitReader(os.Stdin, 64))
+		if err != nil || strings.TrimSpace(string(line)) != "operator input" {
+			return fmt.Errorf("operator stdin was not passed through: %v", err)
+		}
+		fmt.Println("escrow verified through delegation")
 		return nil
 	default:
 		return fmt.Errorf("unsupported helper operation")


### PR DESCRIPTION
## Summary

Closes #698. Tonight's live run needed four hand-fed details to run `hikyo escrow verify` on the upgraded host: both environment files, a root key override (the runtime file names a systemd credential descriptor), running as the `hikyo` user (installation custody is owner-checked), and re-owned key copies.

Now, when `hikyo backup|restore|escrow|admin` runs as root on a Linux host where `/etc/hikyo/upgrade.json` exists (the file `hikyo upgrade` maintains), the verb is delegated through `hostupgrade`: it runs as the service user in the working directory with the unit's environment files applied in order, the configured root key on descriptor 3, the operator's terminal passed through, and any `--root-key-file` custody copy handed over on descriptor 4 so it can stay root-owned. With `HIKYO_DB` set, a leading `--dev`, or no deployment file, behaviour is unchanged.

Escrow verification accepts a root-owned private custody file in addition to an operator-owned one.

Acceptance target from the ticket now holds:

```sh
sudo hikyo escrow verify --root-key-file /root/recovered-root --assert-separate-custody
```

## Verification

- Real systemd acceptance (`scripts/ci/test-host-upgrade-systemd.sh`) drives a delegated `escrow verify` end to end: unprivileged child, merged environment from both files, descriptors 3 and 4, stdin passthrough.
- `scripts/ci/test-host-upgrade.sh`, `go test ./internal/hostupgrade/ ./internal/crypto/ ./cmd/hikyo/ ./internal/app/` pass. Docs check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)