### PR TITLE
ci(nightly): declare edges from several signed predecessors

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,14 +163,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ALLOW_MISSING_PREDECESSOR: ${{ inputs.allow_missing_predecessor == true }}
+          PREDECESSOR_EDGES: 3
         run: |
           set -o pipefail
-          previous_tag=$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases?per_page=100" | jq '
+          # Up to PREDECESSOR_EDGES signed predecessors, newest first, each
+          # becomes an exact-schema upgrade source of this nightly (#700), so a
+          # route can skip one revoked or missing release without a bridge.
+          # Directory 1 is the newest predecessor; the highest number the oldest.
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases?per_page=100" | jq '
             map(map(select(any(.assets[]; .name == "release-manifest.sigstore.json"))))
-          ' | ./scripts/release/latest-nightly-tag.sh)
-          if [ -n "$previous_tag" ]; then
-            gh release download "$previous_tag" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/previous-nightly"
-            go run ./scripts/release/nightly sources --directory "$RUNNER_TEMP/previous-nightly" --out "$RUNNER_TEMP/nightly-sources.json"
+          ' | ./scripts/release/latest-nightly-tag.sh --limit "$PREDECESSOR_EDGES" >"$RUNNER_TEMP/predecessor-tags"
+          set --
+          index=0
+          while IFS= read -r previous_tag; do
+            [ -n "$previous_tag" ] || continue
+            index=$((index + 1))
+            gh release download "$previous_tag" --repo "$GITHUB_REPOSITORY" --dir "$RUNNER_TEMP/previous-nightly/$index"
+            set -- "$@" --directory "$RUNNER_TEMP/previous-nightly/$index"
+          done <"$RUNNER_TEMP/predecessor-tags"
+          if [ "$index" -gt 0 ]; then
+            printf '%s\n' "$index" >"$RUNNER_TEMP/previous-nightly/count"
+            go run ./scripts/release/nightly sources "$@" --out "$RUNNER_TEMP/nightly-sources.json"
           elif [ "$ALLOW_MISSING_PREDECESSOR" = true ]; then
             echo '::warning::Building without a signed predecessor by explicit request; installations below this release need a recovery bridge.'
             go run ./scripts/release/nightly sources --out "$RUNNER_TEMP/nightly-sources.json"
@@ -292,7 +305,7 @@ jobs:
           go run ./scripts/release/nightly verify --directory nightly-payloads
           if [ -d "$RUNNER_TEMP/previous-nightly" ]; then
             ./scripts/release/assemble-nightly.sh release/trust "$RUNNER_TEMP/nightly-bundle" \
-              "$RUNNER_TEMP/previous-nightly" nightly-payloads
+              "$RUNNER_TEMP"/previous-nightly/[0-9]* nightly-payloads
           elif [ "$ALLOW_MISSING_PREDECESSOR" = true ]; then
             ./scripts/release/assemble-nightly.sh release/trust "$RUNNER_TEMP/nightly-bundle" nightly-payloads
           else
@@ -318,17 +331,25 @@ jobs:
             exit 1
           fi
           if [ -d "$RUNNER_TEMP/previous-nightly" ]; then
-            previous_version=$(jq -r '.version' "$RUNNER_TEMP/previous-nightly/release-manifest.json")
-            mkdir "$RUNNER_TEMP/previous-binary"
-            tar -xzf "$RUNNER_TEMP/previous-nightly/hikyo_${previous_version}_Linux_x86_64.tar.gz" \
-              -C "$RUNNER_TEMP/previous-binary" hikyo
-            export HIKYO_NIGHTLY_PREVIOUS_BINARY="$RUNNER_TEMP/previous-binary/hikyo"
+            # Prove the newest predecessor (the ordinary hop) and the oldest
+            # declared one (the route that skips everything in between).
+            count=$(cat "$RUNNER_TEMP/previous-nightly/count")
             export HIKYO_NIGHTLY_TARGET_BINARY="$GITHUB_WORKSPACE/image-root/amd64/hikyo"
             export HIKYO_NIGHTLY_TRUST="$GITHUB_WORKSPACE/release/trust"
             export HIKYO_NIGHTLY_BUNDLE="$RUNNER_TEMP/nightly-bundle"
-            export HIKYO_NIGHTLY_PREVIOUS_COMPATIBILITY="$RUNNER_TEMP/previous-nightly/upgrade-compatibility.json"
             export HIKYO_NIGHTLY_TARGET_COMPATIBILITY="$GITHUB_WORKSPACE/nightly-payloads/upgrade-compatibility.json"
-            go test ./internal/upgradegate -run '^TestPackagedNightlyReleaseUpgrade$' -count=1 -v
+            for index in $(printf '%s\n' 1 "$count" | sort -un); do
+              previous="$RUNNER_TEMP/previous-nightly/$index"
+              previous_version=$(jq -r '.version' "$previous/release-manifest.json")
+              rm -rf "$RUNNER_TEMP/previous-binary"
+              mkdir "$RUNNER_TEMP/previous-binary"
+              tar -xzf "$previous/hikyo_${previous_version}_Linux_x86_64.tar.gz" \
+                -C "$RUNNER_TEMP/previous-binary" hikyo
+              export HIKYO_NIGHTLY_PREVIOUS_BINARY="$RUNNER_TEMP/previous-binary/hikyo"
+              export HIKYO_NIGHTLY_PREVIOUS_COMPATIBILITY="$previous/upgrade-compatibility.json"
+              printf 'Populated upgrade proof from predecessor %s (%s)\n' "$index" "$previous_version"
+              go test ./internal/upgradegate -run '^TestPackagedNightlyReleaseUpgrade$' -count=1 -v
+            done
           else
             printf 'First signed nightly: no authenticated predecessor exists; fresh boot gates passed.\n'
           fi

--- a/docs/operations/signed-nightlies.md
+++ b/docs/operations/signed-nightlies.md
@@ -82,7 +82,11 @@ bundle and boots/restarts the packaged Linux binary in production mode on both
 engines. After the first signed nightly, it also runs the previous published
 binary, populates an encrypted secret, exports and drills a backup, signs local
 operator evidence, upgrades with the candidate binary, and checks readiness,
-secret readability and restart. A run with no signed predecessor release fails
+secret readability and restart. Each nightly declares up to three signed
+predecessors as exact-schema upgrade sources, newest first, and the populated
+upgrade proof runs from both the newest and the oldest of them, so a route can
+skip one revoked or missing release without a bridge ceremony as long as an
+older declared predecessor still exists. A run with no signed predecessor release fails
 before building: every nightly declares its predecessor as an upgrade source,
 so a missing one means the chain was cut and every installation below the gap
 would be stranded. Revoke a bad nightly through the policy instead of deleting

--- a/scripts/release/latest-nightly-tag.sh
+++ b/scripts/release/latest-nightly-tag.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 set -eu
 
+# Prints the newest published signed-or-unsigned nightly prerelease tags,
+# newest first, one per line. --limit N (default 1) bounds the count.
+limit=1
+if [ "$#" -eq 2 ] && [ "$1" = "--limit" ]; then
+	limit=$2
+	shift 2
+fi
 [ "$#" -eq 0 ] || {
-	printf 'usage: GitHub release pages JSON | %s\n' "$0" >&2
+	printf 'usage: GitHub release pages JSON | %s [--limit N]\n' "$0" >&2
 	exit 2
 }
+case "$limit" in '' | *[!0-9]* | 0) printf 'latest nightly tag: positive --limit required\n' >&2; exit 2 ;; esac
 
-jq -r '
+jq -r --argjson limit "$limit" '
   if type != "array" or any(.[]; type != "array") then
     error("expected an array of GitHub release pages")
   else
@@ -16,10 +24,6 @@ jq -r '
       (.tag_name | type) == "string" and
       (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\."))
     )] |
-    if length == 0 then
-      ""
-    else
-      .[0].tag_name
-    end
+    .[:$limit][].tag_name
   end
 '

--- a/scripts/release/latest-nightly-tag_test.sh
+++ b/scripts/release/latest-nightly-tag_test.sh
@@ -19,6 +19,10 @@ mixed='[[
 ]]'
 [ "$(printf '%s\n' "$mixed" | "$script")" = 'v0.0.1-nightly.20260824.3.gcf4bb563' ]
 
+[ "$(printf '%s\n' "$pages" | "$script" --limit 2)" = 'v0.0.1-nightly.20260824.3.gcf4bb563
+v0.0.1-nightly.20260823.2.g12345678' ]
+[ "$(printf '%s\n' "$pages" | "$script" --limit 5 | wc -l | tr -d ' ')" = 2 ]
+
 expect_reject() {
 	label=$1
 	payload=$2
@@ -30,5 +34,9 @@ expect_reject() {
 
 expect_reject malformed-json '{'
 expect_reject wrong-shape '{}'
+if printf '%s\n' "$pages" | "$script" --limit 0 >/dev/null 2>&1; then
+	printf 'latest nightly tag fixture failed: zero limit accepted\n' >&2
+	exit 1
+fi
 
 printf 'latest nightly tag fixture: published prerelease selection is deterministic\n'

--- a/scripts/release/nightly/main.go
+++ b/scripts/release/nightly/main.go
@@ -33,7 +33,8 @@ func run(ctx context.Context, args []string, output io.Writer) error {
 	}
 	fs := flag.NewFlagSet("nightly", flag.ContinueOnError)
 	trust := fs.String("trust", "release/trust", "independently pinned public trust directory")
-	directory := fs.String("directory", "", "complete signed nightly download")
+	var directories multiFlag
+	fs.Var(&directories, "directory", "complete signed nightly download; sources accepts it repeatedly, newest predecessor first")
 	sources := fs.String("sources", "release/compatibility/sources.json", "reviewed genesis/source edges")
 	out := fs.String("out", "", "new source edges file")
 	if err := fs.Parse(args[1:]); err != nil {
@@ -46,22 +47,28 @@ func run(ctx context.Context, args []string, output io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("signed nightly bootstrap required: %w", err)
 	}
+	directory := ""
+	if len(directories) == 1 {
+		directory = directories[0]
+	} else if len(directories) > 1 && args[0] != "sources" {
+		return errors.New("only sources accepts multiple --directory values")
+	}
 	switch args[0] {
 	case "preflight":
 		_, err = fmt.Fprintf(output, "Authenticated nightly policy %s\n", releaseidentity.Hash(policy))
 		return err
 	case "verify":
-		release, err := upgradebundle.VerifyNightlyDirectory(ctx, *directory, snapshot)
+		release, err := upgradebundle.VerifyNightlyDirectory(ctx, directory, snapshot)
 		if err != nil {
 			return err
 		}
 		return json.NewEncoder(output).Encode(release.Identity())
 	case "legacy-bridges":
-		release, err := upgradebundle.VerifyNightlyDirectory(ctx, *directory, snapshot)
+		release, err := upgradebundle.VerifyNightlyDirectory(ctx, directory, snapshot)
 		if err != nil {
 			return err
 		}
-		raw, err := read(filepath.Join(*directory, releasetrust.CompatibilityArtifact))
+		raw, err := read(filepath.Join(directory, releasetrust.CompatibilityArtifact))
 		if err != nil {
 			return err
 		}
@@ -117,12 +124,20 @@ func run(ctx context.Context, args []string, output io.Writer) error {
 		if document.Schema != "hikyo.dev/upgrade-sources/v1" || len(document.Engines) != 2 {
 			return errors.New("invalid reviewed source inventory")
 		}
-		if *directory != "" {
-			release, err := upgradebundle.VerifyNightlyDirectory(ctx, *directory, snapshot)
+		// Every verified predecessor becomes an exact-schema source edge, so a
+		// route can skip a revoked or missing nightly as long as an older
+		// declared predecessor still exists (#700). Identities must be distinct
+		// and the count bounded; nothing here authorizes a route by itself.
+		if len(directories) > MaxPredecessors {
+			return fmt.Errorf("at most %d predecessor directories", MaxPredecessors)
+		}
+		seen := map[releaseidentity.Identity]bool{}
+		for _, dir := range directories {
+			release, err := upgradebundle.VerifyNightlyDirectory(ctx, dir, snapshot)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", dir, err)
 			}
-			raw, err := read(filepath.Join(*directory, releasetrust.CompatibilityArtifact))
+			raw, err := read(filepath.Join(dir, releasetrust.CompatibilityArtifact))
 			if err != nil {
 				return err
 			}
@@ -130,6 +145,10 @@ func run(ctx context.Context, args []string, output io.Writer) error {
 			if err != nil {
 				return err
 			}
+			if seen[node.Identity()] {
+				return fmt.Errorf("%s: duplicate predecessor %s", dir, node.Identity().Version)
+			}
+			seen[node.Identity()] = true
 			for engine, edges := range document.Engines {
 				manifest, err := node.Manifest(engine)
 				if err != nil {
@@ -247,3 +266,12 @@ func loadTrust(directory string) (releasetrust.Snapshot, []byte, error) {
 	}
 	return snapshot, policyRaw, nil
 }
+
+// MaxPredecessors bounds how many signed predecessors one nightly declares as
+// direct upgrade sources. Each costs a full verified release download in CI.
+const MaxPredecessors = 8
+
+type multiFlag []string
+
+func (m *multiFlag) String() string     { return strings.Join(*m, ",") }
+func (m *multiFlag) Set(v string) error { *m = append(*m, v); return nil }

--- a/scripts/release/nightly/main_test.go
+++ b/scripts/release/nightly/main_test.go
@@ -111,6 +111,46 @@ func TestNightlyPreparationRequiresRecoveryAuthorization(t *testing.T) {
 			t.Fatal("source edge did not bind authenticated previous release")
 		}
 	}
+	// A second, older predecessor adds its own exact edge; repeating one is refused.
+	older := declaration
+	older.Version, older.Sequence = "1.1.0-nightly.0", 1
+	olderMaterial := f.SignNightly(testfixture.JSON(t, older), older.Version, older.Sequence)
+	olderDownload := t.TempDir()
+	for name, reader := range olderMaterial.Artifacts {
+		raw, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		put(filepath.Join(olderDownload, name), raw)
+	}
+	put(filepath.Join(olderDownload, "release-manifest.json"), olderMaterial.Manifest)
+	put(filepath.Join(olderDownload, "release-manifest.sigstore.json"), olderMaterial.Bundle)
+	for name, raw := range map[string][]byte{"nightly-policy.json": olderMaterial.Policy, "sigstore-trusted-root.json": olderMaterial.TrustedRoot} {
+		put(filepath.Join(olderDownload, name), raw)
+	}
+	multi := filepath.Join(t.TempDir(), "multi.json")
+	if err := run(t.Context(), []string{"sources", "--trust", trust, "--directory", download, "--directory", olderDownload, "--sources", sources, "--out", multi}, &output); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = os.ReadFile(multi)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result.Engines = nil
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatal(err)
+	}
+	for engine, edges := range result.Engines {
+		if len(edges) != len(engines[engine])+2 || edges[len(edges)-1].Source.Release.ManifestSHA256 != releaseidentity.Hash(olderMaterial.Manifest) || edges[len(edges)-2].Source.Release.ManifestSHA256 != releaseidentity.Hash(material.Manifest) {
+			t.Fatalf("%s: predecessor edges missing or misordered", engine)
+		}
+	}
+	if err := run(t.Context(), []string{"sources", "--trust", trust, "--directory", download, "--directory", download, "--sources", sources, "--out", filepath.Join(t.TempDir(), "dup.json")}, &output); err == nil || !strings.Contains(err.Error(), "duplicate predecessor") {
+		t.Fatalf("duplicate predecessor accepted: %v", err)
+	}
+	if err := run(t.Context(), []string{"verify", "--trust", trust, "--directory", download, "--directory", olderDownload}, &output); err == nil {
+		t.Fatal("verify accepted several directories")
+	}
 	bridgeDir := filepath.Join(t.TempDir(), "bridges")
 	if err := run(t.Context(), []string{"legacy-bridges", "--trust", trust, "--directory", download, "--out", bridgeDir}, &output); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Closes #700. Each nightly declared only its newest signed predecessor as an upgrade source, so revoking or losing one release severed the route for every installation below it (what deleting nightly 26 did) and needed a recovery-key ceremony to repair.

- `scripts/release/latest-nightly-tag.sh` gains `--limit N` (newest first).
- `scripts/release/nightly sources` accepts repeated `--directory`, verifies each predecessor, refuses duplicates, bounded at eight. `verify` and `legacy-bridges` refuse more than one.
- The nightly workflow resolves up to three predecessors (`PREDECESSOR_EDGES`), declares an exact-schema edge from each, bundles all of them, and runs the populated upgrade proof from both the newest and the oldest, so the skip route is exercised every night.

Cost: three verified release downloads per nightly run instead of one. Runbook updated.

## Verification

- `scripts/release/latest-nightly-tag_test.sh` covers `--limit`, ordering and the zero-limit refusal.
- `scripts/release/nightly` test builds two signed predecessors, checks both edges and their order, refuses a duplicate, and refuses several directories for `verify`.
- actionlint and `scripts/ci/check-nightly-release_test.sh` pass.
- Workflow behaviour only takes effect on main; tonight's run has one predecessor (27) and takes the same path as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)