### PR TITLE
fix(self-config): name the refused key when a runtime value blocks a publish

### DIFF
--- a/docs/handoff/self-config-publish-refusal-detail.md
+++ b/docs/handoff/self-config-publish-refusal-detail.md
@@ -1,0 +1,67 @@
+# Handoff: self-config publish refusals name the key
+
+Status: fix committed on this branch; cross-model review pending (native Codex
+usage limit reached 2026-09-07, fallback model is Marc's call).
+
+## Symptom
+
+Publishing drafts in the instance's own configuration project (the
+`Hikyo ins_...` project) answered `error 400` with no detail. Reported with
+`HIKYO_MCP_ALLOWED_ORIGINS=192.168.0.0/24,95.99.20...` and
+`HIKYO_MCP_ENABLED=true` staged in Production.
+
+## Root cause
+
+Two layers dropped the reason:
+
+1. `config.applyManagedOwnerValues` runs the startup parser over the managed
+   owner values and replaced its key-named failure
+   (`HIKYO_MCP_ALLOWED_ORIGINS: "192.168.0.0/24" is not an exact HTTP(S)
+   origin`) with the fixed string `managed owner configuration is invalid for
+   this node`.
+2. `service.validateSelfConfigCells` wrapped that as a bare `domain.ErrInvalid`
+   with no `SafeDetail`, so `bad_request` went out without `error.detail` and
+   the matrix fell back to its generic sentence.
+
+The staged value itself is wrong: the key takes exact browser origins
+(`https://app.example.com`), not IPs or CIDRs. MCP client IP restriction is
+not a setting today.
+
+## Fix
+
+- `internal/config/managed_owner.go`: `managedOwnerRefusal` returns the
+  parser message verbatim when it opens with a non-secret managed owner key,
+  the key alone for a secret one (`HIKYO_DIRECTORY_PROXY` echoes its raw
+  value in parser errors), and the fixed wording for everything else
+  (parser-only inputs such as `HIKYO_DB`, cross-variable rules).
+- `internal/service/self_config_values.go`: `invalidDetail(...)` so the
+  message rides the wire; every other `runtimeconfig.Prepare` refusal was
+  already key-named and value-free (`mail.invalid`, node overrides,
+  bootstrap sources).
+- No web change: `matrixMutationError` already renders
+  `Publish refused: <detail> Fix the named key in the matrix row editor`.
+
+Tests: `TestSelfConfigInvalidOwnerValuePublishNamesTheKey` (CIDR refused with
+key and value in the detail, corrected origin publishes),
+`TestSelfConfigInvalidSecretOwnerValuePublishNamesKeyOnly`,
+`TestManagedOwnerRefusalNamesKeyAndHidesSecretValues`.
+
+## Disclosure argument
+
+A self-config publish is post-authorization (`OpValuePublish` on the
+instance-config scope) and the values are the caller's own drafts. Managed
+owner keys have no prefix overlap (checked), so prefix matching cannot pick
+the wrong descriptor's secret flag.
+
+## Not in this branch: upgrade from the web UI
+
+Investigated, not built. `docs/adr/signed-upgrade-compatibility.md` (locked
+2026-09-05) already decides the shape: WebUI application is stable-only,
+instance-admin-only with fresh proof, and only creates a bounded request for
+external orchestration; a separately installed root-owned host helper
+(systemd, Compose) or a pull-based Flux controller applies it. The server never
+gets a Docker socket or systemd/Helm authority. The API skeleton exists and is
+deliberately dead (`requestInstanceUpdate` answers 409
+`remote-apply-disabled`; `web/src/routes/Remotes.tsx` apply button gated on
+`apply_supported`, forced false). Enabling it is a Marc decision on which
+adapter to build first.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,9 +145,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
-		"postgres:///hikyo", // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
+		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,9 +145,9 @@ func TestPostgresRemoteVerifiedTLSAllowed(t *testing.T) {
 
 func TestPostgresHostParamCannotBypassTLSCheck(t *testing.T) {
 	for _, dsn := range []string{
-		"postgres:///hikyo?host=remote.example.com",              // libpq-style host param
-		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer",     // empty authority + host param
-		"postgres:///hikyo",                                      // no host at all (implicit PGHOST)
+		"postgres:///hikyo?host=remote.example.com",          // libpq-style host param
+		"postgres://u:p@/hikyo?host=10.0.0.5&sslmode=prefer", // empty authority + host param
+		"postgres:///hikyo", // no host at all (implicit PGHOST)
 		"postgres://u:p@localhost/hikyo?host=remote.example.com", // conflicting hosts
 		"postgres:///hikyo?host=a,b",                             // multi-host
 	} {

--- a/internal/config/managed_owner.go
+++ b/internal/config/managed_owner.go
@@ -145,7 +145,7 @@ func applyManagedOwnerValues(base *Config, values map[string]string, validateNod
 	}
 	parsed, _, err := Load("server", args, func(key string) string { return inputs[key] }, nil)
 	if err != nil {
-		return nil, errors.New("managed owner configuration is invalid for this node")
+		return nil, managedOwnerRefusal(err, keys)
 	}
 	result := *base
 	result.ManagedInputs = maps.Clone(base.ManagedInputs)
@@ -175,4 +175,25 @@ func clonePrefixPolicy(policy map[string][]netip.Prefix) map[string][]netip.Pref
 		result[key] = slices.Clone(values)
 	}
 	return result
+}
+
+// managedOwnerRefusal turns a startup-parser failure into the refusal a
+// self-config publish may quote to its caller. The parser names the offending
+// variable first ("HIKYO_X: reason"), so a message that opens with a managed
+// owner key is about the caller's own draft: it is returned as is for a
+// non-secret key, and as the key alone for a secret one, because the parser
+// echoes the raw value and a secret may not travel back on the wire. Anything
+// else (a parser-only input, a cross-variable rule) keeps the fixed wording.
+func managedOwnerRefusal(err error, keys []string) error {
+	message := err.Error()
+	for _, descriptor := range VariableInventory() {
+		if !slices.Contains(keys, descriptor.Key) || !strings.HasPrefix(message, descriptor.Key) {
+			continue
+		}
+		if descriptor.Secret {
+			return errors.New(descriptor.Key + " is invalid for this node")
+		}
+		return errors.New(message)
+	}
+	return errors.New("managed owner configuration is invalid for this node")
 }

--- a/internal/config/managed_owner_test.go
+++ b/internal/config/managed_owner_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"maps"
 	"net/netip"
 	"reflect"
@@ -128,5 +129,23 @@ func TestBootstrapOwnerInputsAreDeferredAndSeedImportsOriginalValues(t *testing.
 	}
 	if _, err := cfg.ManagedSeed(); err == nil || strings.Contains(err.Error(), "do-not-disclose") {
 		t.Fatalf("new adoption did not validate original inputs safely: %v", err)
+	}
+}
+
+func TestManagedOwnerRefusalNamesKeyAndHidesSecretValues(t *testing.T) {
+	for _, tc := range []struct {
+		name, err, want string
+	}{
+		{"non-secret key echoes the parser message", `HIKYO_MCP_ALLOWED_ORIGINS: "192.168.0.0/24" is not an exact HTTP(S) origin`, `HIKYO_MCP_ALLOWED_ORIGINS: "192.168.0.0/24" is not an exact HTTP(S) origin`},
+		{"secret key names itself only", `HIKYO_DIRECTORY_PROXY: "http://u:hunter2@proxy" must be https`, "HIKYO_DIRECTORY_PROXY is invalid for this node"},
+		{"parser-only input keeps the fixed wording", "HIKYO_DB: invalid postgres DSN", "managed owner configuration is invalid for this node"},
+		{"cross-variable rule keeps the fixed wording", "MCP requires an https HIKYO_EXTERNAL_ORIGIN", "managed owner configuration is invalid for this node"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := managedOwnerRefusal(errors.New(tc.err), ManagedOwnerKeys()).Error()
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/runtimeconfig/catalogue.go
+++ b/internal/runtimeconfig/catalogue.go
@@ -55,7 +55,7 @@ func Catalogue() []Key {
 		"HIKYO_BACKUP_RTO_TARGET":          "Positive backup recovery time objective, for example 30m.",
 		"HIKYO_DIRECTORY_PROXY":            "Optional HTTPS fleet directory proxy. Credentials are treated as secret.",
 		"HIKYO_EXTERNAL_ORIGIN":            "Exact public HTTP(S) origin, without credentials, path, query or fragment.",
-		"HIKYO_MCP_ALLOWED_ORIGINS":        "Optional comma-separated exact browser origins. Requires MCP enabled.",
+		"HIKYO_MCP_ALLOWED_ORIGINS":        "Optional comma-separated exact browser origins such as https://app.example.com, not IPs or CIDRs. Requires MCP enabled.",
 		"HIKYO_MCP_ENABLED":                "Enable the MCP endpoint. Requires an HTTPS public origin outside loopback development.",
 		"HIKYO_REAUTH_WINDOW_SECONDS":      "Disclosure reauthentication window in seconds, from 0 to 86400. Apply still requires its own ceremony.",
 	}

--- a/internal/service/self_config_runtime_test.go
+++ b/internal/service/self_config_runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -600,5 +601,88 @@ func TestSelfConfigExpiredApplyRetryDoesNotRestartPreparation(t *testing.T) {
 				t.Fatalf("expired retry changed target: %+v", retried)
 			}
 		})
+	}
+}
+
+// A self-config publish that the runtime parser refuses must say WHICH key it
+// refused, in the caller-safe detail the matrix quotes verbatim. A bare
+// ErrInvalid renders as "error 400" with nothing to fix (the report that
+// motivated this: CIDRs typed into HIKYO_MCP_ALLOWED_ORIGINS).
+func TestSelfConfigInvalidOwnerValuePublishNamesTheKey(t *testing.T) {
+	t.Parallel()
+	s, local := selfConfigFixture(t)
+	if err := s.LoadRuntime(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	status, err := s.Status(t.Context(), local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := domain.Scope{Org: domain.OrgID(status.Binding.OrgID), Project: domain.ProjectID(status.Binding.ProjectID), Env: domain.EnvID(status.Binding.EnvironmentID)}
+	values := &Values{DB: s.DB, Keyring: s.Keyring, Auth: s.Auth}
+	revisions := &Revisions{DB: s.DB, Keyring: s.Keyring, Auth: s.Auth}
+	enabled, err := values.Set(t.Context(), local, scope, "HIKYO_MCP_ENABLED", "true", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origins, err := values.Set(t.Context(), local, scope, "HIKYO_MCP_ALLOWED_ORIGINS", "192.168.0.0/24,95.99.20.1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = revisions.PublishPlanned(t.Context(), local, scope, PublishRequest{VersionIDs: []string{enabled.VersionID, origins.VersionID}})
+	if !errors.Is(err, domain.ErrInvalid) {
+		t.Fatalf("CIDR origins published: %v", err)
+	}
+	carrier, ok := err.(interface{ SafeDetail() string })
+	if !ok {
+		t.Fatalf("refusal carries no caller-safe detail: %v", err)
+	}
+	if detail := carrier.SafeDetail(); !strings.Contains(detail, "HIKYO_MCP_ALLOWED_ORIGINS") || !strings.Contains(detail, "192.168.0.0/24") {
+		t.Fatalf("detail does not name the key and the offending value: %q", detail)
+	}
+
+	// The corrected value publishes: the fixture's loopback origin admits MCP.
+	origins, err = values.Set(t.Context(), local, scope, "HIKYO_MCP_ALLOWED_ORIGINS", "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := revisions.PublishPlanned(t.Context(), local, scope, PublishRequest{VersionIDs: []string{enabled.VersionID, origins.VersionID}}); err != nil {
+		t.Fatalf("valid origins refused: %v", err)
+	}
+}
+
+// A secret owner key never echoes its value: the refusal names the key only.
+func TestSelfConfigInvalidSecretOwnerValuePublishNamesKeyOnly(t *testing.T) {
+	t.Parallel()
+	s, local := selfConfigFixture(t)
+	if err := s.LoadRuntime(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	status, err := s.Status(t.Context(), local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := domain.Scope{Org: domain.OrgID(status.Binding.OrgID), Project: domain.ProjectID(status.Binding.ProjectID), Env: domain.EnvID(status.Binding.EnvironmentID)}
+	values := &Values{DB: s.DB, Keyring: s.Keyring, Auth: s.Auth}
+	revisions := &Revisions{DB: s.DB, Keyring: s.Keyring, Auth: s.Auth}
+	const secret = "http://user:hunter2@proxy.internal"
+	proxy, err := values.Set(t.Context(), local, scope, "HIKYO_DIRECTORY_PROXY", secret, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = revisions.PublishPlanned(t.Context(), local, scope, PublishRequest{VersionIDs: []string{proxy.VersionID}})
+	if !errors.Is(err, domain.ErrInvalid) {
+		t.Fatalf("plaintext directory proxy published: %v", err)
+	}
+	carrier, ok := err.(interface{ SafeDetail() string })
+	if !ok {
+		t.Fatalf("refusal carries no caller-safe detail: %v", err)
+	}
+	detail := carrier.SafeDetail()
+	if !strings.Contains(detail, "HIKYO_DIRECTORY_PROXY") {
+		t.Fatalf("detail does not name the key: %q", detail)
+	}
+	if strings.Contains(detail, "hunter2") || strings.Contains(err.Error(), "hunter2") {
+		t.Fatalf("secret value echoed: %q / %v", detail, err)
 	}
 }

--- a/internal/service/self_config_values.go
+++ b/internal/service/self_config_values.go
@@ -1,10 +1,7 @@
 package service
 
 import (
-	"fmt"
-
 	"github.com/Hikyo-Org/hikyo/internal/authz"
-	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/runtimeconfig"
 	"github.com/Hikyo-Org/hikyo/internal/schema"
 	"github.com/Hikyo-Org/hikyo/internal/store"
@@ -30,8 +27,12 @@ func validateSelfConfigCells(p authz.Proof, cells []resolvedCell) error {
 			values[cell.key.Name] = cell.value
 		}
 	}
+	// Every Prepare refusal names the key it is about and never a secret value
+	// (config.managedOwnerRefusal, mail.invalid), so it travels as the
+	// caller-safe detail: a self-config publish is post-authorization and the
+	// values are the caller's own drafts, and a bare 400 leaves nothing to fix.
 	if _, err := runtimeconfig.Prepare(values); err != nil {
-		return fmt.Errorf("%w: %s", domain.ErrInvalid, err)
+		return invalidDetail("%s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Symptom

Publishing drafts in the instance's own configuration project answered `The server could not publish the selected drafts (error 400)` with nothing to fix. Reported with `HIKYO_MCP_ALLOWED_ORIGINS=192.168.0.0/24,...` staged in Production.

## Root cause

`config.applyManagedOwnerValues` replaced the startup parser's key-named failure with fixed wording, and `service.validateSelfConfigCells` wrapped it as a bare `domain.ErrInvalid` with no `SafeDetail`, so `bad_request` went out without `error.detail`.

## Fix

- `managedOwnerRefusal` returns the parser message verbatim for a non-secret managed owner key, the key alone for a secret one (`HIKYO_DIRECTORY_PROXY` echoes its raw value), and the fixed wording for parser-only inputs and cross-variable rules.
- `validateSelfConfigCells` returns `invalidDetail(...)` so the message rides the wire; every other `runtimeconfig.Prepare` refusal was already key-named and value-free.
- No web change: the matrix already quotes `error.detail` verbatim.
- Catalogue description for `HIKYO_MCP_ALLOWED_ORIGINS` now shows an example and says IPs/CIDRs are not accepted.

Handoff: `docs/handoff/self-config-publish-refusal-detail.md`.

## Review status

Cross-model review skipped by owner instruction (Codex and OpenCode at their limits during the 1.0 run on 2026-09-07). Recorded in docs/reports/1.0/release-run-2026-09-07.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)