### PR TITLE
feat(upgrade): wrap operator custody with the root key instead of a passphrase

### DIFF
--- a/docs/adr/signed-upgrade-compatibility.md
+++ b/docs/adr/signed-upgrade-compatibility.md
@@ -176,13 +176,23 @@ The operator explicitly approved running a single `sudo hikyo upgrade` command
 on the server, with encrypted operator-only recovery keys stored locally. For
 this nightly CLI flow, the operator process may hold an encrypted age identity,
 an independent attestation key and root-key escrow in a root-owned directory
-outside the runtime user's writable paths. Unlocking requires an interactive
-operator passphrase. Private material is decrypted only in operator-process
-memory and is never placed in server environment variables, command arguments,
-public evidence directories or the database. The unprivileged server and host
-adapter receive public evidence only. This explicit exception supersedes the
-off-host custody requirement below for this flow; it does not establish an
-off-host disaster-recovery copy or authorize unattended key unlocking.
+outside the runtime user's writable paths. Private material is decrypted only
+in operator-process memory and is never placed in server environment
+variables, command arguments, public evidence directories or the database.
+The unprivileged server and host adapter receive public evidence only. This
+explicit exception supersedes the off-host custody requirement below for this
+flow; it does not establish an off-host disaster-recovery copy.
+
+Amended 2026-09-07, operator decision: the vault is wrapped with a secret
+derived from the installation's root key file instead of an interactive
+passphrase. Everything the vault protects is already reachable by whoever can
+read that root-owned file, so a second human-held secret added a prompt without
+adding a boundary, and it prevented unattended upgrades. The vault stays
+encrypted at rest and unlocks only for a process that can read the root key.
+A vault created under the passphrase design is rewrapped once, asking for the
+passphrase a last time, so the backup identity that decrypts earlier upgrade
+backups is preserved. The attestation key therefore attests root-level
+authority on the host, which is what the earlier passphrase also amounted to.
 
 The CLI automates authenticated release discovery, complete bundle assembly,
 encrypted export, real scratch restore and credential proof, installation,

--- a/docs/handoff/20260906-automatic-nightly-upgrade.md
+++ b/docs/handoff/20260906-automatic-nightly-upgrade.md
@@ -26,8 +26,10 @@ command, rerun that same bootstrap command. Subsequent upgrades use the CLI.
   isolation, atomic executable replacement and exact process/readiness proof.
 - `internal/upgradecustody`: age-encrypted, installation-bound backup identity,
   independent attestation signer and root escrow. Root-only vault defaults to
-  `/etc/hikyo/upgrade-keys/operator.age`; the passphrase is interactive and is
-  never persisted. Runtime receives only the public operator pin and proof.
+  `/etc/hikyo/upgrade-keys/operator.age`, wrapped since 2026-09-07 with a
+  secret derived from the root key file (operator decision, ADR amended);
+  passphrase vaults are rewrapped once. Runtime receives only the public
+  operator pin and proof.
 - `internal/selfupdate` and `internal/upgradeassembly`: reuse complete nightly
   verification and atomic public bundle assembly. Cached assets are rechecked
   against immutable API inventory and current signed trust. Route discovery
@@ -136,3 +138,13 @@ Still open: the server on nightly 23 cannot upgrade until a nightly containing
 this feature is published; then the bootstrap command in the Upgrades docs
 applies. The stale worktree `~/.t3/worktrees/wenv/t3code-4827c9b7` and its
 local `feat/automatic-systemd-upgrade` branch can be removed after merge.
+
+## 2026-09-07 evening: live bootstrap findings
+
+The first real bootstrap of the nightly 23 server surfaced and fixed: deleted
+nightly 26 release (catalog 3, #696), bootstrap umask hiding the public bundle
+and a bare child exit status (#697), operator commands needing hand-fed
+environment (#701), the nightly building silently without a predecessor
+(#699), and the passphrase prompt blocking unattended upgrades (this branch).
+Releases 5 through 23 were deleted by the operator; only 27 and later exist.
+Open: #700 multi-predecessor edges, #694 floor-bench margin.

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -22,8 +22,9 @@ Intermediate releases stay in maintenance. The command reports success only
 after the exact final executable and database state pass health checks.
 
 The first run creates `/etc/hikyo/upgrade.json` for the standard `hikyo.service`
-installation and prompts twice for a recovery-key passphrase. Subsequent runs
-prompt once to unlock the encrypted operator keys. Custom deployments can supply
+installation and the encrypted operator keys, wrapped with a secret derived
+from the root key file, so no prompt is needed then or later and the command
+can run unattended. Custom deployments can supply
 a root-owned config with `--config FILE`; unsupported unit settings fail before
 the service stops. This command currently supports nightly releases on a single
 Linux systemd host with SQLite. Compose, Kubernetes, PostgreSQL and stable
@@ -32,8 +33,7 @@ deployment upgrades use the manual procedure below.
 Older nightlies, including the pre-ledger releases, do not contain this command.
 After a signed release containing it is published, bootstrap the new coordinator
 without replacing the working server first. The bootstrap needs `curl`,
-`python3` and `openssl` on the server, plus an interactive terminal for the
-recovery-key passphrase:
+`python3` and `openssl` on the server:
 
 ```sh
 curl --fail --silent --show-error --proto '=https' https://hikyo.app/upgrade-nightly.sh | sudo sh
@@ -45,9 +45,12 @@ exact recovery-signed bridge; the command finds and verifies it automatically.
 
 Encrypted operator custody lives in `/etc/hikyo/upgrade-keys/operator.age`, owned
 by root and inaccessible to the runtime user. It includes the backup identity,
-independent attestation key and root escrow. The passphrase is never saved.
-This explicitly chosen local custody model does not provide an off-host recovery
-copy. Preserve the encrypted vault and passphrase through your recovery process.
+independent attestation key and root escrow, wrapped with a secret derived from
+`/etc/hikyo/root.key`. Keys created by earlier releases under a passphrase are
+rewrapped the next time `sudo hikyo upgrade` runs from a terminal; it asks for
+the passphrase once more and never again. This explicitly chosen local custody
+model does not provide an off-host recovery copy. Preserve the encrypted vault
+together with the root key through your recovery process.
 After each completed upgrade the command keeps only the encrypted backup taken
 before the current schema under `/var/lib/hikyo-upgrade`; earlier `backup-*`,
 `bundle-*` and `evidence-*` directories there are removed. Copy any backup you

--- a/internal/app/automatic_upgrade.go
+++ b/internal/app/automatic_upgrade.go
@@ -249,41 +249,49 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	return nil
 }
 
+// openAutomaticCustody unlocks the operator vault with a secret derived from
+// the installation's root key, so an upgrade needs no human at a terminal.
+// A vault created under the earlier passphrase design is migrated once: the
+// passphrase is asked for a last time, the same record is rewrapped, and the
+// backup identity that decrypts earlier upgrade backups is preserved.
 func openAutomaticCustody(c hostupgrade.Config, instance string, readPassword func(string) (string, error)) (*upgradecustody.Vault, error) {
-	if readPassword == nil {
-		return nil, errors.New("upgrade custody requires an interactive operator terminal")
-	}
-	_, err := os.Lstat(filepath.Join(c.CustodyDirectory, "operator.age"))
-	create := errors.Is(err, os.ErrNotExist)
-	if err != nil && !create {
-		return nil, err
-	}
-	prompt := "Unlock upgrade recovery keys: "
-	if create {
-		prompt = "Create a passphrase for encrypted upgrade recovery keys: "
-	}
-	password, err := readPassword(prompt)
-	if err != nil {
-		return nil, err
-	}
-	secret := []byte(password)
-	defer clear(secret)
-	if !create {
-		return upgradecustody.Open(c.CustodyDirectory, secret, instance)
-	}
-	confirm, err := readPassword("Confirm upgrade recovery passphrase: ")
-	if err != nil {
-		return nil, err
-	}
-	if confirm != password {
-		return nil, errors.New("upgrade recovery passphrases differ")
-	}
 	root, err := crypto.ReadRootKey(c.RootKeyFile, "")
 	if err != nil {
 		return nil, err
 	}
 	defer crypto.Zero(root)
-	return upgradecustody.Create(c.CustodyDirectory, secret, root, instance)
+	secret, err := upgradecustody.RootKeySecret(root)
+	if err != nil {
+		return nil, err
+	}
+	defer clear(secret)
+	_, err = os.Lstat(filepath.Join(c.CustodyDirectory, "operator.age"))
+	if errors.Is(err, os.ErrNotExist) {
+		return upgradecustody.Create(c.CustodyDirectory, secret, root, instance)
+	}
+	if err != nil {
+		return nil, err
+	}
+	vault, err := upgradecustody.Open(c.CustodyDirectory, secret, instance)
+	if err == nil {
+		return vault, nil
+	}
+	if !errors.Is(err, upgradecustody.ErrUnlock) {
+		return nil, err
+	}
+	if readPassword == nil {
+		return nil, errors.New("upgrade custody still uses a passphrase; run sudo hikyo upgrade once from a terminal to migrate it to root-key wrapping")
+	}
+	password, err := readPassword("Enter the upgrade recovery passphrase once more to migrate the keys to root-key wrapping: ")
+	if err != nil {
+		return nil, err
+	}
+	previous := []byte(password)
+	defer clear(previous)
+	if err := upgradecustody.Rewrap(c.CustodyDirectory, previous, secret, instance); err != nil {
+		return nil, err
+	}
+	return upgradecustody.Open(c.CustodyDirectory, secret, instance)
 }
 
 func prepareAutomaticEvidence(ctx context.Context, host *hostupgrade.Host, database upgrade.Config, route automaticRoute, candidate string, vault *upgradecustody.Vault, journal *automaticJournal, out io.Writer) error {

--- a/internal/crypto/custody.go
+++ b/internal/crypto/custody.go
@@ -1,0 +1,25 @@
+package crypto
+
+import (
+	"crypto/hkdf"
+	"crypto/sha256"
+	"fmt"
+)
+
+const custodyWrapLabel = "hikyo.dev/upgrade-custody/root-key-wrap/v1"
+
+// CustodyWrapKey derives the secret that wraps the operator upgrade vault
+// from the installation's root key. Everything the vault protects is already
+// reachable by whoever can read that key, so a separate human-held secret
+// added a prompt without adding a boundary. Domain-separated from every
+// other root-key derivation by its label.
+func CustodyWrapKey(root []byte) ([]byte, error) {
+	if len(root) != KeySize {
+		return nil, fmt.Errorf("crypto: custody wrap root is %d bytes, want %d", len(root), KeySize)
+	}
+	key, err := hkdf.Key(sha256.New, root, nil, custodyWrapLabel, KeySize)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: derive custody wrap key: %w", err)
+	}
+	return key, nil
+}

--- a/internal/upgradecustody/files_other.go
+++ b/internal/upgradecustody/files_other.go
@@ -10,7 +10,7 @@ import (
 func custodyDirectory(string, bool, int) (*os.File, error) {
 	return nil, errors.New("local operator custody is unsupported on this platform")
 }
-func publish(*os.File, []byte) error {
+func publish(*os.File, []byte, bool) error {
 	return errors.New("local operator custody is unsupported on this platform")
 }
 func read(*os.File, int) ([]byte, error) {

--- a/internal/upgradecustody/files_unix.go
+++ b/internal/upgradecustody/files_unix.go
@@ -57,7 +57,7 @@ func custodyDirectory(path string, create bool, owner int) (*os.File, error) {
 	return current, nil
 }
 
-func publish(dir *os.File, ciphertext []byte) error {
+func publish(dir *os.File, ciphertext []byte, replace bool) error {
 	var nonce [16]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return errors.New("create encrypted custody temporary name")
@@ -79,13 +79,21 @@ func publish(dir *os.File, ciphertext []byte) error {
 	if err := f.Close(); err != nil {
 		return errors.New("close encrypted operator custody")
 	}
-	// linkat is the atomic no-overwrite publication point. A crash may leave an
-	// encrypted temporary file, never a plaintext secret or a partial final file.
-	if err := unix.Linkat(int(dir.Fd()), name, int(dir.Fd()), fileName, 0); err != nil {
-		return errors.New("publish operator custody: existing custody is never replaced")
-	}
-	if err := unix.Unlinkat(int(dir.Fd()), name, 0); err != nil {
-		return errors.New("remove encrypted operator custody temporary link")
+	if replace {
+		// Rewrapping replaces the whole file atomically; the record inside is
+		// the same, so a crash leaves either the old or the new container.
+		if err := unix.Renameat(int(dir.Fd()), name, int(dir.Fd()), fileName); err != nil {
+			return errors.New("replace encrypted operator custody")
+		}
+	} else {
+		// linkat is the atomic no-overwrite publication point. A crash may leave an
+		// encrypted temporary file, never a plaintext secret or a partial final file.
+		if err := unix.Linkat(int(dir.Fd()), name, int(dir.Fd()), fileName, 0); err != nil {
+			return errors.New("publish operator custody: existing custody is never replaced")
+		}
+		if err := unix.Unlinkat(int(dir.Fd()), name, 0); err != nil {
+			return errors.New("remove encrypted operator custody temporary link")
+		}
 	}
 	if err := dir.Sync(); err != nil {
 		return errors.New("sync operator custody directory")

--- a/internal/upgradecustody/vault.go
+++ b/internal/upgradecustody/vault.go
@@ -8,9 +8,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/hkdf"
 	"crypto/rand"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
@@ -21,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
+	hikyocrypto "github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
@@ -141,12 +140,9 @@ func seal(r record, passphrase []byte) ([]byte, error) {
 // read that key, so wrapping with it keeps the file encrypted at rest without
 // asking a human for a second secret, which lets upgrades run unattended.
 func RootKeySecret(rootKey []byte) ([]byte, error) {
-	if len(rootKey) != 32 {
-		return nil, errors.New("custody wrapping requires the 32-byte root key")
-	}
-	secret, err := hkdf.Key(sha256.New, rootKey, nil, "hikyo.dev/upgrade-custody/root-key-wrap/v1", 32)
+	secret, err := hikyocrypto.CustodyWrapKey(rootKey)
 	if err != nil {
-		return nil, errors.New("derive custody wrapping secret")
+		return nil, err
 	}
 	out := make([]byte, hex.EncodedLen(len(secret)))
 	hex.Encode(out, secret)

--- a/internal/upgradecustody/vault.go
+++ b/internal/upgradecustody/vault.go
@@ -8,9 +8,12 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/hkdf"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -99,13 +102,26 @@ func create(directory string, passphrase, rootKey []byte, instance string, owner
 			vault.Close()
 		}
 	}()
+	ciphertext, err := seal(r, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	if err := publish(dir, ciphertext, false); err != nil {
+		return nil, err
+	}
+	ok = true
+	return vault, nil
+}
+
+// seal encrypts one custody record. The container is the same age scrypt
+// profile the backup package uses for exports; age's default work factor
+// applies.
+func seal(r record, passphrase []byte) ([]byte, error) {
 	plain, err := json.Marshal(r)
 	if err != nil {
 		return nil, errors.New("encode operator custody")
 	}
 	defer clear(plain)
-	// The passphrase container is the same age scrypt profile the backup
-	// package uses for exports; age's default work factor applies.
 	var ciphertext bytes.Buffer
 	w, err := backup.Encrypt(&ciphertext, backup.Options{Passphrase: string(passphrase)})
 	if err != nil {
@@ -117,11 +133,54 @@ func create(directory string, passphrase, rootKey []byte, instance string, owner
 	if err = w.Close(); err != nil {
 		return nil, errors.New("finish encrypted operator custody")
 	}
-	if err := publish(dir, ciphertext.Bytes()); err != nil {
-		return nil, err
+	return ciphertext.Bytes(), nil
+}
+
+// RootKeySecret derives the custody wrapping secret from the installation's
+// root key. Everything the vault protects is already reachable by whoever can
+// read that key, so wrapping with it keeps the file encrypted at rest without
+// asking a human for a second secret, which lets upgrades run unattended.
+func RootKeySecret(rootKey []byte) ([]byte, error) {
+	if len(rootKey) != 32 {
+		return nil, errors.New("custody wrapping requires the 32-byte root key")
 	}
-	ok = true
-	return vault, nil
+	secret, err := hkdf.Key(sha256.New, rootKey, nil, "hikyo.dev/upgrade-custody/root-key-wrap/v1", 32)
+	if err != nil {
+		return nil, errors.New("derive custody wrapping secret")
+	}
+	out := make([]byte, hex.EncodedLen(len(secret)))
+	hex.Encode(out, secret)
+	clear(secret)
+	return out, nil
+}
+
+// Rewrap re-encrypts existing custody under a new secret, replacing the file
+// atomically. The record itself, including the backup identity that decrypts
+// earlier upgrade backups, is unchanged. Used once to move a passphrase vault
+// to root-key wrapping.
+func Rewrap(directory string, current, next []byte, instance string) error {
+	return rewrap(directory, current, next, instance, 0)
+}
+
+func rewrap(directory string, current, next []byte, instance string, owner int) error {
+	if len(next) == 0 || len(next) > 1024 {
+		return errors.New("invalid replacement custody secret")
+	}
+	r, err := unseal(directory, current, instance, owner)
+	if err != nil {
+		return err
+	}
+	defer r.clear()
+	ciphertext, err := seal(r, next)
+	if err != nil {
+		return err
+	}
+	dir, err := custodyDirectory(directory, false, owner)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return publish(dir, ciphertext, true)
 }
 
 // Open decrypts custody only after checking directory/file ownership and modes.
@@ -131,30 +190,44 @@ func Open(directory string, passphrase []byte, instance string) (*Vault, error) 
 }
 
 func open(directory string, passphrase []byte, instance string, owner int) (*Vault, error) {
+	r, err := unseal(directory, passphrase, instance, owner)
+	if err != nil {
+		return nil, err
+	}
+	defer r.clear()
+	return decodeRecord(r, instance)
+}
+
+// ErrUnlock reports a custody file that did not open under the given secret.
+var ErrUnlock = errors.New("operator custody unlock failed")
+
+func unseal(directory string, passphrase []byte, instance string, owner int) (record, error) {
 	if len(passphrase) == 0 || len(passphrase) > 1024 {
-		return nil, errors.New("invalid operator passphrase")
+		return record{}, errors.New("invalid operator passphrase")
 	}
 	dir, err := custodyDirectory(directory, false, owner)
 	if err != nil {
-		return nil, err
+		return record{}, err
 	}
 	defer dir.Close()
 	ciphertext, err := read(dir, owner)
 	if err != nil {
-		return nil, err
+		return record{}, err
 	}
 	var plaintext boundedBuffer
 	defer clear(plaintext.buf)
 	if err := backup.ExtractTo(&plaintext, bytes.NewReader(ciphertext), backup.Unlock{Passphrase: string(passphrase)}); err != nil {
-		return nil, errors.New("operator custody unlock failed")
+		return record{}, ErrUnlock
 	}
-	plain := plaintext.buf
 	var r record
-	defer r.clear()
-	if definitions.DecodeStrict(plain, &r) != nil {
-		return nil, errors.New("invalid encrypted operator custody")
+	if definitions.DecodeStrict(plaintext.buf, &r) != nil {
+		return record{}, errors.New("invalid encrypted operator custody")
 	}
-	return decodeRecord(r, instance)
+	if r.Format != vaultFormat || r.Instance != instance {
+		r.clear()
+		return record{}, errors.New("operator custody does not match installation")
+	}
+	return r, nil
 }
 
 func decodeRecord(r record, instance string) (*Vault, error) {

--- a/internal/upgradecustody/vault_test.go
+++ b/internal/upgradecustody/vault_test.go
@@ -5,7 +5,9 @@ package upgradecustody
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
 	"os"
@@ -265,5 +267,67 @@ func TestCustodyRefusesUnsafeAncestorAndOversizedFile(t *testing.T) {
 	}
 	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); err == nil {
 		t.Fatal("oversized ciphertext accepted")
+	}
+}
+
+func TestRootKeySecretIsDerivedAndBoundToKeyLength(t *testing.T) {
+	root := bytes.Repeat([]byte{0x7b}, 32)
+	a, err := RootKeySecret(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := RootKeySecret(bytes.Clone(root))
+	if err != nil || !bytes.Equal(a, b) || len(a) != 64 {
+		t.Fatal("wrapping secret must be deterministic hex of 32 derived bytes", err)
+	}
+	if bytes.Contains(a, root) || bytes.Contains(a, []byte(hex.EncodeToString(root))) {
+		t.Fatal("wrapping secret must not expose the root key")
+	}
+	other, err := RootKeySecret(bytes.Repeat([]byte{0x7c}, 32))
+	if err != nil || bytes.Equal(other, a) {
+		t.Fatal("different root keys must derive different secrets")
+	}
+	if _, err := RootKeySecret(root[:31]); err == nil {
+		t.Fatal("accepted a short root key")
+	}
+}
+
+func TestRewrapMigratesPassphraseCustodyWithoutChangingIdentity(t *testing.T) {
+	dir, v := testVault(t)
+	derived, err := RootKeySecret(v.RootKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rewrap(dir, []byte("wrong passphrase"), derived, instance, os.Geteuid()); !errors.Is(err, ErrUnlock) {
+		t.Fatalf("rewrap with the wrong secret: %v", err)
+	}
+	if after, err := os.ReadFile(filepath.Join(dir, fileName)); err != nil || !bytes.Equal(before, after) {
+		t.Fatal("failed rewrap changed custody")
+	}
+	if err := rewrap(dir, []byte("correct horse battery staple"), derived, instance, os.Geteuid()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := open(dir, []byte("correct horse battery staple"), instance, os.Geteuid()); !errors.Is(err, ErrUnlock) {
+		t.Fatalf("old passphrase still opens rewrapped custody: %v", err)
+	}
+	got, err := open(dir, derived, instance, os.Geteuid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Close()
+	if got.Recipient() != v.Recipient() || got.Pin().KeyID() != v.Pin().KeyID() || !bytes.Equal(got.RootKey(), v.RootKey()) {
+		t.Fatal("rewrap changed the custody record")
+	}
+	files, err := os.ReadDir(dir)
+	if err != nil || len(files) != 1 || files[0].Name() != fileName {
+		t.Fatalf("rewrap left extra files: %v %v", files, err)
+	}
+	info, err := os.Lstat(filepath.Join(dir, fileName))
+	if err != nil || info.Mode().Perm() != 0600 {
+		t.Fatal("rewrapped custody lost its private mode", err)
 	}
 }


### PR DESCRIPTION
## Summary

Re-opens #704 against `main`. #704 was stacked on #701's branch and got merged into that branch instead of `main` when #701 was squash-merged separately, so the change never reached `main`. Same two commits, cherry-picked onto current `main`.

Operator decision (option A): the upgrade vault no longer asks for a passphrase. Its wrapping secret is derived from `/etc/hikyo/root.key` inside the `internal/crypto` chokepoint (`CustodyWrapKey`), so the file stays encrypted at rest and unlocks only for a process that can read the root key. `sudo hikyo upgrade` can run unattended. Existing passphrase vaults migrate once: the next terminal run asks for the passphrase a last time, rewraps the same record atomically, and the backup identity that decrypts earlier upgrade backups is preserved. ADR, upgrade docs and handoff updated.

## Verification

- `internal/upgradecustody`: derivation deterministic and bound to a 32-byte key; rewrap refuses a wrong secret without touching the file; afterwards the old passphrase no longer opens the vault while recipient, pin and root escrow are unchanged.
- `internal/boundary` chokepoint test passes; `go test ./internal/app/ -run TestAutomatic` passes; docs check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)