### PR TITLE
feat(cli): answer --help at every command depth and align docs with the shipped surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ hikyo migrate [--dev]
 hikyo admin [--dev] create --username admin
 hikyo backup [--dev] export
 hikyo restore [--dev] run --from <archive> --identity-file <path>
+sudo hikyo upgrade [--target VERSION]
 hikyo update channel stable|nightly|off
 hikyo update check
 
@@ -165,7 +166,9 @@ hikyo values copy --context <ctx> --from staging --to production --keys NAME
 ```
 
 Secret values never belong in command-line arguments. Use `--value-file` or
-`--stdin`. See the complete [CLI reference](https://hikyo.app/docs/cli-reference/).
+`--stdin`. Every command answers `--help` at any depth (`hikyo values set --help`,
+`hikyo help adapter target`). See the complete
+[CLI reference](https://hikyo.app/docs/cli-reference/).
 
 ## Run in production
 

--- a/cmd/hikyo/config_rollout.go
+++ b/cmd/hikyo/config_rollout.go
@@ -24,6 +24,9 @@ func runConfigRollout(ctx context.Context, args []string, stderr io.Writer) int 
 	enrollmentPath := fs.String("enrollment-file", "/run/hikyo/rollout/enrollment/enrollment.json", "operator-installed rollout enrollment")
 	publicPath := fs.String("authority-public-key", "/run/hikyo/rollout/enrollment/authority.pub", "operator-installed Ed25519 deployment authority public key")
 	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 2
 	}
 	enrollmentRaw, err := readRolloutInstalled(*enrollmentPath)

--- a/cmd/hikyo/main.go
+++ b/cmd/hikyo/main.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"slices"
+	"strings"
 	"syscall"
 
 	"golang.org/x/term"
@@ -62,10 +63,14 @@ func run() int {
 		return code
 	}
 	if len(os.Args) < 2 {
-		usage()
+		usage(os.Stderr)
 		return 2
 	}
-	cmd, args := os.Args[1], os.Args[2:]
+	invocation, handled, code := runHelp(os.Args[1:], os.Stdout, os.Stderr)
+	if handled {
+		return code
+	}
+	cmd, args := invocation[0], invocation[1:]
 	// Datastore and custody commands must reach their gate before any optional
 	// executable housekeeping. Only remote client verbs own CLI update cleanup.
 	if slices.Contains(cli.Verbs, cmd) {
@@ -126,13 +131,66 @@ func run() int {
 	case cmd == "restore":
 		return runOperator(ctx, "restore", args, app.RunRestore)
 	case slices.Contains(cli.Verbs, cmd):
+		if cli.HelpRequested(args) {
+			// Help never opens the controlling terminal.
+			return cli.Run(ctx, updateIO(nil, nil, builtChannel), invocation)
+		}
 		terminalSession, terminalError := disclose.OpenTerminalSession()
-		return cli.Run(ctx, updateIO(terminalSession, terminalError, builtChannel), os.Args[1:])
+		return cli.Run(ctx, updateIO(terminalSession, terminalError, builtChannel), invocation)
 	default:
 		fmt.Fprintf(os.Stderr, "hikyo: unknown command %q\n\n", cmd)
-		usage()
+		usage(os.Stderr)
 		return 2
 	}
+}
+
+// runHelp answers `hikyo --help`, `hikyo help [command...]` and
+// `hikyo <command...> --help` for every role of the binary, on stdout with
+// exit 0, before any mode touches its configuration, datastore, network, or
+// terminal. Client verbs answer inside cli.Run, which owns their help text,
+// so for them only the `help` spelling is rewritten and handed back.
+func runHelp(args []string, stdout, stderr io.Writer) (invocation []string, handled bool, code int) {
+	if args[0] == "help" {
+		args = append(slices.Clone(args[1:]), "--help")
+	}
+	cmd := args[0]
+	if cli.IsHelpFlag(cmd) {
+		usage(stdout)
+		return args, true, 0
+	}
+	if slices.Contains(cli.Verbs, cmd) || !cli.HelpRequested(args[1:]) {
+		return args, false, 0
+	}
+	switch cmd {
+	case "client":
+		cli.Usage(stdout)
+	case "admin":
+		app.AdminUsage(stdout)
+	case "backup":
+		app.BackupUsage(stdout)
+	case "restore":
+		app.RestoreUsage(stdout)
+	case "escrow":
+		app.EscrowUsage(stdout)
+	case "server", "migrate", "config-rollout":
+		// These parse their own flag sets, and the flag package's generated
+		// usage is the complete, always-current list of what they accept.
+		return args, false, 0
+	case "upgrade":
+		// The automatic upgrade parses its own flags; `upgrade operator`
+		// loads server configuration first, so it answers from the text.
+		if len(args) < 2 || args[1] != "operator" {
+			return args, false, 0
+		}
+		cli.HelpFromText(stdout, usageText, cli.CommandPath(args))
+	default:
+		if !cli.HelpFromText(stdout, usageText, cli.CommandPath(args)) {
+			fmt.Fprintf(stderr, "hikyo: unknown command %q\n\n", cmd)
+			usage(stderr)
+			return args, true, 2
+		}
+	}
+	return args, true, 0
 }
 
 // writeVersion prints the readable build summary. `hikyo version` shows this
@@ -214,6 +272,9 @@ func shouldCheckForUpdate(command string) bool {
 
 func runServer(ctx context.Context, args []string) int {
 	cfg, warnings, err := config.LoadBootstrap("server", args, os.Getenv, os.Environ())
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "hikyo server:", err)
 		return 1
@@ -339,6 +400,9 @@ func workdir() string {
 
 func runMigrate(ctx context.Context, args []string) int {
 	cfg, warnings, err := config.Load("migrate", args, os.Getenv, os.Environ())
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "hikyo migrate:", err)
 		return 1
@@ -401,34 +465,74 @@ func runUpgradeOperator(ctx context.Context, args []string) int {
 	return 0
 }
 
-func usage() {
-	fmt.Fprintf(os.Stderr, `hikyo — one binary, several roles
+func usage(w io.Writer) {
+	fmt.Fprint(w, usageText)
+	fmt.Fprintf(w, "client verbs (hikyo help client prints the full reference):\n%s\n", wrapWords(cli.Verbs, 2, 78))
+}
 
-server commands:
-  sudo hikyo upgrade [--target VERSION] [--config FILE]
-  hikyo server [--dev] [--listen ADDR] [--auto-migrate=BOOL]
+// usageText is the multicall help. cmd/hikyo's TestUsage keeps it aligned
+// with run's dispatch table; the client verb list is appended from cli.Verbs.
+const usageText = `hikyo - one binary, several roles
+
+  hikyo --help                          this overview
+  hikyo help <command...>               help for one command, at any depth
+  hikyo <command...> --help             the same
+
+server:
+  hikyo server [--dev] [--listen ADDR] [--auto-migrate=BOOL] [flags]
+                                        hikyo server --help lists every flag
   hikyo migrate [--dev]
+  sudo hikyo upgrade [--target VERSION] [--config FILE]
+                                        verified in-place upgrade on a systemd host
+  hikyo upgrade operator rotate --statement FILE --signature FILE --new-public-key FILE
 
 kubernetes operator (separate deployable; HIKYO_OPERATOR_* env only):
   hikyo operator
+  hikyo config-rollout [--enrollment-file PATH] [--authority-public-key PATH]
 
 privileged local update helper (separate service; JSON config only):
   hikyo updater --config /etc/hikyo/updater.json
+                                        remote apply is disabled; see hikyo upgrade
 
 information:
-  hikyo version
+  hikyo version                         readable build summary
+  hikyo --version                       the version alone, for scripts
   hikyo about
   hikyo welcome
 
-local host authority (server host only):
+local host authority (server host only; --dev directly after the group):
   hikyo admin [--dev] create --username USER
-  hikyo backup [--dev] export [--out DIR]
+  hikyo admin [--dev] reset-credential --principal ID
+  hikyo admin [--dev] grant --principal ID --capability CAP
+  hikyo admin [--dev] privacy export|restrict|erase|release|correct|reapply
+  hikyo admin [--dev] config status|recover
+  hikyo backup [--dev] export [--out DIR] [--recipient R]... [--passphrase-file PATH]
   hikyo backup [--dev] keygen
-  hikyo restore [--dev] run --from ARCHIVE --identity-file PATH
+  hikyo backup [--dev] upgrade-export|upgrade-drill
+  hikyo escrow [--dev] verify --root-key-file FILE --assert-separate-custody
+  hikyo restore [--dev] run --from ARCHIVE (--identity-file PATH | --passphrase-file PATH)
   hikyo restore [--dev] status
   hikyo restore [--dev] reconcile --principal ID
+  hikyo restore [--dev] drill --from ARCHIVE
 
-client verbs:
-  %v
-`, cli.Verbs)
+  each group answers --help with its full synopsis: hikyo backup --help
+
+`
+
+// wrapWords lays words out in lines of at most width columns, each indented.
+func wrapWords(words []string, indent, width int) string {
+	var b strings.Builder
+	line := strings.Repeat(" ", indent)
+	for _, word := range words {
+		if len(line) > indent && len(line)+1+len(word) > width {
+			b.WriteString(line + "\n")
+			line = strings.Repeat(" ", indent)
+		}
+		if len(line) > indent {
+			line += " "
+		}
+		line += word
+	}
+	b.WriteString(line + "\n")
+	return b.String()
 }

--- a/cmd/hikyo/main_test.go
+++ b/cmd/hikyo/main_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/Hikyo-Org/hikyo/internal/app"
+	"github.com/Hikyo-Org/hikyo/internal/cli"
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/console"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
@@ -181,5 +182,68 @@ func TestEscrowDispatchPreservesServerRootIdentity(t *testing.T) {
 		if !called || code == 0 {
 			t.Fatal("actual dispatch accepted same-file custody")
 		}
+	}
+}
+
+func TestUsageCoversEveryMode(t *testing.T) {
+	// The mode switch in run() and the multicall help must not drift apart:
+	// every dispatched mode has a synopsis line, and no line names a mode
+	// that does not dispatch. Client verbs are appended from cli.Verbs.
+	modes := []string{"server", "migrate", "upgrade", "operator", "config-rollout", "updater",
+		"version", "about", "welcome", "admin", "backup", "escrow", "restore"}
+	var out bytes.Buffer
+	usage(&out)
+	text := out.String()
+	if strings.Contains(text, "—") {
+		t.Error("usage contains an em-dash")
+	}
+	for _, mode := range modes {
+		if !strings.Contains(text, "  hikyo "+mode) && !strings.Contains(text, "  sudo hikyo "+mode) {
+			t.Errorf("usage has no synopsis for mode %q", mode)
+		}
+		if !cli.HelpFromText(io.Discard, usageText, []string{mode}) {
+			t.Errorf("hikyo %s --help would find no section", mode)
+		}
+	}
+	for _, verb := range cli.Verbs {
+		if !strings.Contains(text, verb) {
+			t.Errorf("usage does not list client verb %q", verb)
+		}
+	}
+	if cli.HelpFromText(io.Discard, usageText, []string{"teleport"}) {
+		t.Error("usage answers help for an unknown mode")
+	}
+}
+
+func TestRunHelpRewritesTheHelpWord(t *testing.T) {
+	// `hikyo help values set` is `hikyo values set --help`, handed on to the
+	// client dispatcher untouched otherwise; host groups answer in place.
+	invocation, handled, code := runHelp([]string{"help", "values", "set"}, io.Discard, io.Discard)
+	if handled || code != 0 || strings.Join(invocation, " ") != "values set --help" {
+		t.Errorf("runHelp(help values set) = %q, %v, %d", invocation, handled, code)
+	}
+	invocation, handled, _ = runHelp([]string{"login", "--local"}, io.Discard, io.Discard)
+	if handled || strings.Join(invocation, " ") != "login --local" {
+		t.Errorf("runHelp(login --local) = %q, %v", invocation, handled)
+	}
+	for _, args := range [][]string{{"help"}, {"-h"}, {"help", "backup", "export"}, {"admin", "create", "--help"}, {"escrow", "--help"}, {"help", "client"}, {"updater", "--help"}, {"upgrade", "operator", "--help"}, {"upgrade", "operator", "rotate", "-h"}} {
+		if _, handled, code := runHelp(args, io.Discard, io.Discard); !handled || code != 0 {
+			t.Errorf("runHelp(%q) = %v, %d, want handled with success", args, handled, code)
+		}
+	}
+	// Modes with their own flag sets answer --help through the flag package.
+	for _, args := range [][]string{{"server", "--help"}, {"migrate", "-h"}, {"upgrade", "--help"}, {"config-rollout", "--help"}} {
+		if _, handled, _ := runHelp(args, io.Discard, io.Discard); handled {
+			t.Errorf("runHelp(%q) handled, want the mode's own flag usage", args)
+		}
+	}
+	if _, handled, code := runHelp([]string{"help", "teleport"}, io.Discard, io.Discard); !handled || code != 2 {
+		t.Errorf("runHelp(help teleport) = %v, %d, want usage exit", handled, code)
+	}
+}
+
+func TestConfigRolloutHelpExitsZero(t *testing.T) {
+	if code := runConfigRollout(context.Background(), []string{"--help"}, io.Discard); code != 0 {
+		t.Errorf("config-rollout --help exited %d, want 0", code)
 	}
 }

--- a/docs/handoff/cli-help-and-docs-alignment.md
+++ b/docs/handoff/cli-help-and-docs-alignment.md
@@ -1,0 +1,134 @@
+# CLI help at every depth, and docs aligned with the shipped surface
+
+Branch `t3code/f403c26d`. Two deliverables: `--help` that works for every
+command and sub-subcommand of the multicall binary, and the docs site, landing
+page and README brought back in line with what the code dispatches today.
+
+## What changed
+
+### Help mechanism
+
+- `internal/cli/help.go` (new): a slicer over the frozen client usage text.
+  `parseUsage` reads the text into sections, entries and notes using its
+  existing layout (unindented `heading:` lines, two-space `hikyo ...`
+  synopses, deeper-indented continuation lines, two-space prose). `Help(w,
+  path)` renders every entry whose leading literal words match `path`, grouped
+  under its section with the section's notes, and trims unmatched trailing
+  words so `values set KEY --help` shows `values set`. Alternations
+  (`project list|show|create`) answer for each alternative. `HelpRequested`
+  stops at `--` so `hikyo run -- child --help` is the child's flag.
+- `internal/cli/verbs.go` `Run`: `help <words...>` is rewritten to
+  `<words...> --help`; `--help`/`-h`/`-help` anywhere before `--` answers on
+  stdout with exit 0 before any flag parsing, resolution, network or
+  terminal. The usage text moved into the `usageText` const `Usage` prints.
+- `cmd/hikyo/main.go` `runHelp`: same contract for the multicall modes. Host
+  groups print their own frozen usage (`app.AdminUsage`, `BackupUsage`,
+  `RestoreUsage`, new `EscrowUsage`). `server`, `migrate`, `upgrade`,
+  `config-rollout` keep the flag package's generated usage (complete and
+  always current; note it goes to stderr for `server` and `migrate`) and now
+  exit 0 on `flag.ErrHelp`. `help client` prints the full client reference.
+  The update check is skipped when help is requested. Multicall usage text
+  rewritten: no em-dash, every dispatched mode listed (`escrow`,
+  `config-rollout`, `--version`, `upgrade operator rotate`, admin
+  `privacy|config|grant`, backup `upgrade-export|upgrade-drill`, restore
+  `drill`), client verbs appended from `cli.Verbs` as wrapped words.
+
+### Help content (findings from a mechanical handler-vs-help audit)
+
+- Client help: added `rotate-scanning-key` (dispatched, undocumented) and the
+  flags that existed in code but not in help: login `--name --trust-file
+  --device`, establish-credential/recovery/context `--trust-file`,
+  instance-config `--idempotency-key --confirm-restored-credentials`, key
+  create/declare `--forbidden-in --group ...`, the `--acknowledge` family,
+  values publish `--preview-token --confirm-protected`, import
+  `--kube-context`, pin `--expires-at --override-schema`, approval policy
+  member flags, adapter `--create-environment --move --cancel-move`,
+  dynamic-provider `--tls-mode`, instance-config provider create/update/
+  disable/refresh-metadata flags, scim binding NameID flags.
+- `BackupUsage`: `upgrade-export`, `upgrade-drill` and their flags, the
+  `--dev` note. `RestoreUsage`: `--dev` note. `AdminUsage`: privacy actions
+  other than export need `--confirm`; `correct` takes optional username and
+  display name. Usage-error strings updated to name every subverb.
+
+### Tests
+
+- `internal/cli/golden_test.go`: `TestEveryVerbHasHelp` (every `cli.Verbs`
+  entry renders help; unknown verb does not), `TestHelpSlicesTheFrozenText`,
+  `TestHelpRequestedStopsAtSeparator`, eight new exit-code matrix rows.
+  Goldens `help.txt` and `exit-codes.txt` regenerated with `-update` and
+  reviewed.
+- `cmd/hikyo/main_test.go`: `TestUsageCoversEveryMode` (every dispatched mode
+  has a synopsis and a help section, no em-dash, every client verb listed),
+  `TestRunHelpRewritesTheHelpWord`.
+
+### Docs
+
+- `cli-reference.mdx`: new "Getting help" section; server/host table now
+  lists `upgrade`, `escrow`, `operator`, `config-rollout`, `updater`,
+  `--version`; domain table lists `dynamic-provider`, `lease`, `revision`,
+  `pin`, `approval`, `definitions`, `import`, `remote`, `rotate-*`; adapter row
+  names GitHub Actions; import wizard described as shipped; removed the
+  "commands not yet implemented" section (`render`, `sync`, `adopt` were
+  never stubs); managed configuration paragraph describes runtime and node
+  settings, not mail only.
+- `browser-operations.mdx`: dynamic-secret provider and lease management is
+  no longer a tracked browser exception (#595 landed); host-local class lists
+  `sudo hikyo upgrade`, `escrow verify`, `config-rollout`; managed
+  configuration paragraph as above.
+- `getting-started.mdx`: `cd Hikyo` (clone directory case); the `--dev`
+  callout no longer claims an environment variable for the admin command.
+- `index.mdx`: managed configuration row reworded, configuration rollouts
+  row added, em-dashes removed.
+- Em-dashes removed from prose in `values-workflows`, `configuration`,
+  `dynamic-secrets`, `self-hosting` (repo rule, AGENTS.md). The comparison
+  table glyphs on the landing page are not prose and were left.
+- `installation.mdx`: signed nightlies exist; install-path table gains the
+  `sudo hikyo upgrade` row; callouts say "stable" where they said "official".
+- `self-hosting.mdx` and `configuration.mdx`: TLS is imported once into
+  managed node configuration; there is no 10-second file poll, `SIGHUP`
+  refuses to reload, and the reload-failure counter is `0` by construction
+  (`internal/app/tls.go`, `app.go` `ReloadTLS`). Adapter egress policy is
+  provider-generic, not Forgejo-only.
+- `high-availability.mdx`: "Rolling upgrades" replaced by the full-stop,
+  single-migrator, exact-target procedure the chart and upgrades page state.
+- `architecture.mdx`: roles table lists upgrade, escrow, operator and
+  config-rollout; `restore drill` named as the one root-key exception.
+- `upgrades.mdx`: dropped the two-hop "intermediate binary" note (legacy
+  bridges now land directly in the current nightly).
+- `roadmap.mdx`: snapshot refreshed to today's `main`; the "open pull
+  requests" table is now "merged since the previous snapshot"; the upgrade
+  foundations paragraph lists what landed.
+- `build-from-source.mdx`: `cd Hikyo`.
+- Audit claims rejected after verification: `/implementation-status/` does
+  build (prepare-content.mjs writes it); `upgrade-nightly.sh` is published
+  (same script copies it to `public/`).
+- Landing page `index.astro`: page title no longer uses an em-dash.
+- `README.md`: `sudo hikyo upgrade` in the operate block; `--help` pointer.
+
+## Verification
+
+- `go test ./cmd/hikyo ./internal/cli ./internal/app` pass.
+- `pnpm --dir docs/site run check` and `run build` pass on Node 26.7.0;
+  `scripts/ci/check-doc-status.mjs --check` verifies 33 ledger entries.
+- Manual probes on the built binary: `hikyo --help`, `hikyo help`, `hikyo help
+  client`, `hikyo account factor --help`, `hikyo instance-config --help` (four
+  sections), `hikyo values set KEY --stdin --help`, `hikyo help adapter
+  target`, `hikyo backup export --help`, `hikyo escrow --help`, `hikyo server
+  --help` (exit 0), `hikyo teleport --help` (exit 2), `hikyo run -- ... --help`
+  (not help).
+
+## Deliberate limits
+
+- `hikyo server --help`, `hikyo migrate --help` and `hikyo config-rollout
+  --help` print through the flag package to stderr (exit 0). Routing them to
+  stdout means threading a writer through `config.Load`, which every test
+  constructs; not worth it for three commands. The CLI reference says so.
+- `hikyo upgrade operator ... --help` answers from the multicall usage text
+  because that path loads server configuration before its flag set.
+- Client-verb help never opens the controlling terminal: main passes a nil
+  session when help is requested.
+- Codex review: native `codex exec` hit the account usage limit (reset
+  Sep 13); the cross-model review has not run. Fallback model is Marc's call.
+- Client help lines are synopses, not exhaustive flag tables. The additions
+  above cover every flag the audit found missing; the per-verb flag parser
+  still refuses unknown flags with a usage error naming the accepted set.

--- a/docs/site/src/content/docs/docs/architecture.mdx
+++ b/docs/site/src/content/docs/docs/architecture.mdx
@@ -23,16 +23,21 @@ hikyo server --- datastore
 
 Only the server and local admin role unwrap the data-encryption key. The
 browser, network CLI, reverse proxy, datastore, backup exporter, and restore
-command never receive the operator root key.
+command never receive the operator root key. The one exception is `restore
+drill`, which boots the restored scratch copy with an explicitly supplied root
+key file to prove recovery.
 
-## One binary, four roles
+## One binary, several roles
 
 | Role | Commands | Boundary |
 | --- | --- | --- |
 | Server | `hikyo server` | Serves UI, API, health, and readiness. |
-| Migration | `hikyo migrate` | Applies datastore schema changes. |
-| Host operator | `hikyo admin`, `backup`, `restore` | Runs only beside the datastore. |
+| Migration | `hikyo migrate`, `sudo hikyo upgrade` | Applies datastore schema changes; the upgrade coordinator drives the verified in-place upgrade. |
+| Host operator | `hikyo admin`, `backup`, `restore`, `escrow` | Runs only beside the datastore. |
+| Kubernetes operator | `hikyo operator`, `config-rollout` | Separate deployable; reconciles `HikyoSecret` and the in-cluster rollout authority. |
 | Network client | login, hierarchy, values, access, identities | Uses the versioned HTTP API. |
+
+Every role answers `--help`; see [CLI reference](/docs/cli-reference/#getting-help).
 
 Host-operator commands do not have network routes. Host access is the authority
 for bootstrap and recovery, so these commands must run on the server host.

--- a/docs/site/src/content/docs/docs/browser-operations.mdx
+++ b/docs/site/src/content/docs/docs/browser-operations.mdx
@@ -5,9 +5,7 @@ editUrl: https://github.com/Hikyo-Org/Hikyo/edit/main/docs/site/src/content/docs
 ---
 
 Hikyo's server-mediated capabilities are reachable from both the CLI and the
-embedded web UI, with one tracked exception listed at the end of this page
-(dynamic-secret provider and lease management). Neither surface is the
-"advanced" one. This page follows the browser path end to end, from a fresh
+embedded web UI. Neither surface is the "advanced" one. This page follows the browser path end to end, from a fresh
 organisation on an installation whose only human is the bootstrap
 administrator to a workload receiving secrets in Kubernetes, and then lists
 exactly what stays outside the browser and why.
@@ -91,15 +89,10 @@ without a disposition or an issue is closed without its surface.
 
 | Class | Examples | Why |
 | --- | --- | --- |
-| Host-local authority | `hikyo admin create`, `migrate`, restore reconcile, break-glass | No HTTP endpoint exists; the act needs the host and the root key |
+| Host-local authority | `hikyo admin create`, `migrate`, `sudo hikyo upgrade`, `escrow verify`, restore reconcile, `config-rollout`, break-glass | No HTTP endpoint exists; the act needs the host and the root key |
 | Client-local delivery | `hikyo run`, `render`, the Compose and Kubernetes delivery fetch | Acts on the box the credential lives on and admits no human session |
 | Kubernetes reconciliation | `HikyoSecret` converge | The operator speaks only the delivery wire |
 | Identity-protocol endpoints | OIDC callback, SAML ACS, the SCIM wire, the CLI's own reauthentication legs | Protocol-shaped and client-specific by nature |
-
-One domain capability is tracked as open browser work and remains CLI/API
-only until its issue closes:
-[dynamic-secret provider and lease management](https://github.com/Hikyo-Org/Hikyo/issues/595).
-The Leases tab on Machine access is read-only until then.
 
 ## Parity is by outcome, not by form
 
@@ -112,7 +105,9 @@ redaction and audit rules.
 
 ## Managed Hikyo configuration
 
-For owner-local mail and release-notification settings, use
-[Manage Hikyo with Hikyo](/docs/managed-configuration/): edit the protected project,
-publish an exact revision, reauthenticate and apply. That guide covers adoption,
-per-node convergence, independent remote projects and rollback.
+Owner runtime settings and per-node settings are edited in the protected
+project like any other values, published as an exact revision, then applied
+after reauthentication. [Manage Hikyo with Hikyo](/docs/managed-configuration/)
+covers adoption, per-node convergence, independent remote projects and
+rollback; settings that need a restart go through
+[configuration rollouts](/docs/configuration-rollouts/).

--- a/docs/site/src/content/docs/docs/build-from-source.mdx
+++ b/docs/site/src/content/docs/docs/build-from-source.mdx
@@ -25,7 +25,7 @@ binary; no local SQLite service is needed.
 
 ```bash
 git clone https://github.com/Hikyo-Org/Hikyo.git
-cd hikyo
+cd Hikyo
 git status --short --branch
 git rev-parse HEAD
 ```

--- a/docs/site/src/content/docs/docs/cli-reference.mdx
+++ b/docs/site/src/content/docs/docs/cli-reference.mdx
@@ -4,17 +4,41 @@ description: Find Hikyo command families, target rules, output contracts, and ex
 editUrl: https://github.com/Hikyo-Org/Hikyo/edit/main/docs/site/src/content/docs/docs/cli-reference.mdx
 ---
 
-Run `hikyo` for the exact help shipped by your binary. This page is a map, not a
-replacement for version-matched help.
+Run `hikyo --help` for the exact help shipped by your binary. This page is a
+map, not a replacement for version-matched help.
+
+## Getting help
+
+Every command answers `--help` (or `-h`) at any depth with exit `0`, before
+it touches configuration, the datastore, the network, or the terminal.
+`hikyo help <command...>` is the same request spelled as a word. Help goes to
+stdout, except that `server`, `migrate`, and `config-rollout` print their flag
+parser's usage on stderr.
+
+```text
+hikyo --help                     every role of the binary, and the client verb list
+hikyo help client                the full client reference
+hikyo values --help              one verb family
+hikyo adapter target --help      one sub-family, at any depth
+hikyo backup export --help       a host operator group
+hikyo server --help              every server flag, from the flag parser
+```
+
+Anything after `--` belongs to the command `hikyo run` executes and is never
+read as a request for help.
 
 ## Server and host operator
 
 | Command family | Purpose |
 | --- | --- |
 | `server`, `migrate` | Serve Hikyo and manage schema state. |
-| `admin` | Bootstrap and break-glass account authority on the server host. |
-| `backup`, `restore` | Export, reconstruct, inspect, and reconcile an instance. |
-| `version` | Print readable build identity interactively; retain legacy one-line output when redirected. |
+| `upgrade` | `sudo hikyo upgrade` performs the verified in-place upgrade on a systemd host; `upgrade operator rotate` rotates the deployment authority. |
+| `admin` | Bootstrap, break-glass account authority, privacy actions, and configuration recovery on the server host. |
+| `backup`, `restore` | Export, reconstruct, inspect, drill, and reconcile an instance. |
+| `escrow` | Prove the separately held root escrow matches this instance. |
+| `operator`, `config-rollout` | The Kubernetes operator deployable and its in-cluster rollout authority stage. |
+| `updater` | The legacy privileged update helper; remote apply is disabled and it points at `hikyo upgrade`. |
+| `version`, `--version` | `version` prints the readable build summary; `--version` prints the version alone for scripts. |
 | `about`, `welcome` | Show Hikyo's full terminal artwork and product information. |
 
 ## Authentication and local state
@@ -38,7 +62,12 @@ stored locally and are never printed as a login receipt.
 | `folder`, `key` | Manage the catalogue and declarations. |
 | `values` | List, get, set, clear, diff, copy, and bulk declare. |
 | `access`, `project-settings` | Manage grants, members, and protected environments. |
-| `adapter` | Configure Forgejo deployment adapters, targets, plans, adoption, and converge jobs. |
+| `adapter` | Configure Forgejo and GitHub Actions deployment adapters, targets, plans, adoption, and converge jobs. |
+| `dynamic-provider`, `lease` | Register dynamic-secret providers and mint, renew, revoke, and settle short-lived leases. |
+| `revision`, `pin`, `approval` | Inspect lineage, pin workloads to a revision, and run change-approval policies and requests. |
+| `definitions`, `import` | Author and apply the reviewable catalogue, and stage values from other systems. |
+| `remote`, `remote-credential` | Peer instances and the credentials they present. |
+| `rotate-*`, `reencrypt` | Key rotation ceremonies and the re-encryption that completes a project rotation. |
 
 Most list and show commands accept `-o table|json`. JSON shapes may gain fields;
 automation must ignore unknown fields.
@@ -164,10 +193,9 @@ live Kubernetes and Vault/OpenBao sources. Use explicit flag mode or replay a
 recorded mapping; run `hikyo import --help` for the current source-specific
 flags.
 
-The interactive, multi-environment wizard is not implemented yet. Running
-`hikyo import` without `--from` or `--mapping` refuses explicitly and directs
-you to the available modes. Completion is tracked by
-[#112](https://github.com/Hikyo-Org/Hikyo/issues/112).
+Running `hikyo import` without `--from` or `--mapping` on a terminal enters the
+interactive, multi-environment wizard. Off a terminal the same invocation
+refuses explicitly and directs you to the flag and mapping modes.
 
 For a plaintext `.env`, use `definitions scaffold --from .env` to author a
 declaration offline, then `values import --from-dotenv .env` for the values. See
@@ -189,15 +217,11 @@ hikyo definitions apply --plan ID [--file PATH] [--allow-delete]
 no server, and emits an additive bundle every key of which is `config` with a
 `TODO: classify` marker. `check` exits `0` equal, `1` different, `2` on error.
 
-## Commands not yet implemented
-
-`render`, `sync`, and `adopt` remain reserved top-level stubs. Compose delivery
-uses `compose render` and `compose sync`; `adopt` is not implemented in the
-current 0.x build.
-
 ## Managed Hikyo configuration
 
-For owner-local mail and release-notification settings, use
-[Manage Hikyo with Hikyo](/docs/managed-configuration/): edit the protected project,
-publish an exact revision, reauthenticate and apply. That guide covers adoption,
-per-node convergence, independent remote projects and rollback.
+Owner runtime settings and per-node settings are managed through Hikyo itself:
+edit the protected project, publish an exact revision, reauthenticate and apply
+with `instance-config apply`. [Manage Hikyo with Hikyo](/docs/managed-configuration/)
+covers adoption, per-node convergence, independent remote projects and rollback,
+and [configuration rollouts](/docs/configuration-rollouts/) covers the controlled
+bootstrap rollouts for settings that need a restart.

--- a/docs/site/src/content/docs/docs/configuration.mdx
+++ b/docs/site/src/content/docs/docs/configuration.mdx
@@ -31,17 +31,19 @@ Do not use `--dev` for real secret material or any non-loopback deployment.
 | `HIKYO_TLS_CERT_FILE`, `HIKYO_TLS_KEY_FILE` | Native TLS pair; both or neither. |
 | `HIKYO_OPERATIONAL_LISTEN` | Separate operational bind; default `127.0.0.1:8081`. |
 | `HIKYO_TRUSTED_PROXY_CIDRS` | Alternative proxy mode for a non-loopback plaintext public listener. |
-| `HIKYO_ADAPTER_EGRESS_POLICY_FILE` | Optional startup-only Forgejo origin-to-CIDR exception policy. |
+| `HIKYO_ADAPTER_EGRESS_POLICY_FILE` | Optional startup-only adapter origin-to-CIDR exception policy, for any provider. |
 
 When origin is unset, Hikyo derives `https://<listen>` with native TLS and
 `http://<listen>` otherwise. Proxy mode should set the public HTTPS origin
 explicitly because the private listener cannot infer it.
 
 Native TLS is the default direct-deployment posture. Hikyo validates the pair at
-startup, rejects expired or mismatched files, warns within 14 days of expiry,
-polls for replacements every 10 seconds, and also reloads on `SIGHUP`. A bad
-replacement leaves the last known-good certificate live and increments
-`hikyo_tls_reload_failures_total`.
+startup and rejects expired, not-yet-valid, or mismatched files. The bootstrap
+pair is imported once into the managed node configuration and never watched:
+`SIGHUP` refuses to reload it, and a replacement is published and applied as
+the node certificate through [managed configuration](/docs/managed-configuration/).
+A failed candidate is reported by the apply job and never replaces the live
+certificate; `hikyo_tls_reload_failures_total` stays `0` by construction.
 
 Proxy mode requires trusted CIDRs when the plaintext public listener is not
 loopback. The list names proxies, not browser client networks. Operational
@@ -127,11 +129,11 @@ deliberately does not send because they commit hostnames it does not serve.
 `/metrics` on the operational listener serves Prometheus text exposition
 (`text/plain; version=0.0.4`) using the official Prometheus Go client. Scraping
 requires no sidecar, external service, or egress. It is plaintext and
-unauthenticated by design — keep the operational bind private and scrape it from
+unauthenticated by design. Keep the operational bind private and scrape it from
 the host or a trusted network.
 
 Alongside the retention and TLS gauges it exposes RED-style request metrics
-keyed by a closed **surface class** — `auth`, `hierarchy`, `values`,
+keyed by a closed **surface class**: `auth`, `hierarchy`, `values`,
 `revisions`, `delivery`, `scim`, `admin`, and a fail-closed `other`. There are
 no raw paths and no identifiers in any label, so cardinality is bounded no
 matter the traffic.
@@ -140,16 +142,16 @@ matter the traffic.
 | --- | --- | --- | --- |
 | `hikyo_http_requests_total` | counter | `class`, `status` (`2xx`/`3xx`/`4xx`/`5xx`/`other`) | Requests per surface class and status bucket. A recovered panic counts as `5xx`. |
 | `hikyo_http_request_errors_total` | counter | `class`, `status` (`4xx`/`5xx`) | Client and server errors per surface class. |
-| `hikyo_http_requests_in_flight` | gauge | — | Requests currently executing in the API stack. |
+| `hikyo_http_requests_in_flight` | gauge | none | Requests currently executing in the API stack. |
 | `hikyo_http_request_duration_seconds` | histogram | `class` | Request latency; fixed buckets `0.005, 0.025, 0.1, 0.5, 1, 5` seconds plus `+Inf`. |
 | `hikyo_mcp_requests_total` | counter | `method`, `tool`, `status` | MCP requests by closed protocol method, registered tool name, and status bucket. |
 | `hikyo_mcp_requests_in_flight` | gauge | none | MCP requests currently executing. |
 | `hikyo_mcp_request_duration_seconds` | histogram | `method`, `tool` | MCP request latency using the fixed HTTP bucket grid. |
-| `hikyo_admission_concurrency_limit` | gauge | — | Derived Argon2id verification slots. |
-| `hikyo_admission_in_flight` | gauge | — | Verification slots currently held. |
-| `hikyo_admission_queue_depth_limit` | gauge | — | Bound on simultaneous pre-auth waiters. |
-| `hikyo_admission_queue_waiting` | gauge | — | Waiters currently queued for a slot. |
-| `hikyo_admission_active_backoffs` | gauge | — | Accounts currently past the failure-backoff threshold. |
+| `hikyo_admission_concurrency_limit` | gauge | none | Derived Argon2id verification slots. |
+| `hikyo_admission_in_flight` | gauge | none | Verification slots currently held. |
+| `hikyo_admission_queue_depth_limit` | gauge | none | Bound on simultaneous pre-auth waiters. |
+| `hikyo_admission_queue_waiting` | gauge | none | Waiters currently queued for a slot. |
+| `hikyo_admission_active_backoffs` | gauge | none | Accounts currently past the failure-backoff threshold. |
 
 Counters cover all `/api/v1/*` traffic. Unmatched paths, unsupported methods,
 and CORS preflights use the closed `other` class.
@@ -158,8 +160,8 @@ Under `--dev` the server also emits a per-request access log (method, surface
 class, status, duration) at debug level. The production handler starts at Info,
 so these Debug request lines are absent unless debug logging is enabled.
 
-Adapter egress is public-address-only by default. To approve a private Forgejo
-origin, point `HIKYO_ADAPTER_EGRESS_POLICY_FILE` at a JSON object whose keys are
+Adapter egress is public-address-only by default. To approve a private adapter
+origin (Forgejo or GitHub Enterprise Server), point `HIKYO_ADAPTER_EGRESS_POLICY_FILE` at a JSON object whose keys are
 exact canonical bare HTTPS origins and whose values are CIDR lists:
 
 ```json

--- a/docs/site/src/content/docs/docs/dynamic-secrets.mdx
+++ b/docs/site/src/content/docs/docs/dynamic-secrets.mdx
@@ -80,7 +80,7 @@ hikyo lease mint --provider <provider> --env production --ttl 1h \
 
 A machine principal mints under the project's machine-reveal opt-in; a human
 operator minting for testing completes the mint reauthentication ceremony
-first. A retry mints a **new** lease with a new secret — the old secret is
+first. A retry mints a **new** lease with a new secret. The old secret is
 never returned again.
 
 ```sh

--- a/docs/site/src/content/docs/docs/getting-started.mdx
+++ b/docs/site/src/content/docs/docs/getting-started.mdx
@@ -21,7 +21,7 @@ SQLite database, and one administrator account.
 
 ```bash
 git clone https://github.com/Hikyo-Org/Hikyo.git
-cd hikyo
+cd Hikyo
 npm install --global --ignore-scripts corepack@0.35.0
 corepack enable
 corepack install --global pnpm@11.24.0
@@ -86,8 +86,9 @@ or a pipe. Delete `hikyo-admin-authority` after the command succeeds, then open
 
 <Callout type="warn" title="Evaluation only">
   `--dev` is deliberately convenient, not a production configuration. It uses
-  local plaintext HTTP and an environment variable for the one-off admin command.
-  Follow the self-hosting guide before exposing Hikyo beyond loopback.
+  local plaintext HTTP and a zero-config SQLite datastore in its own
+  development trust domain. Follow the self-hosting guide before exposing
+  Hikyo beyond loopback.
 </Callout>
 
 ## Next steps

--- a/docs/site/src/content/docs/docs/high-availability.mdx
+++ b/docs/site/src/content/docs/docs/high-availability.mdx
@@ -86,18 +86,19 @@ Node clocks must be reasonably synchronised (NTP). Lease acquisition compares
 the acquiring node's clock against the recorded expiry, so clock skew larger
 than the heartbeat is a split-brain risk.
 
-## Rolling upgrades
+## Upgrades
 
-Schema changes must land once, before the new binary serves:
+Rolling replacement is not an upgrade procedure. An HA upgrade is an
+operator-enforced full stop of every replica, one verified migrator, then an
+exact-target boot of the new image:
 
-1. Apply migrations once, with a single `hikyo migrate`, or let the first
-   upgraded replica apply them (concurrent migrators serialize under a database
-   session lock, so this is safe).
-2. Roll the replicas to the new image. A replica whose binary is older than the
-   database schema reports not-ready and stays out of rotation, so mixed
-   versions never serve incompatible schemas.
+1. Scale the replicas to zero and confirm every old process has exited.
+2. Run the verified migration once (`hikyo migrate` against the target release
+   under the [controlled migration](/docs/upgrades/#controlled-migration) gates).
+3. Boot the replicas on the exact target release.
 
-Never roll replicas before the migration lands.
+Never restart replicas on the old image after the migration lands, and never
+roll replicas while the schema is moving.
 
 ## Node replacement and capacity
 

--- a/docs/site/src/content/docs/docs/index.mdx
+++ b/docs/site/src/content/docs/docs/index.mdx
@@ -46,7 +46,8 @@ Choose the path that matches what you need to do now.
 | Plan SOC 2 and GDPR controls | [Self-hosted compliance](/docs/compliance/) |
 | Inventory personal data and retention | [Personal data and retention](/docs/privacy/) |
 | Handle rights requests and incidents | [Compliance operator procedures](/docs/compliance-operations/) |
-| Apply Hikyo mail settings without restarting | [Manage Hikyo with Hikyo](/docs/managed-configuration/) |
+| Edit and apply owner and node settings | [Manage Hikyo with Hikyo](/docs/managed-configuration/) |
+| Roll out settings that need a restart | [Configuration rollouts](/docs/configuration-rollouts/) |
 | Configure a server | [Configuration](/docs/configuration/) |
 | Recover from an archive | [Backup and restore](/docs/backup-and-restore/) |
 | Look up commands or routes | [CLI reference](/docs/cli-reference/) or [HTTP API](/docs/http-api/) |
@@ -58,8 +59,8 @@ Choose the path that matches what you need to do now.
 
 ## Load-bearing policy
 
-- [Security](/security/) — private reporting and disclosure timelines.
-- [Support](/support/) — exactly one supported release line.
-- [Governance](/governance/) — public authority and amendment rules.
-- [Implementation status](/implementation-status/) — machine-checked current capability and obligation state.
-- [License](/license/) — MPL-2.0 and the permanent no-enterprise-directory pledge.
+- [Security](/security/): private reporting and disclosure timelines.
+- [Support](/support/): exactly one supported release line.
+- [Governance](/governance/): public authority and amendment rules.
+- [Implementation status](/implementation-status/): machine-checked current capability and obligation state.
+- [License](/license/): MPL-2.0 and the permanent no-enterprise-directory pledge.

--- a/docs/site/src/content/docs/docs/installation.mdx
+++ b/docs/site/src/content/docs/docs/installation.mdx
@@ -4,9 +4,9 @@ description: Choose a safe Hikyo installation path for local evaluation or produ
 editUrl: https://github.com/Hikyo-Org/Hikyo/edit/main/docs/site/src/content/docs/docs/installation.mdx
 ---
 
-Hikyo is in `0.x` development and has no published stable release yet. Build
-from source for evaluation. Do not treat a development build as a supported
-production release.
+Hikyo is in `0.x` development and has no published stable release yet. Signed
+nightly prereleases are published; build from source for evaluation. Do not
+treat a development build or a nightly as a supported production release.
 
 ## Choose an installation path
 
@@ -14,15 +14,18 @@ production release.
 | --- | --- | --- |
 | Try Hikyo locally | [Getting started](/docs/getting-started/) | Loopback-only server, SQLite, embedded web UI |
 | Try the latest `main` build | [Unsigned development snapshot](#unsigned-development-snapshots) | Exact-commit archive for six desktop/server targets |
+| Run a signed nightly on a systemd host | [Upgrades](/docs/upgrades/#one-command-nightly-upgrade) | `sudo hikyo upgrade` with verified release evidence and a tested encrypted backup |
 | Build a reusable binary | [Build from source](/docs/build-from-source/) | One binary for your current platform |
 | Prepare a real deployment | [Self-hosting baseline](/docs/self-hosting/) | Explicit storage, keys, TLS boundary, and backups |
 | Upgrade an existing instance | [Upgrades](/docs/upgrades/) | Pre-migration export and verified rollout |
 
-<Callout type="info" title="Official release installers are not published yet">
+<Callout type="info" title="Stable release installers are not published yet">
   The repository contains the signed-release pipeline, installer template,
-  OCI image, and Helm chart. Those become installation options only after a
-  release is published. Development snapshots below are unsigned CI output,
-  not substitutes for that ceremony.
+  OCI image, and Helm chart. Those become stable installation options only
+  after a stable release is published. Signed nightlies ship six archives and
+  the native packages under the `nightly/v1` keyless policy and are upgraded
+  with `sudo hikyo upgrade`. Development snapshots below are unsigned CI
+  output, not substitutes for either ceremony.
 </Callout>
 
 ## Native packages after a signed release
@@ -120,8 +123,9 @@ Hikyo fails closed when these boundaries are missing. Continue with the
 ## Platform support
 
 Source builds follow Go's supported host platforms. Unsigned development
-snapshots cover Linux, macOS, and Windows on `x86_64` and `arm64`. Official
-downloads do not exist until the first signed release is published.
+snapshots and signed nightlies cover Linux, macOS, and Windows on `x86_64` and
+`arm64`. Stable downloads do not exist until the first stable release is
+published.
 
 The server is designed to run as one binary. The browser UI is embedded when
 the binary is built with the `ui` build tag.

--- a/docs/site/src/content/docs/docs/roadmap.mdx
+++ b/docs/site/src/content/docs/docs/roadmap.mdx
@@ -9,8 +9,8 @@ secrets service with controlled human onboarding, workload delivery, and
 recoverable operations. New product surfaces follow after that boundary is
 verified.
 
-<Callout type="warn" title="Development snapshot, 5 September 2026">
-  This page describes main at `0d591366874ad525b60ca12938dfd0ef2efe12d4`
+<Callout type="warn" title="Development snapshot, 7 September 2026">
+  This page describes main at `98ccf489758f1043448aa3008b484d41a0ebb7f7`
   and the review queue at this assessment. Merged code is not a released 1.0
   build. The [release gate](https://github.com/Hikyo-Org/Hikyo/issues/79)
   and [implementation status](/implementation-status/) remain authoritative
@@ -47,10 +47,11 @@ That implementation does not establish every advertised client's live result.
 
 The release is not reduced to a signing ceremony or tag push. Supported
 workflows, compatibility safety and candidate evidence still need closure.
-The following changes were **open pull requests at this snapshot**; their links
-show the current review and merge state.
+The following changes have **merged since the previous snapshot**; their links
+record the review that admitted them. Merged code still awaits the exact
+candidate's acceptance run.
 
-| Work | Why it belongs in 1.0 | Delivery under review |
+| Work | Why it belongs in 1.0 | Delivery |
 | --- | --- | --- |
 | Browser bundle export/check/plan/apply and this instance's directory | Browser-only operators need the actual immutable bundle and directory workflows; catalogue editing is not equivalent. | [#644](https://github.com/Hikyo-Org/Hikyo/pull/644), issues [#575](https://github.com/Hikyo-Org/Hikyo/issues/575) and [#576](https://github.com/Hikyo-Org/Hikyo/issues/576) |
 | Safe upgrade boundary | Refuse legacy remote apply before effects, preserve discovery/manual operation, and record the compatibility governance. A refusal is not an implemented signed migration graph. | [#645](https://github.com/Hikyo-Org/Hikyo/pull/645), [#638](https://github.com/Hikyo-Org/Hikyo/issues/638) |
@@ -68,9 +69,17 @@ provider evidence, API/CLI freeze and bidirectional skew checks, self-hoster
 and disclosure-channel checks, and the real release-signing ceremony.
 Published trust material and a stable tag cannot stand in for those results.
 Signed compatibility metadata and release binding, the applied-release ledger,
-exact legacy genesis, and mandatory migration gates on both engines remain
-required implementation before 1.0. PR #645 records governance and disables
-unsafe apply; it does not complete those foundations.
+exact legacy genesis, and mandatory migration gates on both engines have since
+landed ([#664](https://github.com/Hikyo-Org/Hikyo/pull/664),
+[#666](https://github.com/Hikyo-Org/Hikyo/pull/666),
+[#687](https://github.com/Hikyo-Org/Hikyo/pull/687)), together with
+`sudo hikyo upgrade` for signed nightlies on systemd hosts
+([#693](https://github.com/Hikyo-Org/Hikyo/pull/693)) and the recovery-signed
+legacy bridges into the current nightly
+([#690](https://github.com/Hikyo-Org/Hikyo/pull/690),
+[#696](https://github.com/Hikyo-Org/Hikyo/pull/696)). Runtime settings and
+controlled bootstrap rollouts ([#686](https://github.com/Hikyo-Org/Hikyo/pull/686))
+replaced restart-only configuration. What remains is the acceptance act itself.
 
 ## MCP: deployment proof and human delegation are separate
 

--- a/docs/site/src/content/docs/docs/self-hosting.mdx
+++ b/docs/site/src/content/docs/docs/self-hosting.mdx
@@ -61,9 +61,10 @@ HIKYO_EXTERNAL_ORIGIN=https://hikyo.example.com \
   --root-key-file /etc/hikyo/root.key
 ```
 
-Install the TLS private key as mode `0400` or `0600`. Renewals are detected by
-a 10-second file poll; `SIGHUP` reloads immediately. Failed reloads retain the
-last known-good certificate.
+Install the TLS private key as mode `0400` or `0600`. The bootstrap pair is
+imported once into the managed node configuration; files are not watched and
+`SIGHUP` does not reload them. Renew by publishing and applying the node
+certificate through [managed configuration](/docs/managed-configuration/).
 
 For reverse-proxy mode, omit the TLS flags, bind the public listener privately,
 set `HIKYO_TRUSTED_PROXY_CIDRS` to the exact proxy networks, and set
@@ -93,9 +94,9 @@ Readiness gives the complete datastore and optional HA check a two-second budget
 An unavailable or stalled datastore returns HTTP 503; `/healthz` remains independent
 so a database outage removes traffic without triggering a process restart.
 
-The same private listener serves `/metrics` in Prometheus text format —
-RED-style request counters and latency per surface class, in-flight and
-admission-pressure gauges, plus the retention and TLS gauges — with no external
+The same private listener serves `/metrics` in Prometheus text format (RED-style
+request counters and latency per surface class, in-flight and
+admission-pressure gauges, plus the retention and TLS gauges) with no external
 service dependency. It is unauthenticated; scrape it only from the host or a
 trusted network and never expose the operational bind. See
 [metrics](/docs/configuration/#operational-metrics) for the full list.

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -54,10 +54,9 @@ before the current schema under `/var/lib/hikyo-upgrade`; earlier `backup-*`,
 want to keep elsewhere.
 No operator private key enters the service configuration or release workflow.
 
-If an upgrade is interrupted, rerun the same command. During the first upgrade,
-an intermediate older binary can still lack `hikyo upgrade`; in that case rerun
-the bootstrap command above. Its durable journal and
-systemd startup fence survive reboot. Proven pre-write attempts and known healthy
+If an upgrade is interrupted, rerun the same command; if the installed binary
+still lacks `hikyo upgrade`, rerun the bootstrap command above. Its durable
+journal and systemd startup fence survive reboot. Proven pre-write attempts and known healthy
 or schema-applied targets can continue. An uncertain or failed schema change
 leaves the service stopped and requires explicit operator recovery; the command
 never automatically rolls back the database or starts an older binary.

--- a/docs/site/src/content/docs/docs/values-workflows.mdx
+++ b/docs/site/src/content/docs/docs/values-workflows.mdx
@@ -85,9 +85,9 @@ normal secure-file procedure.
 
 A disclosure needs a reauthentication window over the environment. When none is
 live the CLI opens one: where the environment's effective window is above `0`
-it prompts for an authenticator code at the terminal; where it is `0` — a
+it prompts for an authenticator code at the terminal; where it is `0` (a
 protected environment, or an instance that keeps the production default
-`HIKYO_REAUTH_WINDOW_SECONDS=0` — a code cannot bind the decision, so the CLI
+`HIKYO_REAUTH_WINDOW_SECONDS=0`) a code cannot bind the decision, so the CLI
 opens the browser to the same purpose-bound passkey ceremony the Values page
 runs, naming exactly the secret keys the command will open, and continues once
 you approve. Either way the session token rotates and is stored. `--dev`
@@ -106,7 +106,7 @@ hikyo definitions scaffold --from .env > definitions-bundle.json
 
 `scaffold` is offline. It contacts no server, reads only the file you give it,
 and emits an additive bundle in which every key is `config` with a
-`TODO: classify` marker — it cannot know which keys are secret, so it does not
+`TODO: classify` marker. It cannot know which keys are secret, so it does not
 guess. Open the bundle, change each secret key's classification, then apply it:
 
 ```bash
@@ -120,7 +120,7 @@ With the keys declared, import the values through the same strict path:
 hikyo values import --context production --from-dotenv .env
 ```
 
-Any key still not declared is refused by name — that surfaced typo is the point.
+Any key still not declared is refused by name. That surfaced typo is the point.
 After a successful import the source `.env` is still plaintext on disk; delete
 it once the values have landed.
 

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -14,7 +14,7 @@ const links = {
   security: `${base}security/`,
   support: `${base}support/`,
 };
-const title = 'Hikyo — explicit secrets and configuration across environments';
+const title = 'Hikyo: explicit secrets and configuration across environments';
 const description =
   'Hikyo is a fully open-source, self-hosted control plane that makes configuration state explicit across every environment.';
 const faq = [

--- a/internal/app/admin.go
+++ b/internal/app/admin.go
@@ -38,8 +38,10 @@ func AdminUsage(w io.Writer) {
                     [--output-file PATH | --dangerously-print]
   hikyo admin reset-credential --principal ID
                     [--output-file PATH | --dangerously-print]
-  hikyo admin privacy export|restrict|erase|release --principal ID --output-file PATH
-  hikyo admin privacy correct --principal ID --username USER --display-name NAME --output-file PATH --confirm
+  hikyo admin privacy export --principal ID --output-file PATH
+  hikyo admin privacy restrict|erase|release --principal ID --output-file PATH --confirm
+  hikyo admin privacy correct --principal ID [--username USER] [--display-name NAME]
+                    --output-file PATH --confirm
   hikyo admin privacy reapply --receipt PATH --output-file PATH --confirm
   hikyo admin grant --principal ID --capability CAP
                     [--org ID [--project ID [--env ID]]]
@@ -82,7 +84,7 @@ func RunAdmin(ctx context.Context, cfg *config.Config, log *slog.Logger, args []
 ) error {
 	if len(args) == 0 {
 		AdminUsage(stderr)
-		return errors.New("usage: hikyo admin create --username USER | hikyo admin reset-credential --principal ID | hikyo admin grant --principal ID --capability CAP")
+		return errors.New("usage: hikyo admin create | reset-credential | grant | privacy | config (hikyo admin --help)")
 	}
 	switch args[0] {
 	case "create":
@@ -97,7 +99,7 @@ func RunAdmin(ctx context.Context, cfg *config.Config, log *slog.Logger, args []
 		return runAdminGrant(ctx, cfg, log, args, stderr)
 	default:
 		AdminUsage(stderr)
-		return errors.New("usage: hikyo admin create --username USER | hikyo admin reset-credential --principal ID | hikyo admin grant --principal ID --capability CAP")
+		return errors.New("usage: hikyo admin create | reset-credential | grant | privacy | config (hikyo admin --help)")
 	}
 }
 

--- a/internal/app/backup.go
+++ b/internal/app/backup.go
@@ -62,6 +62,15 @@ func BackupUsage(w io.Writer) {
   hikyo backup export [--out DIR] [--recipient AGE-RECIPIENT]...
                       [--passphrase-file PATH]
   hikyo backup keygen [--output-file PATH | --dangerously-print]
+  hikyo backup upgrade-export [--bundle DIR] [--out DIR] [--recipient AGE-RECIPIENT]... [--json]
+  hikyo backup upgrade-drill --from ARCHIVE --receipt PATH --identity-file PATH
+                      --root-key-file PATH (--target-sqlite PATH | --target-postgres-dsn-file PATH)
+                      [--principal ID] [--project ORG/PROJECT] [--bundle DIR] [--out DIR]
+                      [--cosign PATH] [--signing-key PATH] [--valid-for 24h]
+
+For a development datastore, put --dev immediately after the group:
+  hikyo backup --dev export
+The production trust domain remains the default.
 
 export writes ONE age-encrypted archive holding a consistent snapshot of the
 datastore. Every sensitive field inside it is already envelope ciphertext and
@@ -79,6 +88,11 @@ keygen mints a backup identity and prints it once. Store the PRIVATE half in a
 custody store SEPARATE from the root key's - two keys in one password manager
 is one failure domain wearing two names, and the escrow runbook requires two.
 Delivery follows the print triad, as with every other display-once value.
+
+upgrade-export and upgrade-drill are the pre-upgrade evidence pair that
+sudo hikyo upgrade runs against a verified release bundle: export writes the
+public ciphertext and its receipt, drill restores that archive into an empty
+scratch datastore and signs an attestation that the restore path works.
 `)
 }
 
@@ -95,6 +109,10 @@ func RestoreUsage(w io.Writer) {
                       --root-key-file PATH --principal ID --project ORG/PROJECT
                       (--target-sqlite PATH | --target-postgres-dsn-file PATH)
                       [--cleanup] [-o json]
+
+For a development datastore, put --dev immediately after the group:
+  hikyo restore --dev status
+The production trust domain remains the default.
 
 run refuses anything that is not a complete archive for THIS engine, and it
 refuses it BEFORE touching the target: the container is decrypted in full and
@@ -132,7 +150,7 @@ func RunBackup(ctx context.Context, cfg *config.Config, log *slog.Logger, args [
 ) error {
 	if len(args) == 0 {
 		BackupUsage(stderr)
-		return errors.New("usage: hikyo backup export | hikyo backup keygen")
+		return errors.New("usage: hikyo backup export | keygen | upgrade-export | upgrade-drill")
 	}
 	switch args[0] {
 	case "upgrade-export", "upgrade-drill":
@@ -278,7 +296,7 @@ func RunRestore(ctx context.Context, cfg *config.Config, log *slog.Logger, args 
 ) error {
 	if len(args) == 0 {
 		RestoreUsage(stderr)
-		return errors.New("usage: hikyo restore run --from ARCHIVE | hikyo restore status | hikyo restore reconcile --principal ID")
+		return errors.New("usage: hikyo restore run --from ARCHIVE | hikyo restore status | hikyo restore reconcile --principal ID | hikyo restore drill --from ARCHIVE")
 	}
 	switch args[0] {
 	case "run":

--- a/internal/app/escrow.go
+++ b/internal/app/escrow.go
@@ -14,6 +14,21 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/service"
 )
 
+// EscrowUsage is the frozen help text for the escrow verb group.
+func EscrowUsage(w io.Writer) {
+	fmt.Fprint(w, `hikyo escrow - prove the offline root escrow matches this instance (server host only)
+
+  hikyo escrow verify --root-key-file FILE --assert-separate-custody
+
+verify reads the root key recovered from the separate offline custody store
+and checks it against the running hierarchy without exposing it. The server
+root must be a file (HIKYO_ROOT_KEY_FILE) so the two custodies are provably
+distinct files; --assert-separate-custody is the operator's recorded
+assertion, which filesystem checks cannot prove. For a development datastore,
+put --dev immediately after the group: hikyo escrow --dev verify ...
+`)
+}
+
 func RunEscrow(ctx context.Context, cfg *config.Config, _ *slog.Logger, args []string, out io.Writer, _ *disclose.TerminalSession, _ error) error {
 	if len(args) == 0 || args[0] != "verify" {
 		return errors.New("usage: hikyo escrow verify --root-key-file FILE --assert-separate-custody")

--- a/internal/cli/golden_test.go
+++ b/internal/cli/golden_test.go
@@ -82,6 +82,61 @@ func TestHelpOutputIsFrozen(t *testing.T) {
 	golden(t, "help.txt", buf.Bytes())
 }
 
+func TestEveryVerbHasHelp(t *testing.T) {
+	// A verb that dispatches but has no line in the frozen help is invisible
+	// to `hikyo <verb> --help`; this keeps the two tables in step.
+	for _, verb := range cli.Verbs {
+		var out bytes.Buffer
+		if !cli.Help(&out, []string{verb}) {
+			t.Errorf("no help for verb %q", verb)
+		}
+	}
+	var out bytes.Buffer
+	if cli.Help(&out, []string{"teleport"}) {
+		t.Errorf("help for an unknown verb rendered %q", out.String())
+	}
+}
+
+func TestHelpSlicesTheFrozenText(t *testing.T) {
+	var out bytes.Buffer
+	if !cli.Help(&out, []string{"account", "factor", "no-such-word"}) {
+		t.Fatal("no help for account factor")
+	}
+	// The unmatched trailing word is dropped, so this is `account factor`.
+	got := out.String()
+	for _, want := range []string{"accounts:\n", "hikyo account factor enrol-totp", "hikyo account factor step-up"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("account factor help lacks %q:\n%s", want, got)
+		}
+	}
+	for _, reject := range []string{"hikyo account passkey", "hikyo login"} {
+		if strings.Contains(got, reject) {
+			t.Errorf("account factor help leaks %q:\n%s", reject, got)
+		}
+	}
+	// Alternation entries answer for each alternative, and a verb spread over
+	// several sections renders each section it appears in.
+	out.Reset()
+	cli.Help(&out, []string{"project", "rename"})
+	if got := out.String(); !strings.Contains(got, "hikyo project list|show|create|rename|delete") || !strings.Contains(got, "hikyo project rename <project>") {
+		t.Errorf("project rename help:\n%s", got)
+	}
+	out.Reset()
+	cli.Help(&out, []string{"instance-config"})
+	if got := out.String(); strings.Count(got, "\ninstance configuration:\n") != 1 || !strings.Contains(got, "managed configuration:\n") || !strings.Contains(got, "oidc federation:\n") {
+		t.Errorf("instance-config help does not span its sections:\n%s", got)
+	}
+}
+
+func TestHelpRequestedStopsAtSeparator(t *testing.T) {
+	if !cli.HelpRequested([]string{"--local", "-h"}) || cli.HelpRequested([]string{"--", "--help"}) || cli.HelpRequested([]string{"--helpful"}) {
+		t.Error("HelpRequested misreads its arguments")
+	}
+	if got := cli.CommandPath([]string{"values", "set", "KEY", "--stdin", "--help"}); strings.Join(got, " ") != "values set KEY" {
+		t.Errorf("CommandPath = %q", got)
+	}
+}
+
 func TestExitCodeMatrix(t *testing.T) {
 	// The scenario matrix the ops spec calls for: a fixed set of invocations
 	// with their committed exit codes. Scripts branch on codes, so a code
@@ -227,6 +282,17 @@ func TestExitCodeMatrix(t *testing.T) {
 		{"values import file and from-dotenv", []string{"values", "import", "--from-dotenv", "a.env", "--file", "v.json", "--instance", "unknown-ref"}, cli.ExitUsage},
 		// run --use-human-session with no terminal is refused (testIO injects none).
 		{"run --use-human-session without a terminal", []string{"run", "--use-human-session", "--instance", "unknown-ref", "--", "true"}, cli.ExitRefused},
+		// Help is answered on stdout with success at every depth, before any
+		// flag parsing or resolution; an unknown command stays usage even with
+		// --help; and nothing after "--" is ever read as a request for help.
+		{"top-level help", []string{"--help"}, cli.ExitOK},
+		{"help word", []string{"help"}, cli.ExitOK},
+		{"verb help", []string{"login", "--help"}, cli.ExitOK},
+		{"subverb help", []string{"account", "factor", "--help"}, cli.ExitOK},
+		{"help word at depth", []string{"help", "adapter", "target"}, cli.ExitOK},
+		{"help after flags", []string{"values", "set", "KEY", "--stdin", "-h"}, cli.ExitOK},
+		{"help for an unknown verb", []string{"teleport", "--help"}, cli.ExitUsage},
+		{"help after the separator is the child's", []string{"run", "--instance", "unknown-ref", "--", "true", "--help"}, cli.ExitRefused},
 	}
 	var report strings.Builder
 	for _, tc := range cases {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+// IsHelpFlag reports whether one argument asks for help.
+func IsHelpFlag(arg string) bool {
+	return arg == "--help" || arg == "-help" || arg == "-h"
+}
+
+// HelpRequested reports whether args ask for help anywhere before the "--"
+// separator. Arguments after "--" belong to the child command of `hikyo run`
+// and are never interpreted.
+func HelpRequested(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if IsHelpFlag(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// CommandPath is the leading literal words of an invocation: everything up to
+// the first flag or "--". `values set KEY --stdin --help` yields
+// [values set KEY]; Help trims unmatched trailing words itself.
+func CommandPath(args []string) []string {
+	var path []string
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			break
+		}
+		path = append(path, arg)
+	}
+	return path
+}
+
+// Help writes the slice of the client help that applies to path: every
+// entry whose leading words match, grouped under its section, followed by
+// that section's notes. Trailing words that match nothing are dropped
+// one at a time so `values set KEY --help` shows `values set`. It returns
+// false when not even the first word is a known command.
+func Help(w io.Writer, path []string) bool {
+	return HelpFromText(w, usageText, path)
+}
+
+// HelpFromText is Help over an arbitrary usage text laid out like usageText.
+func HelpFromText(w io.Writer, text string, path []string) bool {
+	sections := parseUsage(text)
+	for len(path) > 0 {
+		if out := renderHelp(sections, path); out != "" {
+			fmt.Fprint(w, out)
+			return true
+		}
+		path = path[:len(path)-1]
+	}
+	return false
+}
+
+// A section is one heading of the usage text with its entries and notes.
+type helpSection struct {
+	heading string
+	entries []helpEntry
+	// notes are the section's prose paragraphs, each kept as its lines.
+	notes [][]string
+}
+
+// An entry is one `hikyo ...` synopsis with its continuation lines.
+type helpEntry struct {
+	// words are the literal command words before the first placeholder,
+	// flag, or description column: [values set], [project list|show|create].
+	words []string
+	lines []string
+}
+
+func (e helpEntry) matches(path []string) bool {
+	if len(path) > len(e.words) {
+		return false
+	}
+	for i, word := range path {
+		if !slices.Contains(strings.Split(e.words[i], "|"), word) {
+			return false
+		}
+	}
+	return true
+}
+
+func renderHelp(sections []helpSection, path []string) string {
+	var b strings.Builder
+	for _, section := range sections {
+		var matched []helpEntry
+		for _, entry := range section.entries {
+			if entry.matches(path) {
+				matched = append(matched, entry)
+			}
+		}
+		if len(matched) == 0 {
+			continue
+		}
+		b.WriteString(section.heading + "\n")
+		for _, entry := range matched {
+			for _, line := range entry.lines {
+				b.WriteString(line + "\n")
+			}
+		}
+		for _, note := range section.notes {
+			b.WriteString("\n")
+			for _, line := range note {
+				b.WriteString(line + "\n")
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func parseUsage(text string) []helpSection {
+	var (
+		sections []helpSection
+		current  *helpSection
+		entry    *helpEntry
+		note     []string
+		flush    = func() {
+			if current == nil {
+				return
+			}
+			if entry != nil {
+				current.entries = append(current.entries, *entry)
+				entry = nil
+			}
+			if note != nil {
+				current.notes = append(current.notes, note)
+				note = nil
+			}
+		}
+	)
+	for _, line := range strings.Split(text, "\n") {
+		switch {
+		case line == "":
+			flush()
+		case !strings.HasPrefix(line, " "):
+			flush()
+			if current != nil {
+				sections = append(sections, *current)
+			}
+			current = &helpSection{heading: line}
+		case current == nil:
+			// The title line's neighbours before the first heading.
+		case isEntryLine(line):
+			flush()
+			entry = &helpEntry{words: entryWords(line), lines: []string{line}}
+		case entry != nil && strings.HasPrefix(line, "    "):
+			entry.lines = append(entry.lines, line)
+		default:
+			if entry != nil {
+				current.entries = append(current.entries, *entry)
+				entry = nil
+			}
+			note = append(note, line)
+		}
+	}
+	flush()
+	if current != nil {
+		sections = append(sections, *current)
+	}
+	return sections
+}
+
+func isEntryLine(line string) bool {
+	return strings.HasPrefix(line, "  hikyo ") || strings.HasPrefix(line, "  sudo hikyo ")
+}
+
+// entryWords extracts the literal command words of a synopsis line. The
+// description column is separated by three or more spaces; placeholders,
+// flags and the "--" separator end the command words.
+func entryWords(line string) []string {
+	synopsis := strings.TrimSpace(line)
+	if i := strings.Index(synopsis, "   "); i >= 0 {
+		synopsis = synopsis[:i]
+	}
+	fields := strings.Fields(synopsis)
+	if len(fields) > 0 && fields[0] == "sudo" {
+		fields = fields[1:]
+	}
+	var words []string
+	for _, field := range fields[1:] { // fields[0] is "hikyo"
+		if strings.HasPrefix(field, "-") || strings.ContainsAny(field, "<[(") {
+			break
+		}
+		words = append(words, field)
+	}
+	return words
+}

--- a/internal/cli/testdata/exit-codes.txt
+++ b/internal/cli/testdata/exit-codes.txt
@@ -94,3 +94,11 @@ hikyo definitions scaffold -> 2 usage
 hikyo definitions scaffold --from x.env stray -> 2 usage
 hikyo values import --from-dotenv a.env --file v.json --instance unknown-ref -> 2 usage
 hikyo run --use-human-session --instance unknown-ref -- true -> 4 refused
+hikyo --help -> 0 ok
+hikyo help -> 0 ok
+hikyo login --help -> 0 ok
+hikyo account factor --help -> 0 ok
+hikyo help adapter target -> 0 ok
+hikyo values set KEY --stdin -h -> 0 ok
+hikyo teleport --help -> 2 usage
+hikyo run --instance unknown-ref -- true --help -> 4 refused

--- a/internal/cli/testdata/help.txt
+++ b/internal/cli/testdata/help.txt
@@ -1,22 +1,26 @@
 hikyo - environment and secret management
 
 authentication:
-  hikyo login <instance-url> --local [--as USER]   terminal-native local login
+  hikyo login <instance-url> --local [--as USER] [--name REF] [--trust-file PATH]
+                                                 terminal-native local login
+  hikyo login <instance-url> --device              refused by name until the browser login lands
   hikyo logout [--instance REF]                    revoke the stored session
   hikyo whoami [--instance REF] [-o table|json]    describe the stored session
 
 accounts:
-  hikyo account establish-credential --instance <url|ref> [--as USER]
+  hikyo account establish-credential --instance <url|ref> [--as USER] [--trust-file PATH]
   hikyo account factor enrol-totp [--output-file PATH | --dangerously-print]
   hikyo account factor confirm-totp
   hikyo account factor step-up
   hikyo account passkey enrol|list|remove          browser-only; refused on the terminal
   hikyo account recovery-codes regenerate [--output-file PATH | --dangerously-print]
-  hikyo account recovery begin --instance <url|ref> --as USER [--output-file PATH]
+  hikyo account recovery begin --instance <url|ref> --as USER [--trust-file PATH]
+      [--output-file PATH | --dangerously-print]
   hikyo account reset-credential <principal> [--output-file PATH | --dangerously-print]
 
 contexts:
   hikyo context create <name> --instance <url|ref> [--org O] [--project P] [--env E]
+      [--trust-file PATH]                          the trust bundle a CI runner was provisioned with
   hikyo context list [-o table|json]
   hikyo context show <name> [-o table|json]
   hikyo context delete <name>
@@ -24,8 +28,10 @@ contexts:
 
 managed configuration:
   hikyo instance-config status [-o table|json]
-  hikyo instance-config adopt [--yes]              preview or adopt effective settings
+  hikyo instance-config adopt [--yes] [--confirm-restored-credentials]
+                                                 preview or adopt effective settings
   hikyo instance-config apply --revision N --expected-generation N
+      [--idempotency-key KEY] [--confirm-restored-credentials]
   hikyo instance-config test-email --revision N --expected-generation N --to ADDRESS
 
 diagnostics:
@@ -55,16 +61,26 @@ hierarchy:
   hikyo folder rename <folder> --path <new-path>
   hikyo key list|show|create|rename|declare|reclassify|update|set-group|delete
   hikyo key create --name <NAME> --classification secret|config --declaration <json>
+      [--required-in all|none|<ids>] [--forbidden-in all|none|<ids>] [--group G]
+      [--folder P] [--description D] [--deprecated] [--deprecation-note N]
   hikyo key update <key> [--folder P] [--description D] [--deprecated] [--deprecation-note N]
   hikyo key declare <key> --declaration <json> [--required-in all|none|<ids>]
+      [--forbidden-in all|none|<ids>]
   hikyo key reclassify <key> --classification secret|config    the ceremony, never update
   hikyo key group list|show|create|rename|delete
+  hikyo key group create --name <name>
+  hikyo key group rename <group> --name <new-name>
+
+  key create, rename, declare and update, and key group create and rename,
+  take --acknowledge <token,token>: the secret-scanning override tokens a
+  prior refusal printed, once you have reviewed them.
 
 values:                                            --env selects the environment
   hikyo values list [--reveal] [--output-file PATH | --dangerously-print]
   hikyo values get <KEY> [--reveal] [--output-file PATH | --dangerously-print]
   hikyo values set <KEY> (--stdin | --value-file PATH)   stages; publish commits
   hikyo values set <KEY> --clear                    stages a clear to absent
+  hikyo values set <KEY> ... --acknowledge <token,token>   keep-as-config tokens from a prior scanning warning
   hikyo values declare <KEY> --envs <env,env> (--stdin | --value-file PATH)
   hikyo values diff --left <env> --right <env> [--reveal] [--output-file PATH | --dangerously-print]
   hikyo values copy --from <env> --to <env,env> --keys <KEY,KEY> [--confirm-protected]
@@ -73,13 +89,15 @@ values:                                            --env selects the environment
   hikyo values import --from-dotenv <.env>          stage a plaintext .env through the strict path
   hikyo values pending                              your drafts, and the ids to publish
   hikyo values publish --versions <id,id>           selective; closes over key groups
+      [--preview-token T] [--confirm-protected <env,env>]
+                                                 restore preview token; protected envs reviewed by automation
   hikyo values export [--format table|json|dotenv] [--revision N] [--reveal]
       [--output-file PATH | --dangerously-print]
 
 import:                                            authors artifacts, then stops
   hikyo import --from <k8s|sops|vault|infisical> --project <p> --environment <e>
       --file <path> [--env <slug>] [--out-dir <dir>]
-  hikyo import --from k8s --live --namespace <ns> [--name <secret>]
+  hikyo import --from k8s --live --namespace <ns> [--name <secret>] [--kube-context <ctx>]
       --project <p> --environment <e> [--out-dir <dir>]
   hikyo import --from vault --live --mount <mount> [--path <prefix>] [--kv-version <1|2>]
       --project <p> --environment <e> [--out-dir <dir>]
@@ -107,11 +125,15 @@ revisions:                                         --env selects the environment
   hikyo revision show [<N>|latest]                  carries the change token
   hikyo revision rollback <N> [--key KEY]           stage a restore as ordinary drafts
   hikyo pin create --workload ID --revision N       create, re-pin, or renew
+      [--expires-at RFC3339] [--override-schema]    default expiry 180 days; override pins past a schema failure
   hikyo pin list                                    show pins and expired status
   hikyo pin release <workload-principal>            release a durable pin
   hikyo approval policy list                        list change-approval policies
   hikyo approval policy create --min-approvals N    bind an approval policy to a project or env
+      [--covers ENV] [--ttl SECONDS] [--allow-self-approval] [--disabled]
+      [--approver principal:<id>|group:<groupId>:<bindingId>]... [--bypasser <id>]...
   hikyo approval policy update <policy>             replace an approval policy's fields and members
+      (same flags as create)
   hikyo approval policy delete <policy>             delete an approval policy
   hikyo approval request list                       the environment's change-approval requests
   hikyo approval request approve <request>          approve a change-approval request
@@ -119,6 +141,7 @@ revisions:                                         --env selects the environment
   hikyo approval request merge <request>            merge an approved request via the publish path
   hikyo approval request bypass <request> --reason R emergency-bypass a request's quorum
   hikyo rotate-token-key --yes                      new token key; one full fetch, no restart wave
+  hikyo rotate-scanning-key --yes                   new scanning key; every dismissal is dropped
   hikyo rotate-dek --instance --yes                 new instance DEK version (old stays readable)
   hikyo rotate-dek --org O --project P --yes         new project DEK version; follow with reencrypt
   hikyo rotate-master-key --yes                     new master; re-wrap every tier-3 key
@@ -131,23 +154,26 @@ adapters:
       [--visibility all|private|selected] [--selected-repository-ids <id,...>]
       --prefix <prefix> --keys <id,...> [--names <NAME,...>]
       [--include <glob,...>] [--exclude <glob,...>] [--classification secret|config]
-      [--stdin | --value-file PATH]
+      [--stdin | --value-file PATH] [--create-environment]
   hikyo adapter list [-o table|json]
   hikyo adapter show <adapter> [-o table|json]
   hikyo adapter update <adapter> --origin <https-origin>
+  hikyo adapter update <adapter> --move <move-id> | --cancel-move
+                                                   resume or cancel an attention-required origin move
   hikyo adapter update <adapter> --target <target> --env E --kind <kind>
       --owner <owner> [--repo <repo>] [--destination-environment <name>]
       [--visibility all|private|selected] [--selected-repository-ids <id,...>]
       --prefix <prefix> --keys <id,...> [--names <NAME,...>]
       [--include <glob,...>] [--exclude <glob,...>] [--classification secret|config]
   hikyo adapter delete <adapter> [--keep-remote]
-  hikyo adapter credential set --adapter <adapter> [--stdin | --value-file PATH]
+  hikyo adapter credential set --adapter <adapter> [--stdin | --value-file PATH] [--move <move-id>]
   hikyo adapter credential revoke --adapter <adapter>
   hikyo adapter target add --adapter <adapter> --env E --kind <kind> --owner <owner>
       [--repo <repo>] [--destination-environment <name>]
       [--visibility all|private|selected] [--selected-repository-ids <id,...>]
       [--prefix <prefix>] --keys <id,...> [--names <NAME,...>]
       [--include <glob,...>] [--exclude <glob,...>] [--classification secret|config]
+      [--create-environment]
   hikyo adapter target list --adapter <adapter>
   hikyo adapter target show <target> [--format detail|workflow]
   hikyo adapter target pause <target>                stop pushes; ledger and remote names kept
@@ -158,13 +184,15 @@ adapters:
 
   key selection (--names, --include, --exclude, --classification) resolves to
   explicit key ids when the target is saved; keys created later are not added.
+  --create-environment is consent to create a missing GitHub environment and
+  needs Administration:write on the credential.
 
   adapter credentials are read with terminal echo disabled, from stdin, or
   from --value-file. There is no credential-value argv flag.
 
 dynamic secrets:
   hikyo dynamic-provider create --provider postgres --origin <postgres://user@host:port/db>
-      --grant-role <role> [--stdin | --value-file PATH]
+      --grant-role <role> [--tls-mode verify-full] [--stdin | --value-file PATH]
   hikyo dynamic-provider list [-o table|json]
   hikyo dynamic-provider show <provider> [-o table|json]
   hikyo dynamic-provider credential set --provider <provider> [--stdin | --value-file PATH]
@@ -202,9 +230,16 @@ compose:                                           machine credential only
 
 instance configuration:
   hikyo instance-config provider create --kind saml --name <name> --entity-id <entityID> \
-      (--metadata-file <xml> | --metadata-url <url>)
+      (--metadata-file <xml> | --metadata-url <url>) [--display-name NAME]
+      [--assurance-context URI]... [--confirm-fingerprint FP]... [--confirm-endpoint URL]...
+      [--allow-email-nameid] [--force-sign-requests]
   hikyo instance-config provider list|show|update|disable|remove
-  hikyo instance-config provider refresh-metadata <name>
+  hikyo instance-config provider update <name> [--kind oidc|saml] [--display-name NAME]
+      [--assurance-context URI]... | [--clear-assurance-policy]
+      [--allow-email-nameid BOOL] [--force-sign-requests BOOL] [--enabled BOOL]
+  hikyo instance-config provider disable <name> [--kind oidc|saml]
+  hikyo instance-config provider refresh-metadata <name> [--metadata-file <xml>]
+      [--confirm-fingerprint FP]... [--confirm-endpoint URL]...
   hikyo instance-config saml-sp-key list|rotate
   hikyo instance-config saml-sp-key retire|compromise-retire <fingerprint>
 
@@ -271,6 +306,9 @@ oidc federation:
   Bindings are listed and revoked through "sa credential".
 scim provisioning (org scope; the identity provider's own wire is not a CLI surface):
   hikyo scim binding create --org O --provider <provider> --kind oidc|saml
+      [--subject-source ATTR]                      default externalId; userName is refused
+      [--nameid-format URI] [--nameid-qualifier Q] [--nameid-qualifier-present]
+      [--nameid-sp-qualifier Q] [--nameid-sp-qualifier-present]   SAML only
   hikyo scim binding list|show|delete [<binding>]
   hikyo scim mapping add <binding> --group <idp-group-id> --template <name> (--project P [--env E] | --org-scope)
   hikyo scim mapping update <binding> --group <idp-group-id> --template <name> (--project P [--env E] | --org-scope)

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -126,12 +126,26 @@ func Run(ctx context.Context, io IO, args []string) int {
 		Usage(io.Stderr)
 		return ExitUsage
 	}
+	if args[0] == "help" {
+		args = append(slices.Clone(args[1:]), "--help")
+	}
 	verb, rest := args[0], args[1:]
 	handler, ok := verbHandlers[verb]
 	if !ok {
+		if IsHelpFlag(verb) {
+			Usage(io.Stdout)
+			return ExitOK
+		}
 		fmt.Fprintf(io.Stderr, "hikyo: unknown command %q\n\n", verb)
 		Usage(io.Stderr)
 		return ExitUsage
+	}
+	if HelpRequested(rest) {
+		// Every verb answers --help the same way, before any flag parsing,
+		// network, or terminal: the matching slice of the frozen help.
+		if Help(io.Stdout, CommandPath(args)) {
+			return ExitOK
+		}
 	}
 	return Report(io.Stderr, handler(ctx, io, rest))
 }
@@ -182,25 +196,38 @@ var verbHandlers = map[string]func(context.Context, IO, []string) error{
 // snapshot: help output is part of the CLI's stable surface, and a diff to it
 // is reviewed like a spec change.
 func Usage(w io.Writer) {
-	fmt.Fprint(w, `hikyo - environment and secret management
+	fmt.Fprint(w, usageText)
+}
+
+// usageText is the frozen help text Usage prints and Help slices per command
+// path (help.go). Its layout is the contract the slicer parses: a section is
+// an unindented line ending in a colon (an optional note may follow the
+// colon), an entry is a line indented two spaces and starting with "hikyo",
+// its continuation lines are indented deeper, and anything else indented two
+// spaces is prose attached to the enclosing section.
+const usageText = `hikyo - environment and secret management
 
 authentication:
-  hikyo login <instance-url> --local [--as USER]   terminal-native local login
+  hikyo login <instance-url> --local [--as USER] [--name REF] [--trust-file PATH]
+                                                 terminal-native local login
+  hikyo login <instance-url> --device              refused by name until the browser login lands
   hikyo logout [--instance REF]                    revoke the stored session
   hikyo whoami [--instance REF] [-o table|json]    describe the stored session
 
 accounts:
-  hikyo account establish-credential --instance <url|ref> [--as USER]
+  hikyo account establish-credential --instance <url|ref> [--as USER] [--trust-file PATH]
   hikyo account factor enrol-totp [--output-file PATH | --dangerously-print]
   hikyo account factor confirm-totp
   hikyo account factor step-up
   hikyo account passkey enrol|list|remove          browser-only; refused on the terminal
   hikyo account recovery-codes regenerate [--output-file PATH | --dangerously-print]
-  hikyo account recovery begin --instance <url|ref> --as USER [--output-file PATH]
+  hikyo account recovery begin --instance <url|ref> --as USER [--trust-file PATH]
+      [--output-file PATH | --dangerously-print]
   hikyo account reset-credential <principal> [--output-file PATH | --dangerously-print]
 
 contexts:
   hikyo context create <name> --instance <url|ref> [--org O] [--project P] [--env E]
+      [--trust-file PATH]                          the trust bundle a CI runner was provisioned with
   hikyo context list [-o table|json]
   hikyo context show <name> [-o table|json]
   hikyo context delete <name>
@@ -208,8 +235,10 @@ contexts:
 
 managed configuration:
   hikyo instance-config status [-o table|json]
-  hikyo instance-config adopt [--yes]              preview or adopt effective settings
+  hikyo instance-config adopt [--yes] [--confirm-restored-credentials]
+                                                 preview or adopt effective settings
   hikyo instance-config apply --revision N --expected-generation N
+      [--idempotency-key KEY] [--confirm-restored-credentials]
   hikyo instance-config test-email --revision N --expected-generation N --to ADDRESS
 
 diagnostics:
@@ -239,16 +268,26 @@ hierarchy:
   hikyo folder rename <folder> --path <new-path>
   hikyo key list|show|create|rename|declare|reclassify|update|set-group|delete
   hikyo key create --name <NAME> --classification secret|config --declaration <json>
+      [--required-in all|none|<ids>] [--forbidden-in all|none|<ids>] [--group G]
+      [--folder P] [--description D] [--deprecated] [--deprecation-note N]
   hikyo key update <key> [--folder P] [--description D] [--deprecated] [--deprecation-note N]
   hikyo key declare <key> --declaration <json> [--required-in all|none|<ids>]
+      [--forbidden-in all|none|<ids>]
   hikyo key reclassify <key> --classification secret|config    the ceremony, never update
   hikyo key group list|show|create|rename|delete
+  hikyo key group create --name <name>
+  hikyo key group rename <group> --name <new-name>
+
+  key create, rename, declare and update, and key group create and rename,
+  take --acknowledge <token,token>: the secret-scanning override tokens a
+  prior refusal printed, once you have reviewed them.
 
 values:                                            --env selects the environment
   hikyo values list [--reveal] [--output-file PATH | --dangerously-print]
   hikyo values get <KEY> [--reveal] [--output-file PATH | --dangerously-print]
   hikyo values set <KEY> (--stdin | --value-file PATH)   stages; publish commits
   hikyo values set <KEY> --clear                    stages a clear to absent
+  hikyo values set <KEY> ... --acknowledge <token,token>   keep-as-config tokens from a prior scanning warning
   hikyo values declare <KEY> --envs <env,env> (--stdin | --value-file PATH)
   hikyo values diff --left <env> --right <env> [--reveal] [--output-file PATH | --dangerously-print]
   hikyo values copy --from <env> --to <env,env> --keys <KEY,KEY> [--confirm-protected]
@@ -257,13 +296,15 @@ values:                                            --env selects the environment
   hikyo values import --from-dotenv <.env>          stage a plaintext .env through the strict path
   hikyo values pending                              your drafts, and the ids to publish
   hikyo values publish --versions <id,id>           selective; closes over key groups
+      [--preview-token T] [--confirm-protected <env,env>]
+                                                 restore preview token; protected envs reviewed by automation
   hikyo values export [--format table|json|dotenv] [--revision N] [--reveal]
       [--output-file PATH | --dangerously-print]
 
 import:                                            authors artifacts, then stops
   hikyo import --from <k8s|sops|vault|infisical> --project <p> --environment <e>
       --file <path> [--env <slug>] [--out-dir <dir>]
-  hikyo import --from k8s --live --namespace <ns> [--name <secret>]
+  hikyo import --from k8s --live --namespace <ns> [--name <secret>] [--kube-context <ctx>]
       --project <p> --environment <e> [--out-dir <dir>]
   hikyo import --from vault --live --mount <mount> [--path <prefix>] [--kv-version <1|2>]
       --project <p> --environment <e> [--out-dir <dir>]
@@ -291,11 +332,15 @@ revisions:                                         --env selects the environment
   hikyo revision show [<N>|latest]                  carries the change token
   hikyo revision rollback <N> [--key KEY]           stage a restore as ordinary drafts
   hikyo pin create --workload ID --revision N       create, re-pin, or renew
+      [--expires-at RFC3339] [--override-schema]    default expiry 180 days; override pins past a schema failure
   hikyo pin list                                    show pins and expired status
   hikyo pin release <workload-principal>            release a durable pin
   hikyo approval policy list                        list change-approval policies
   hikyo approval policy create --min-approvals N    bind an approval policy to a project or env
+      [--covers ENV] [--ttl SECONDS] [--allow-self-approval] [--disabled]
+      [--approver principal:<id>|group:<groupId>:<bindingId>]... [--bypasser <id>]...
   hikyo approval policy update <policy>             replace an approval policy's fields and members
+      (same flags as create)
   hikyo approval policy delete <policy>             delete an approval policy
   hikyo approval request list                       the environment's change-approval requests
   hikyo approval request approve <request>          approve a change-approval request
@@ -303,6 +348,7 @@ revisions:                                         --env selects the environment
   hikyo approval request merge <request>            merge an approved request via the publish path
   hikyo approval request bypass <request> --reason R emergency-bypass a request's quorum
   hikyo rotate-token-key --yes                      new token key; one full fetch, no restart wave
+  hikyo rotate-scanning-key --yes                   new scanning key; every dismissal is dropped
   hikyo rotate-dek --instance --yes                 new instance DEK version (old stays readable)
   hikyo rotate-dek --org O --project P --yes         new project DEK version; follow with reencrypt
   hikyo rotate-master-key --yes                     new master; re-wrap every tier-3 key
@@ -315,23 +361,26 @@ adapters:
       [--visibility all|private|selected] [--selected-repository-ids <id,...>]
       --prefix <prefix> --keys <id,...> [--names <NAME,...>]
       [--include <glob,...>] [--exclude <glob,...>] [--classification secret|config]
-      [--stdin | --value-file PATH]
+      [--stdin | --value-file PATH] [--create-environment]
   hikyo adapter list [-o table|json]
   hikyo adapter show <adapter> [-o table|json]
   hikyo adapter update <adapter> --origin <https-origin>
+  hikyo adapter update <adapter> --move <move-id> | --cancel-move
+                                                   resume or cancel an attention-required origin move
   hikyo adapter update <adapter> --target <target> --env E --kind <kind>
       --owner <owner> [--repo <repo>] [--destination-environment <name>]
       [--visibility all|private|selected] [--selected-repository-ids <id,...>]
       --prefix <prefix> --keys <id,...> [--names <NAME,...>]
       [--include <glob,...>] [--exclude <glob,...>] [--classification secret|config]
   hikyo adapter delete <adapter> [--keep-remote]
-  hikyo adapter credential set --adapter <adapter> [--stdin | --value-file PATH]
+  hikyo adapter credential set --adapter <adapter> [--stdin | --value-file PATH] [--move <move-id>]
   hikyo adapter credential revoke --adapter <adapter>
   hikyo adapter target add --adapter <adapter> --env E --kind <kind> --owner <owner>
       [--repo <repo>] [--destination-environment <name>]
       [--visibility all|private|selected] [--selected-repository-ids <id,...>]
       [--prefix <prefix>] --keys <id,...> [--names <NAME,...>]
       [--include <glob,...>] [--exclude <glob,...>] [--classification secret|config]
+      [--create-environment]
   hikyo adapter target list --adapter <adapter>
   hikyo adapter target show <target> [--format detail|workflow]
   hikyo adapter target pause <target>                stop pushes; ledger and remote names kept
@@ -342,13 +391,15 @@ adapters:
 
   key selection (--names, --include, --exclude, --classification) resolves to
   explicit key ids when the target is saved; keys created later are not added.
+  --create-environment is consent to create a missing GitHub environment and
+  needs Administration:write on the credential.
 
   adapter credentials are read with terminal echo disabled, from stdin, or
   from --value-file. There is no credential-value argv flag.
 
 dynamic secrets:
   hikyo dynamic-provider create --provider postgres --origin <postgres://user@host:port/db>
-      --grant-role <role> [--stdin | --value-file PATH]
+      --grant-role <role> [--tls-mode verify-full] [--stdin | --value-file PATH]
   hikyo dynamic-provider list [-o table|json]
   hikyo dynamic-provider show <provider> [-o table|json]
   hikyo dynamic-provider credential set --provider <provider> [--stdin | --value-file PATH]
@@ -386,9 +437,16 @@ compose:                                           machine credential only
 
 instance configuration:
   hikyo instance-config provider create --kind saml --name <name> --entity-id <entityID> \
-      (--metadata-file <xml> | --metadata-url <url>)
+      (--metadata-file <xml> | --metadata-url <url>) [--display-name NAME]
+      [--assurance-context URI]... [--confirm-fingerprint FP]... [--confirm-endpoint URL]...
+      [--allow-email-nameid] [--force-sign-requests]
   hikyo instance-config provider list|show|update|disable|remove
-  hikyo instance-config provider refresh-metadata <name>
+  hikyo instance-config provider update <name> [--kind oidc|saml] [--display-name NAME]
+      [--assurance-context URI]... | [--clear-assurance-policy]
+      [--allow-email-nameid BOOL] [--force-sign-requests BOOL] [--enabled BOOL]
+  hikyo instance-config provider disable <name> [--kind oidc|saml]
+  hikyo instance-config provider refresh-metadata <name> [--metadata-file <xml>]
+      [--confirm-fingerprint FP]... [--confirm-endpoint URL]...
   hikyo instance-config saml-sp-key list|rotate
   hikyo instance-config saml-sp-key retire|compromise-retire <fingerprint>
 
@@ -455,6 +513,9 @@ oidc federation:
   Bindings are listed and revoked through "sa credential".
 scim provisioning (org scope; the identity provider's own wire is not a CLI surface):
   hikyo scim binding create --org O --provider <provider> --kind oidc|saml
+      [--subject-source ATTR]                      default externalId; userName is refused
+      [--nameid-format URI] [--nameid-qualifier Q] [--nameid-qualifier-present]
+      [--nameid-sp-qualifier Q] [--nameid-sp-qualifier-present]   SAML only
   hikyo scim binding list|show|delete [<binding>]
   hikyo scim mapping add <binding> --group <idp-group-id> --template <name> (--project P [--env E] | --org-scope)
   hikyo scim mapping update <binding> --group <idp-group-id> --template <name> (--project P [--env E] | --org-scope)
@@ -484,8 +545,7 @@ target resolution, per dimension, first hit wins:
 exit codes:
   0 success   1 internal   2 usage   3 authentication   4 refused
   5 not found (also unauthorized - indistinguishable by design)   6 unavailable
-`)
-}
+`
 
 // ---------------------------------------------------------------------------
 // login


### PR DESCRIPTION
## Summary

- `hikyo --help`, `hikyo help <command...>` and `hikyo <command...> --help` answer at any depth for every role of the multicall binary, on stdout with exit 0, before any mode touches configuration, the datastore, the network or the terminal. Client verbs slice the frozen usage text by command path (`internal/cli/help.go`); host groups print their own usage (new `EscrowUsage`); `server`, `migrate`, `config-rollout` and `upgrade` keep the flag package's usage and now exit 0 on `-h`.
- Help content: `rotate-scanning-key` and every flag/subverb a handler-vs-help audit found undocumented (client verbs, `backup upgrade-export|upgrade-drill`, `restore drill`, `admin privacy|config`, `escrow`, `config-rollout`, `upgrade operator rotate`). Multicall usage no longer prints a raw Go slice or an em-dash.
- Docs site, landing page and README aligned with the code: new "Getting help" section and missing command families in the CLI reference; corrected TLS reload, HA upgrade, import wizard, browser lease parity, nightly installer and roadmap claims; em-dashes removed from prose.

Handoff: `docs/handoff/cli-help-and-docs-alignment.md`.

## Verification

- `go test ./cmd/hikyo ./internal/cli ./internal/app`
- `pnpm --dir docs/site run check` and `run build` (Node 26.7.0); `scripts/ci/check-doc-status.mjs --check`
- Manual probes of the built binary at top level, verb, sub-verb and sub-sub-verb depth, plus `hikyo run -- child --help` staying the child's flag.

Cross-model (Codex) review skipped at Marc's instruction: native Codex is at its usage limit until Sep 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)