### PR TITLE
ci: weight the app race split toward the light shard

### DIFF
--- a/scripts/ci/analysis-shards-go/main.go
+++ b/scripts/ci/analysis-shards-go/main.go
@@ -183,7 +183,7 @@ func writeRaceShard(output io.Writer, packages []packageInfo, opts options) erro
 			}
 			names := make([]string, 0, len(tests))
 			for _, test := range tests {
-				if shardFor("race-app", test.name, opts.shardCount) == opts.shard {
+				if appRaceShard(test.name, opts.shardCount) == opts.shard {
 					names = append(names, test.name)
 				}
 			}
@@ -336,6 +336,26 @@ func isGoTargetName(name, prefix string) bool {
 	}
 	first, _ := utf8.DecodeRuneInString(name[len(prefix):])
 	return !unicode.IsLower(first)
+}
+
+// appRaceShard places an internal/app race test. The other heavy suites are
+// pinned to shards 1 and 2 (service, lint, migrate; conformance) and measured
+// at about 14 and 16 minutes under the detector, while shard 0's remaining
+// packages take about 5. The app suite is about 12. An even split put it on
+// top of the heavy shards (measured 9 / 18 / 20 minutes); sending two thirds
+// of it to shard 0 lands near 13 / 16 / 18 with headroom under the 20-minute
+// package limit. Deterministic by name, so assignments stay stable.
+func appRaceShard(name string, shardCount int) int {
+	if shardCount == 1 {
+		return 0
+	}
+	hash := fnv.New32a()
+	_, _ = io.WriteString(hash, "race-app:"+name)
+	bucket := int(hash.Sum32() % uint32(2*shardCount))
+	if bucket < shardCount {
+		return 0
+	}
+	return bucket - shardCount
 }
 
 func shardFor(kind, relativePath string, shardCount int) int {


### PR DESCRIPTION
## Summary

Follow-up to #708. The even app split produced race steps of 9 / 18 / 20 minutes on main (run 34138951865): shards 1 and 2 already hold the pinned heavy suites (about 14 and 16 minutes), shard 0's remaining packages take about 5, and the app suite is about 12. Two thirds of the app tests now go to shard 0 and the rest split between 1 and 2, expected near 13 / 16 / 18. Assignment stays deterministic by test name.

Planner fixture passes; behaviour takes effect on main after merge (trusted planner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)