### PR TITLE
feat(cli): add verbosity levels and clean upgrade artifacts

### DIFF
--- a/cmd/hikyo/main.go
+++ b/cmd/hikyo/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/cli"
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/console"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
 	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
 	"github.com/Hikyo-Org/hikyo/internal/importer"
@@ -64,11 +65,12 @@ func run() int {
 	if handled, code := importer.RunInternalSubprocess(os.Args[1:], os.Stdout); handled {
 		return code
 	}
-	if len(os.Args) < 2 {
+	arguments, verbosity := cli.ParseVerbosity(os.Args[1:])
+	if len(arguments) == 0 {
 		usage(os.Stderr)
 		return 2
 	}
-	invocation, handled, code := runHelp(os.Args[1:], os.Stdout, os.Stderr)
+	invocation, handled, code := runHelp(arguments, os.Stdout, os.Stderr)
 	if handled {
 		return code
 	}
@@ -90,6 +92,11 @@ func run() int {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	ctx = diagnostics.With(ctx, verbosity, os.Stderr)
+	if slices.Contains([]string{"server", "operator", "config-rollout", "updater", "migrate", "upgrade", "admin", "backup", "escrow", "restore"}, cmd) && !cli.HelpRequested(args) {
+		diagnostics.Printf(ctx, 1, "starting %s", cmd)
+		defer diagnostics.Time(ctx, cmd)()
+	}
 	if shouldCheckForUpdate(cmd) {
 		terminalSession, terminalError := disclose.OpenTerminalSession()
 		updated := cli.NotifyUpdate(ctx, updateIO(terminalSession, terminalError, builtChannel))
@@ -273,14 +280,17 @@ func shouldCheckForUpdate(command string) bool {
 }
 
 func runServer(ctx context.Context, args []string) int {
+	loaded := diagnostics.Time(ctx, "load bootstrap configuration")
 	cfg, warnings, err := config.LoadBootstrap("server", args, os.Getenv, os.Environ())
 	if errors.Is(err, flag.ErrHelp) {
 		return 0
 	}
+	loaded()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "hikyo server:", err)
 		return 1
 	}
+	diagnostics.Printf(ctx, 1, "Bootstrap configuration loaded")
 	log := app.Logger(cfg.Dev)
 	for _, w := range warnings {
 		log.Warn(w)
@@ -419,7 +429,9 @@ func runOperatorThroughDeployment(ctx context.Context, name string, args []strin
 		fmt.Fprintf(os.Stderr, "hikyo %s: %v\n", name, err)
 		return 2, true
 	}
-	err = host.RunOperator(ctx, append([]string{name}, args...), os.Stdin, os.Stdout, os.Stderr)
+	diagnostics.Printf(ctx, 1, "running operator command through host deployment")
+	operatorArgs := cli.WithVerbosityArguments(append([]string{name}, args...), diagnostics.Level(ctx))
+	err = host.RunOperator(ctx, operatorArgs, os.Stdin, os.Stdout, os.Stderr)
 	var exit *exec.ExitError
 	if errors.As(err, &exit) {
 		return exit.ExitCode(), true
@@ -440,14 +452,17 @@ func workdir() string {
 }
 
 func runMigrate(ctx context.Context, args []string) int {
+	loaded := diagnostics.Time(ctx, "load bootstrap configuration")
 	cfg, warnings, err := config.Load("migrate", args, os.Getenv, os.Environ())
 	if errors.Is(err, flag.ErrHelp) {
 		return 0
 	}
+	loaded()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "hikyo migrate:", err)
 		return 1
 	}
+	diagnostics.Printf(ctx, 1, "Bootstrap configuration loaded")
 	log := app.Logger(cfg.Dev)
 	for _, w := range warnings {
 		log.Warn(w)
@@ -479,7 +494,8 @@ func runUpgradeOperator(ctx context.Context, args []string) int {
 				fmt.Fprintln(os.Stderr, "hikyo upgrade:", err)
 				return 1
 			}
-			command := exec.CommandContext(ctx, handoff.Executable, handoff.Arguments...)
+			diagnostics.Printf(ctx, 1, "handing upgrade to verified candidate")
+			command := exec.CommandContext(ctx, handoff.Executable, cli.WithVerbosityArguments(handoff.Arguments, diagnostics.Level(ctx))...)
 			command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
 			command.Env = []string{"PATH=/usr/bin:/bin", "LANG=C.UTF-8"}
 			err = command.Run()
@@ -508,7 +524,8 @@ func runUpgradeOperator(ctx context.Context, args []string) int {
 
 func usage(w io.Writer) {
 	fmt.Fprint(w, usageText)
-	fmt.Fprintf(w, "client verbs (hikyo help client prints the full reference):\n%s\n", wrapWords(cli.Verbs, 2, 78))
+	fmt.Fprint(w, cli.VerbosityHelp())
+	fmt.Fprintf(w, "\nclient verbs (hikyo help client prints the full reference):\n%s\n", wrapWords(cli.Verbs, 2, 78))
 }
 
 // usageText is the multicall help. cmd/hikyo's TestUsage keeps it aligned

--- a/cmd/hikyo/verbosity_test.go
+++ b/cmd/hikyo/verbosity_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGlobalVerbosityKeepsVersionAndHelpContracts(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		code   int
+		stdout string
+		stderr string
+	}{
+		{"machine version", []string{"-vvv", "--version"}, 0, version + "\n", ""},
+		{"overview", []string{"-v", "--verbose", "--help"}, 0, "global diagnostics (stderr only):", ""},
+		{"missing command", []string{"-vvv"}, 2, "", ""},
+		{"server help", []string{"-vvv", "server", "--help"}, 0, "", "Usage of server:"},
+		{"migrate help", []string{"-vvv", "migrate", "--help"}, 0, "", "Usage of migrate:"},
+		{"backup help", []string{"-vvv", "backup", "export", "--help"}, 0, "backup", ""},
+		{"import help", []string{"-vvv", "import", "--help"}, 0, "import", ""},
+		{"upgrade help", []string{"upgrade", "-vvv", "--help"}, 0, "upgrade", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stdout.Close()
+			stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stderr.Close()
+			oldArgs, oldOut, oldErr := os.Args, os.Stdout, os.Stderr
+			t.Cleanup(func() { os.Args, os.Stdout, os.Stderr = oldArgs, oldOut, oldErr })
+			os.Args, os.Stdout, os.Stderr = append([]string{"hikyo"}, tc.args...), stdout, stderr
+			if code := run(); code != tc.code {
+				t.Fatalf("exit=%d want=%d", code, tc.code)
+			}
+			out, err := os.ReadFile(stdout.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			errors, err := os.ReadFile(stderr.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.name == "machine version" && string(out) != tc.stdout {
+				t.Fatalf("machine output=%q", out)
+			}
+			if !strings.Contains(string(out), tc.stdout) {
+				t.Fatalf("stdout=%q", out)
+			}
+			if tc.code == 0 {
+				if tc.stderr == "" && len(errors) != 0 {
+					t.Fatalf("unexpected diagnostic output=%q", errors)
+				}
+				if !strings.Contains(string(errors), tc.stderr) {
+					t.Fatalf("missing help on stderr=%q", errors)
+				}
+				if strings.Contains(string(errors), "hikyo:") || strings.Contains(string(errors), "elapsed=") {
+					t.Fatalf("help emitted diagnostics=%q", errors)
+				}
+			}
+			if tc.code != 0 && !strings.Contains(string(errors), "global diagnostics") {
+				t.Fatalf("missing usage=%q", errors)
+			}
+		})
+	}
+}

--- a/docs/handoff/20260908-cli-verbosity-upgrade-cleanup.md
+++ b/docs/handoff/20260908-cli-verbosity-upgrade-cleanup.md
@@ -1,0 +1,124 @@
+# CLI verbosity and upgrade disk cleanup
+
+## Continuation
+
+Requested in T3 thread `52d45fbe-e5ba-4f2e-a1b3-cd4018719013`, continued in
+`/Users/developwent/.t3/worktrees/wenv/t3code-345b2035` on
+`t3code/verbose-cli-upgrade-cleanup`. The previous thread left signed commit
+`274f9c1b` on `t3code/show-hikyo-upgrade-progress`; this branch fast-forwarded to
+that exact commit before extending it.
+
+The operator supplied evidence of a 7.8 GiB root filesystem with 467 MiB free:
+4.0 GiB in `hikyo-upgrader/downloads`, 1.5 GiB in public `hikyo-upgrade`, and
+230 MiB of staged candidates. Existing code retained downloads and successive
+route bundles, and copied complete cache hits into scratch for re-verification.
+The inherited fix only pruned downloads after success and missed candidate
+cleanup on an already-installed result.
+
+## Behavior
+
+Global `-v`, `-vv`, `-vvv` and repeated `--verbose` provide phases, artifact/HTTP
+metadata, and timings. Put verbosity before other options: the conservative
+parser preserves possible flag values, including a literal `-v`. Everything
+after `--` is untouched. Diagnostics use stderr and do not print raw arguments,
+environments, request paths, query strings, credentials, headers or bodies.
+Levels propagate through the verified coordinator handoff and host operator
+subprocess. Help and machine version output remain quiet.
+
+Before downloads, under the operator lock, the coordinator prunes obsolete
+private cache work. Completed journals permit pruning obsolete public artifacts
+and candidates. Incomplete journals retain every verified release and executable
+needed by the route. Ordinary failures clean disposable cache work too, retaining
+public recovery material. Invalid trust state fails closed before deletion.
+The latest observed release and any explicitly retained target survive cache
+pruning, along with unchanged trust floors and the lock inode.
+
+Cache hits verify existing files in place. Automatic-only transient bundle mode
+removes superseded private bundles before assembling their replacement; manual
+staging keeps its published paths. Generated names are constrained, and cache
+removal uses an opened filesystem root. Unpublished public bundles are cleaned
+if preparation fails before journal/runtime ownership. Successful/no-op runs
+prune candidates. A public cleanup failure after durable completion reports an
+error without fencing the healthy service; the next invocation retries cleanup.
+
+Directory names and ownership remain compatible. The Upgrades docs explain
+runtime data, installation custody, public evidence, candidates and root-only
+coordinator state. Full signed inventories still require temporary disk space;
+this is not a change to the signed artifact format or a platform-only download
+optimization. No live host was inspected or modified by this continuation.
+
+## Validation
+
+Targeted signed nightly, migration route, cleanup, and CLI regressions cover
+cache tampering, trust-state retention, busy locks, symlink confinement,
+interrupted route retention, no-download cache retry, transient/manual bundle
+lifetimes, stderr/JSON separation, passthrough arguments, help and handoff flags.
+The isolated root Linux adapter suite also exercises candidate pruning.
+
+Final command results and review disposition are recorded at completion below.
+
+Completed local checks:
+
+- Full Go suites: `internal/app`, `internal/selfupdate`, `internal/hostupgrade`,
+  `internal/diagnostics`, `internal/cli`, `cmd/hikyo` passed. App suite took 134 s.
+- `go vet` for those six packages passed; `internal/lint` suite passed.
+- Targeted race tests for cache pruning, route assembly, completed-service
+  cleanup failures and diagnostic isolation passed.
+- `scripts/ci/test-host-upgrade.sh` passed in its isolated root Linux container.
+  Its real-systemd-only case is intentionally skipped outside the separate
+  real-systemd container; no service lifecycle implementation changed here.
+- Docs `check` reported zero errors/warnings, and docs build produced 45 pages.
+- Independent review of the final parent cleanup changes returned CLEAN.
+
+Local check logs use `/tmp/hikyo-verbose-*.log`. This is source-worktree evidence,
+not a published nightly or a live host cleanup. No push, merge or deployment has
+been performed by this continuation.
+
+Native Codex review completed in three rounds. R1 found four inherited issues:
+late cleanup, missed no-op candidates, broad/incomplete cache-name matching, and
+broad candidate-name matching. All were fixed. R2 found a new public-bundle leak
+when journal publication fails. The final fix checks the persisted journal before
+removing a newly staged bundle, distinguishing pre-rename failure from a
+post-rename sync failure and preserving data if the journal cannot be read.
+Four filesystem-state regressions cover that boundary. R3 returned `CLEAN`.
+Review artifacts: `/tmp/hikyo-verbose-inherited-review-r{1,2,3}.md`.
+
+After the final fix, all automatic-upgrade tests and main verbosity/help tests
+passed again (app 46 s, command 2 s). Candidate-name preservation was also
+rechecked in the isolated root Linux suite. Final `git diff --check` passed.
+The new continuation edits remain uncommitted on top of `274f9c1b`.
+
+## Follow-up: verbosity across command families
+
+The user accepted extending the same diagnostics beyond the upgrader. Added
+phase/detail/timing instrumentation to ordinary backup export, restore,
+reconciliation and drills; signed upgrade exports/drills; source import,
+wizard/replay and artifact/dotenv value application; schema migration; and
+server bootstrap, datastore/keyring, managed configuration, providers and
+listeners. No new verbosity flags or alternate level meanings were introduced.
+
+Snapshot export and encryption are reported as one streaming operation. Source
+import completion states that review artifacts were created and values have not
+been applied. Migration emits its applying-SQL phase only when SQL is actually
+applied. Server socket preparation and serving readiness are distinct;
+maintenance readiness identifies the restricted operational listener.
+
+New details are static phase names and explicit counts/validated enums. They
+exclude root and backup keys, recipients, values, secret names, DSNs, paths and
+unfiltered errors. Existing command-result and error formats remain unchanged.
+The CLI reference documents levels and examples; backup docs link to it.
+
+Focused tests exercise real backup/restore and signed drill fixtures, JSON
+export and import, levels 0 through 3, secret sentinels, truncated archives,
+parse/apply failures, server readiness/listener failure, migration refusal and
+no-op migration. Expanded main-entrypoint tests keep server, migrate, backup
+and import help free of diagnostics. Startup/migration independent review was
+CLEAN; parent reviewed backup/import changes and their combined contracts.
+
+Follow-up final validation: full `internal/app`, `internal/upgradegate`,
+`internal/cli`, `internal/diagnostics`, `cmd/hikyo` and `internal/lint` suites
+passed. `go vet` on the five implementation packages passed. Targeted race tests
+for startup/migration, backup/restore/drills, source import and value import
+passed (app 152 s, CLI 18 s). Docs check reported zero errors/warnings; docs build
+produced 45 pages. Final whitespace check passed. All continuation work remains
+local and uncommitted; no push, merge, deployment or live-host change.

--- a/docs/site/src/content/docs/docs/backup-and-restore.mdx
+++ b/docs/site/src/content/docs/docs/backup-and-restore.mdx
@@ -7,6 +7,11 @@ editUrl: https://github.com/Hikyo-Org/Hikyo/edit/main/docs/site/src/content/docs
 Hikyo backup and restore are host-only commands. They operate on the configured
 datastore and have no network API.
 
+Add global `-v`, `-vv` or `-vvv` before the command to see phases, operational
+details or timings, for example `hikyo -vvv backup export`. Archive contents,
+unlock material and root keys are excluded from these diagnostics. See
+[CLI verbosity](/docs/cli-reference/#verbosity) for the shared output contract.
+
 ## What an archive protects
 
 One age-encrypted archive contains a consistent datastore snapshot and its

--- a/docs/site/src/content/docs/docs/cli-reference.mdx
+++ b/docs/site/src/content/docs/docs/cli-reference.mdx
@@ -27,6 +27,45 @@ hikyo server --help              every server flag, from the flag parser
 Anything after `--` belongs to the command `hikyo run` executes and is never
 read as a request for help.
 
+## Verbosity
+
+Use the same repeatable global options with any command. Place them before the
+command or its other options:
+
+| Option | Additional diagnostics |
+| --- | --- |
+| `-v` or `--verbose` | Progress through operational phases. |
+| `-vv` | Counts, artifact sizes, database mode and HTTP request status. |
+| `-vvv` | Timings for operations and individual phases. |
+
+```sh
+sudo hikyo -vvv upgrade
+hikyo -v backup export --out /var/backups/hikyo
+hikyo -vv migrate
+hikyo -v server
+hikyo -vv values import --env staging --from-dotenv .env -o json
+```
+
+Repeat `--verbose` to increase the level: `--verbose --verbose` equals `-vv`.
+Diagnostics go to stderr; command results, including JSON, stay on stdout.
+Help and machine-version output retain their normal output contracts. Tokens
+after `--` remain arguments to the child command.
+
+Backup and restore report archive authentication, snapshot export with encryption,
+validation, data publication and recovery drills. Migration reports signed
+release checks and actual schema writes; an already-applied schema does not
+claim another write. Server startup reports configuration, datastore and keyring
+loading, service/provider preparation and listener setup. Serving readiness is
+reported separately after serving begins; maintenance mode identifies its
+restricted listener.
+
+Source imports report parsing, planning and review-artifact creation. Those
+artifacts are preparation; `values import` reports the separate application step.
+Detailed diagnostics use counts and explicitly selected operational metadata.
+They do not include secret names or values, key material, database connection
+strings, file paths, request bodies or credential-bearing URLs. Existing command
+results and errors keep their existing formats.
+
 ## Server and host operator
 
 | Command family | Purpose |

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -64,6 +64,56 @@ or schema-applied targets can continue. An uncertain or failed schema change
 leaves the service stopped and requires explicit operator recovery; the command
 never automatically rolls back the database or starts an older binary.
 
+## Progress and disk use
+
+Use repeatable global verbosity options before the command or its other options:
+
+```sh
+sudo hikyo -v upgrade       # phases, selected releases, route and cleanup
+sudo hikyo -vv upgrade      # also artifact sizes, cache removals and HTTP status
+sudo hikyo -vvv upgrade     # also operation and download timings
+```
+
+`--verbose --verbose` is equivalent to `-vv`. Verbosity follows the verified
+coordinator handoff. Diagnostic lines go to stderr, keeping stdout usable for
+command results. Request headers, bodies, URL credentials and query strings are
+not printed. Arguments after `--` belong to the child command and remain untouched.
+
+The directories have distinct ownership and lifetimes:
+
+| Default path under `/var/lib` | Contents and access |
+| --- | --- |
+| `hikyo` | Live application data, owned by the runtime user. |
+| `hikyo-installation` | Persistent installation custody, owned by the runtime user. |
+| `hikyo-upgrade` | Root-staged verification bundles readable by the runtime, private backup exports and recovery proof. |
+| `hikyo-upgrade-candidates` | Root-owned executables staged for installation. |
+| `hikyo-upgrader` | Root-only download cache, operation journal and generated runtime configuration. |
+
+The similarly named `hikyo-upgrade` and `hikyo-upgrader` separate service-readable
+verification evidence from privileged coordinator state. They are not duplicate
+application data directories.
+
+The coordinator prunes obsolete downloads before fetching a release, and again
+on completion, including an already-installed result. It retains the latest
+observed release for handoff and retry, plus an explicitly pinned target when
+needed. Installed executables and the service's public verification bundle are
+independent copies. Superseded private route bundles are discarded during
+preparation; cache hits reverify existing bytes without writing a second full
+release copy. Anti-rollback trust state is never pruned.
+
+After an interruption, exact downloaded releases and candidate executables stay
+available for the unfinished route. Disposable private bundles and abandoned
+assembly files are removed and rebuilt as needed. The journal, public recovery
+evidence, retained encrypted backup and operator keys remain protected. Cleanup
+errors are reported; cleanup after a completed upgrade does not stop the healthy
+service. A later invocation retries cleanup.
+
+Full signed inventories still include artifacts for every published platform.
+A long route therefore needs temporary space for its releases, assembled bundle,
+candidate executables and backup drill. `-v` reports available space after initial
+cleanup; `-vv` shows individual artifact sizes. Do not delete these directories
+manually during an unfinished upgrade.
+
 ## Release channels
 
 `stable` follows signed production releases. `nightly` follows signed GitHub

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/admission"
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/remotefetch"
 	"github.com/Hikyo-Org/hikyo/internal/runtimeconfig"
 	"github.com/Hikyo-Org/hikyo/internal/server"
@@ -55,10 +56,14 @@ func storeConfig(cfg *config.Config) store.Config {
 // keyring (DDL only). Signed public evidence authorizes schema application;
 // maintenance remains until the exact candidate boot proves hierarchy health.
 func RunMigrate(ctx context.Context, cfg *config.Config, log *slog.Logger) error {
+	diagnostics.Printf(ctx, 1, "Preparing explicit schema migration")
+	defer diagnostics.Time(ctx, "explicit schema migration")()
 	result, err := databaseGate(ctx, cfg, nil, upgradegate.Migrate)
 	if err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 1, "Schema migration finished")
+	diagnostics.Printf(ctx, 2, "Migration result: maintenance=%t schema_only=%t", result.State.Maintenance, result.SchemaOnly)
 	log.Info("verified schema application complete", "phase", result.State.Pending.Phase, "maintenance", result.State.Maintenance)
 	return nil
 }
@@ -235,10 +240,12 @@ func (g *bootGuard) disarm() {
 // resource guard so every error after datastore acquisition closes it exactly
 // once.
 func openKeyed(ctx context.Context, cfg *config.Config, log *slog.Logger, sc store.Config, resources bootResources, guard *bootGuard) (*store.DB, *crypto.Keyring, error) {
+	diagnostics.Printf(ctx, 2, "Hardening process before key access")
 	if err := crypto.HardenProcess(); err != nil {
 		return nil, nil, err
 	}
 
+	diagnostics.Printf(ctx, 1, "Loading root key from configured custody")
 	root, err := resolveRootKey(cfg, log)
 	if err != nil {
 		return nil, nil, err
@@ -248,16 +255,24 @@ func openKeyed(ctx context.Context, cfg *config.Config, log *slog.Logger, sc sto
 		crypto.Zero(root)
 		return nil, nil, err
 	}
+	diagnostics.Printf(ctx, 1, "Opening admitted datastore")
+	opened := diagnostics.Time(ctx, "open admitted datastore")
 	db, err := resources.openDatabase(ctx, sc, admitted.Admission)
+	opened()
 	if err != nil {
 		crypto.Zero(root)
 		return nil, nil, err
 	}
 	guard.add(func() error { return resources.closeDatabase(db) })
 	logDatastorePoolSizes(log, db)
+	limits := db.ConnectionPoolLimits()
+	diagnostics.Printf(ctx, 2, "Datastore pools: primary=%d read_only=%d", limits.Primary, limits.ReadOnly)
 
 	// LoadKeyring consumes root: it is zeroed before this returns.
+	diagnostics.Printf(ctx, 1, "Loading encryption keyring")
+	keyed := diagnostics.Time(ctx, "load encryption keyring")
 	kr, err := crypto.LoadKeyring(ctx, &keyring.Store{DB: db}, root)
+	keyed()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -296,6 +311,8 @@ func Boot(ctx context.Context, cfg *config.Config, log *slog.Logger) (*Server, e
 }
 
 func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources bootResources) (*Server, error) {
+	diagnostics.Printf(ctx, 1, "Resolving server upgrade selection")
+	defer diagnostics.Time(ctx, "server boot")()
 	var selectionErr error
 	cfg, selectionErr = resolveSelectedUpgrade(ctx, cfg, deploymentSelectionDirectory)
 	if selectionErr != nil {
@@ -315,6 +332,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	db, kr, err := openKeyed(ctx, cfg, log, sc, resources, guard)
 	if err != nil {
 		if errors.Is(err, upgradegate.ErrRestoreRequired) || errors.Is(err, upgradegate.ErrNextBinary) {
+			diagnostics.Printf(ctx, 1, "Preparing maintenance-only server for upgrade recovery")
 			return bootMaintenance(cfg, log, resources)
 		}
 		return nil, fmt.Errorf("boot: refusing to serve: %w", err)
@@ -329,7 +347,10 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	if configureDeployment == nil {
 		configureDeployment = configureBootstrapDeployment
 	}
+	diagnostics.Printf(ctx, 1, "Resolving managed deployment configuration")
+	configured := diagnostics.Time(ctx, "resolve deployment configuration")
 	selfConfig.Deployment, err = configureDeployment(ctx, cfg, db, kr)
+	configured()
 	if err != nil {
 		return nil, fmt.Errorf("boot: deployment enrollment unavailable")
 	}
@@ -353,6 +374,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		return nil, fmt.Errorf("boot: managed configuration is invalid: %w", err)
 	}
 	cfg = effective
+	diagnostics.Printf(ctx, 2, "Validating HTTP API contract")
 	if err := resources.warmOpenAPI(); err != nil {
 		return nil, fmt.Errorf("boot: refusing to serve: OpenAPI contract: %w", err)
 	}
@@ -366,11 +388,15 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	if err != nil {
 		return nil, err
 	}
+	diagnostics.Printf(ctx, 1, "Preparing public and operational listeners")
+	listened := diagnostics.Time(ctx, "prepare server listeners")
 	endpoints, err := owner.prepareEndpoints(cfg, certificate)
+	listened()
 	if err != nil {
 		return nil, fmt.Errorf("boot: listeners: %w", err)
 	}
 	endpoints.activate(owner)
+	diagnostics.Printf(ctx, 2, "Public and operational sockets are bound")
 	guard.add(func() error { return resources.closeListener(srv.publicLn) })
 	guard.add(func() error { return resources.closeListener(srv.operationalLn) })
 	if cfg.Store.PostgresPoolMax != bootstrap.Store.PostgresPoolMax {
@@ -386,6 +412,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	}
 	selfConfig.Budget = owner.budget
 	if cfg.HA {
+		diagnostics.Printf(ctx, 1, "Configuring high-availability coordination")
 		installedStamp := ""
 		if selfConfig.Deployment != nil {
 			installedStamp = selfConfig.Deployment.Identity().TemplateStamp
@@ -396,7 +423,10 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 		}
 		kr.SetHAFreshness(true)
 	}
+	diagnostics.Printf(ctx, 1, "Preparing runtime services and providers")
+	provided := diagnostics.Time(ctx, "prepare runtime services and providers")
 	graph, err := owner.prepareGeneration(ctx, cfg)
+	provided()
 	if err != nil {
 		return nil, err
 	}
@@ -414,6 +444,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 			return nil, err
 		}
 	}
+	diagnostics.Printf(ctx, 1, "Activating managed runtime configuration")
 	if err := selfConfig.LoadRuntime(ctx); err != nil && !(missingNode && errors.Is(err, runtimeconfig.ErrNodeNotConfigured)) {
 		if !sourcesPending {
 			return nil, fmt.Errorf("boot: self-configuration: %w", err)
@@ -430,6 +461,7 @@ func boot(ctx context.Context, cfg *config.Config, log *slog.Logger, resources b
 	// Ownership transfers only after the Server is complete. Nothing remains
 	// between disarm and return, so Server.Close is now the sole owner.
 	guard.disarm()
+	diagnostics.Printf(ctx, 1, "Server boot finished; listeners prepared")
 	return srv, nil
 }
 

--- a/internal/app/automatic_apply.go
+++ b/internal/app/automatic_apply.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
@@ -40,9 +41,11 @@ func (s automaticStore) Installed(ctx context.Context, manifest releaseidentity.
 }
 
 func applyAutomaticRoute(ctx context.Context, host automaticApplyHost, database automaticInspection, route automaticRoute, staged map[releaseidentity.Identity]string, journal *automaticJournal, journalPath string, out io.Writer) (err error) {
+	completed := false
+	defer diagnostics.Time(ctx, "apply migration route")()
 	// Register the failure fence before any reconciliation or process operation.
 	defer func() {
-		if err != nil {
+		if err != nil && !completed {
 			cleanup, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 			err = errors.Join(err, host.FenceAndStop(cleanup))
@@ -71,6 +74,7 @@ func applyAutomaticRoute(ctx context.Context, host automaticApplyHost, database 
 	fmt.Fprintln(out, "4/5 Applying the authenticated migration route.")
 	for index := start; index < len(steps); index++ {
 		step := steps[index]
+		diagnostics.Printf(ctx, 1, "Migration hop %d/%d: %s", index+1, len(steps), step.Target.Version)
 		candidate, ok := staged[step.Target]
 		prepared, have := route.Executables[step.Target]
 		if !ok || !have || candidate == "" || prepared.Identity != step.Target || prepared.BinarySHA256.Validate() != nil {
@@ -108,6 +112,7 @@ func applyAutomaticRoute(ctx context.Context, host automaticApplyHost, database 
 				return err
 			}
 		}
+		diagnostics.Printf(ctx, 2, "Installing verified candidate SHA-256 %s", prepared.BinarySHA256)
 		if err := host.InstallBinary(ctx, candidate, string(prepared.BinarySHA256)); err != nil {
 			return err
 		}
@@ -156,9 +161,14 @@ func applyAutomaticRoute(ctx context.Context, host automaticApplyHost, database 
 	if err := writeAutomaticJournal(journalPath, journal); err != nil {
 		return err
 	}
+	completed = true
+	diagnostics.Printf(ctx, 1, "Pruning stale public upgrade evidence; retaining the recovery backup")
 	// Earlier runs' public bundles, one-use attestations and backups are no
 	// longer referenced; only this run's evidence and encrypted backup remain.
-	return host.PrunePublic(journal.Runtime)
+	if err := host.PrunePublic(journal.Runtime); err != nil {
+		return fmt.Errorf("upgrade completed; public evidence cleanup failed: %w", err)
+	}
+	return nil
 }
 
 func validateAutomaticPosition(plan upgradecompat.Plan, journal *automaticJournal) error {

--- a/internal/app/automatic_apply_test.go
+++ b/internal/app/automatic_apply_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -353,6 +354,67 @@ func TestAutomaticHealthFailureIsTerminalWithoutRewritingHealthyDB(t *testing.T)
 			host.events = nil
 			if err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard); err == nil || strings.Join(host.events, ",") != "fence" {
 				t.Fatalf("terminal host journal retried automatically: %v %v", host.events, err)
+			}
+		})
+	}
+}
+
+func TestAutomaticCleanupFailureDoesNotStopCompletedService(t *testing.T) {
+	route, journal, host, staged := automaticApplyFixture(t, 1)
+	host.failAt = "prune"
+	err := applyAutomaticRoute(t.Context(), host, host.db, route, staged, journal, host.path, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "upgrade completed; public evidence cleanup failed") {
+		t.Fatalf("cleanup failure not reported distinctly: %v", err)
+	}
+	persisted, readErr := readAutomaticJournal(host.path)
+	if readErr != nil || persisted.Phase != "complete" || !host.running || !host.completed {
+		t.Fatalf("cleanup fenced healthy service: %v %+v %v", host.events, persisted, readErr)
+	}
+}
+
+func TestAutomaticPublicBundleCleanupChecksJournalPublication(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		published, same, invalid bool
+	}{
+		{name: "failure before first journal publish"},
+		{name: "failure before replacing prior journal", published: true},
+		{name: "failure after journal rename", published: true, same: true},
+		{name: "unreadable journal", invalid: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, journal, host, _ := automaticApplyFixture(t, 1)
+			bundle := filepath.Join(t.TempDir(), "bundle-new")
+			if err := os.Mkdir(bundle, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(bundle, "payload"), []byte("release bytes"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if tc.published {
+				journal.Runtime.BundleDirectory = "prior-bundle"
+				if tc.same {
+					journal.Runtime.BundleDirectory = bundle
+				}
+				if err := writeAutomaticJournal(host.path, journal); err != nil {
+					t.Fatal(err)
+				}
+			} else if tc.invalid {
+				if err := os.WriteFile(host.path, []byte("invalid"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := cleanupAutomaticUnpublishedBundle(host.path, bundle)
+			if (err != nil) != tc.invalid {
+				t.Fatalf("cleanup error=%v", err)
+			}
+			_, statErr := os.Stat(bundle)
+			if tc.same || tc.invalid {
+				if statErr != nil {
+					t.Fatal("removed potentially referenced bundle", statErr)
+				}
+			} else if !os.IsNotExist(statErr) {
+				t.Fatal("left unpublished bundle", statErr)
 			}
 		})
 	}

--- a/internal/app/automatic_discovery_test.go
+++ b/internal/app/automatic_discovery_test.go
@@ -154,7 +154,7 @@ func TestAutomaticDiscoveryNoopDoesNotFetchHistoricalPredecessors(t *testing.T) 
 	for _, identity := range f.identities[:2] {
 		f.forbidden[identity] = true
 	}
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(2), releaseidentity.SQLite, nil, io.Discard)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(2), releaseidentity.SQLite, nil)
 	if err != nil || len(result.Plan.Steps()) != 0 || len(f.fetched) != 0 || f.assembled != 0 {
 		t.Fatalf("same-release restart fetched historical artifacts: %v fetched=%v assemblies=%d", err, f.fetched, f.assembled)
 	}
@@ -163,7 +163,7 @@ func TestAutomaticDiscoveryNoopDoesNotFetchHistoricalPredecessors(t *testing.T) 
 func TestAutomaticDiscoveryRecentUpgradeDoesNotFetchAncientHistory(t *testing.T) {
 	f := newAutomaticDiscoveryFixture(t)
 	f.forbidden[f.identities[0]] = true
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(1), releaseidentity.SQLite, nil, io.Discard)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(1), releaseidentity.SQLite, nil)
 	if err != nil || len(result.Plan.Steps()) != 1 || !slices.Equal(f.fetched, []releaseidentity.Identity{f.identities[1]}) || f.assembled != 1 {
 		t.Fatalf("direct upgrade fetched unrelated predecessor: %v fetched=%v assemblies=%d", err, f.fetched, f.assembled)
 	}
@@ -196,7 +196,7 @@ func TestAutomaticDiscoveryLegacyAndInterruptedRouteKeepExactBridge(t *testing.T
 				inspection.installed.InstanceID = "must-not-inspect-new-source"
 				f.assembled = 0
 			}
-			result, err := discoverAutomaticRoute(t.Context(), f, f, target, f.trust.Pinned, inspection, releaseidentity.SQLite, previous, io.Discard)
+			result, err := discoverAutomaticRoute(t.Context(), f, f, target, f.trust.Pinned, inspection, releaseidentity.SQLite, previous)
 			if err != nil || len(result.Plan.Steps()) != 2 || len(result.Plan.BridgeDigests()) != 1 || !slices.Equal(f.fetched, []releaseidentity.Identity{f.identities[0]}) {
 				t.Fatalf("legacy bridge route unavailable: %v fetched=%v", err, f.fetched)
 			}
@@ -211,7 +211,7 @@ func TestAutomaticDiscoveryRejectsSnapshotBelowInstalledFloorBeforeFetching(t *t
 	f := newAutomaticDiscoveryFixture(t)
 	inspection := f.inspection(1)
 	inspection.state.Floor.CatalogSequence++
-	if _, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, inspection, releaseidentity.SQLite, nil, io.Discard); err == nil || len(f.fetched) != 0 {
+	if _, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, inspection, releaseidentity.SQLite, nil); err == nil || len(f.fetched) != 0 {
 		t.Fatal("stale trust evidence caused historical downloads")
 	}
 }
@@ -222,7 +222,7 @@ func TestAutomaticDiscoveryResolvesShallowAlternativesBeforeLongerHistory(t *tes
 	// the unnecessary interior node of the longer branch.
 	f := newAutomaticDiscoveryGraph(t, [][]int{{}, {0}, {0}, {2}, {3, 1}})
 	f.forbidden[f.identities[2]] = true
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil, io.Discard)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil)
 	if err != nil || len(result.Plan.Steps()) != 2 || result.Plan.Steps()[0].Target != f.identities[1] {
 		t.Fatalf("shortest authenticated branch was not selected: %v fetched=%v", err, f.fetched)
 	}
@@ -234,7 +234,7 @@ func TestAutomaticDiscoveryResolvesShallowAlternativesBeforeLongerHistory(t *tes
 func TestAutomaticDiscoveryPreservesDeterministicRouteTieBreak(t *testing.T) {
 	f := newAutomaticDiscoveryGraph(t, [][]int{{}, {}, {0}, {0}, {3, 2}})
 	f.forbidden[f.identities[1]] = true
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil, io.Discard)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil)
 	if err != nil || len(result.Plan.Steps()) != 2 || result.Plan.Steps()[0].Target != f.identities[2] {
 		t.Fatalf("partial graph changed deterministic tie break: %v fetched=%v", err, f.fetched)
 	}

--- a/internal/app/automatic_discovery_test.go
+++ b/internal/app/automatic_discovery_test.go
@@ -154,7 +154,7 @@ func TestAutomaticDiscoveryNoopDoesNotFetchHistoricalPredecessors(t *testing.T) 
 	for _, identity := range f.identities[:2] {
 		f.forbidden[identity] = true
 	}
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(2), releaseidentity.SQLite, nil)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(2), releaseidentity.SQLite, nil, io.Discard)
 	if err != nil || len(result.Plan.Steps()) != 0 || len(f.fetched) != 0 || f.assembled != 0 {
 		t.Fatalf("same-release restart fetched historical artifacts: %v fetched=%v assemblies=%d", err, f.fetched, f.assembled)
 	}
@@ -163,7 +163,7 @@ func TestAutomaticDiscoveryNoopDoesNotFetchHistoricalPredecessors(t *testing.T) 
 func TestAutomaticDiscoveryRecentUpgradeDoesNotFetchAncientHistory(t *testing.T) {
 	f := newAutomaticDiscoveryFixture(t)
 	f.forbidden[f.identities[0]] = true
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(1), releaseidentity.SQLite, nil)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, f.inspection(1), releaseidentity.SQLite, nil, io.Discard)
 	if err != nil || len(result.Plan.Steps()) != 1 || !slices.Equal(f.fetched, []releaseidentity.Identity{f.identities[1]}) || f.assembled != 1 {
 		t.Fatalf("direct upgrade fetched unrelated predecessor: %v fetched=%v assemblies=%d", err, f.fetched, f.assembled)
 	}
@@ -196,7 +196,7 @@ func TestAutomaticDiscoveryLegacyAndInterruptedRouteKeepExactBridge(t *testing.T
 				inspection.installed.InstanceID = "must-not-inspect-new-source"
 				f.assembled = 0
 			}
-			result, err := discoverAutomaticRoute(t.Context(), f, f, target, f.trust.Pinned, inspection, releaseidentity.SQLite, previous)
+			result, err := discoverAutomaticRoute(t.Context(), f, f, target, f.trust.Pinned, inspection, releaseidentity.SQLite, previous, io.Discard)
 			if err != nil || len(result.Plan.Steps()) != 2 || len(result.Plan.BridgeDigests()) != 1 || !slices.Equal(f.fetched, []releaseidentity.Identity{f.identities[0]}) {
 				t.Fatalf("legacy bridge route unavailable: %v fetched=%v", err, f.fetched)
 			}
@@ -211,7 +211,7 @@ func TestAutomaticDiscoveryRejectsSnapshotBelowInstalledFloorBeforeFetching(t *t
 	f := newAutomaticDiscoveryFixture(t)
 	inspection := f.inspection(1)
 	inspection.state.Floor.CatalogSequence++
-	if _, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, inspection, releaseidentity.SQLite, nil); err == nil || len(f.fetched) != 0 {
+	if _, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[2]], f.trust.Pinned, inspection, releaseidentity.SQLite, nil, io.Discard); err == nil || len(f.fetched) != 0 {
 		t.Fatal("stale trust evidence caused historical downloads")
 	}
 }
@@ -222,7 +222,7 @@ func TestAutomaticDiscoveryResolvesShallowAlternativesBeforeLongerHistory(t *tes
 	// the unnecessary interior node of the longer branch.
 	f := newAutomaticDiscoveryGraph(t, [][]int{{}, {0}, {0}, {2}, {3, 1}})
 	f.forbidden[f.identities[2]] = true
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil, io.Discard)
 	if err != nil || len(result.Plan.Steps()) != 2 || result.Plan.Steps()[0].Target != f.identities[1] {
 		t.Fatalf("shortest authenticated branch was not selected: %v fetched=%v", err, f.fetched)
 	}
@@ -234,7 +234,7 @@ func TestAutomaticDiscoveryResolvesShallowAlternativesBeforeLongerHistory(t *tes
 func TestAutomaticDiscoveryPreservesDeterministicRouteTieBreak(t *testing.T) {
 	f := newAutomaticDiscoveryGraph(t, [][]int{{}, {}, {0}, {0}, {3, 2}})
 	f.forbidden[f.identities[1]] = true
-	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil)
+	result, err := discoverAutomaticRoute(t.Context(), f, f, f.prepared[f.identities[4]], f.trust.Pinned, f.inspection(0), releaseidentity.SQLite, nil, io.Discard)
 	if err != nil || len(result.Plan.Steps()) != 2 || result.Plan.Steps()[0].Target != f.identities[2] {
 		t.Fatalf("partial graph changed deterministic tie break: %v fetched=%v", err, f.fetched)
 	}

--- a/internal/app/automatic_release.go
+++ b/internal/app/automatic_release.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -67,11 +68,11 @@ type automaticReleasePreparer interface {
 // prepareAutomaticRoute follows only authenticated identity references. It
 // stops as soon as the actual source has a complete authenticated route, so a
 // recent installation does not download unrelated predecessor history.
-func prepareAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database upgrade.Config, previous *automaticJournal) (automaticRoute, error) {
-	return discoverAutomaticRoute(ctx, installer, source, target, pinned, automaticStore{database}, database.Engine, previous)
+func prepareAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database upgrade.Config, previous *automaticJournal, out io.Writer) (automaticRoute, error) {
+	return discoverAutomaticRoute(ctx, installer, source, target, pinned, automaticStore{database}, database.Engine, previous, out)
 }
 
-func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database automaticInspection, engine releaseidentity.Engine, previous *automaticJournal) (automaticRoute, error) {
+func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database automaticInspection, engine releaseidentity.Engine, previous *automaticJournal, out io.Writer) (automaticRoute, error) {
 	result := automaticRoute{Directory: target.BundleDirectory, Executables: map[releaseidentity.Identity]selfupdate.PreparedNightly{target.Identity: target}}
 	floor := releaseidentity.SnapshotFloor{}
 	control, err := database.Control(ctx)
@@ -188,6 +189,7 @@ func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePrepa
 		if identity.Profile != releaseidentity.NightlyV1 {
 			return result, errors.New("automatic nightly upgrade cannot cross into a stable release")
 		}
+		fmt.Fprintf(out, "  Route from the installed release needs nightly %s; fetching its evidence.\n", identity.Version)
 		release, err := source.ReleaseByVersion(ctx, identity.Version)
 		if err != nil {
 			return result, err

--- a/internal/app/automatic_release.go
+++ b/internal/app/automatic_release.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"strings"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
 	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
@@ -68,11 +68,11 @@ type automaticReleasePreparer interface {
 // prepareAutomaticRoute follows only authenticated identity references. It
 // stops as soon as the actual source has a complete authenticated route, so a
 // recent installation does not download unrelated predecessor history.
-func prepareAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database upgrade.Config, previous *automaticJournal, out io.Writer) (automaticRoute, error) {
-	return discoverAutomaticRoute(ctx, installer, source, target, pinned, automaticStore{database}, database.Engine, previous, out)
+func prepareAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database upgrade.Config, previous *automaticJournal) (automaticRoute, error) {
+	return discoverAutomaticRoute(ctx, installer, source, target, pinned, automaticStore{database}, database.Engine, previous)
 }
 
-func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database automaticInspection, engine releaseidentity.Engine, previous *automaticJournal, out io.Writer) (automaticRoute, error) {
+func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePreparer, source automaticReleaseSource, target selfupdate.PreparedNightly, pinned releasetrust.PinnedTrust, database automaticInspection, engine releaseidentity.Engine, previous *automaticJournal) (automaticRoute, error) {
 	result := automaticRoute{Directory: target.BundleDirectory, Executables: map[releaseidentity.Identity]selfupdate.PreparedNightly{target.Identity: target}}
 	floor := releaseidentity.SnapshotFloor{}
 	control, err := database.Control(ctx)
@@ -189,7 +189,7 @@ func discoverAutomaticRoute(ctx context.Context, installer automaticReleasePrepa
 		if identity.Profile != releaseidentity.NightlyV1 {
 			return result, errors.New("automatic nightly upgrade cannot cross into a stable release")
 		}
-		fmt.Fprintf(out, "  Route from the installed release needs nightly %s; fetching its evidence.\n", identity.Version)
+		diagnostics.Printf(ctx, 1, "  Route from the installed release needs nightly %s; fetching its evidence.\n", identity.Version)
 		release, err := source.ReleaseByVersion(ctx, identity.Version)
 		if err != nil {
 			return result, err

--- a/internal/app/automatic_upgrade.go
+++ b/internal/app/automatic_upgrade.go
@@ -18,11 +18,13 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/filedurability"
 	"github.com/Hikyo-Org/hikyo/internal/hostupgrade"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
+	"github.com/Hikyo-Org/hikyo/internal/storagehealth"
 	"github.com/Hikyo-Org/hikyo/internal/store"
 	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
@@ -62,12 +64,18 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	configuration := fs.String("config", hostupgrade.ConfigPath, "root-owned deployment configuration")
 	version := fs.String("target", "", "exact nightly version; default is latest signed nightly")
 	handoff := fs.Bool("handoff", false, "continue in the independently verified target executable")
+	fs.Usage = func() {
+		fmt.Fprintln(out, "Usage: sudo hikyo [-v|-vv|-vvv] upgrade [--target VERSION] [--config FILE]")
+		fmt.Fprintln(out, "Verbosity: -v phases, -vv artifacts and requests, -vvv timings. Diagnostics go to stderr.")
+		fs.PrintDefaults()
+	}
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
 		return errors.New("usage: sudo hikyo upgrade [--target VERSION] [--config FILE]")
 	}
+	defer diagnostics.Time(ctx, "automatic upgrade")()
 	if runtime.GOOS != "linux" || os.Geteuid() != 0 {
 		return errors.New("automatic upgrades require sudo hikyo upgrade on the Linux systemd server")
 	}
@@ -79,6 +87,7 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	if err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 1, "Checking deployment configuration and systemd prerequisites")
 	host, err := hostupgrade.New(c)
 	if err != nil {
 		return err
@@ -135,21 +144,64 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	}
 	database := upgrade.Config{Engine: releaseidentity.SQLite, Path: cfg.Store.Path}
 	cache := filepath.Join(c.StateDirectory, "downloads")
-	installer, err := selfupdate.NewInstaller(selfupdate.Config{StateDir: cache, TrustRootBase64: base64.StdEncoding.EncodeToString(pinned.Root), RecoveryKeyBase64: base64.StdEncoding.EncodeToString(pinned.RecoveryPublicKey), Progress: out})
+	installer, err := selfupdate.NewInstaller(selfupdate.Config{StateDir: cache, TrustRootBase64: base64.StdEncoding.EncodeToString(pinned.Root), RecoveryKeyBase64: base64.StdEncoding.EncodeToString(pinned.RecoveryPublicKey), TransientBundles: true})
 	if err != nil {
 		return err
 	}
+	// Reclaim abandoned work before the first download, while the operator
+	// lock is held. Recovery artifacts referenced by the journal stay public.
+	keep := []releaseidentity.Identity{}
+	if previous != nil {
+		keep = append(keep, previous.Target)
+	}
+	diagnostics.Printf(ctx, 1, "Cleaning obsolete private download artifacts in %s", cache)
+	if previous != nil && previous.Phase != "complete" {
+		if err := installer.PruneNightlyScratch(ctx); err != nil {
+			return err
+		}
+	} else if err := installer.PruneNightlyCache(ctx, keep...); err != nil {
+		return err
+	}
+	capacity, err := storagehealth.Read(c.StateDirectory)
+	if err != nil {
+		return fmt.Errorf("inspect upgrade storage: %w", err)
+	}
+	diagnostics.Printf(ctx, 1, "Upgrade filesystem has %.0f MiB available after cleanup", float64(capacity.AvailableBytes)/(1<<20))
+	if previous == nil || previous.Phase == "complete" {
+		if err := host.PruneCandidates(); err != nil {
+			return err
+		}
+		if previous != nil {
+			if err := host.PrunePublic(previous.Runtime); err != nil {
+				return err
+			}
+		}
+	}
+	// Failures can happen before a journal exists. Retire reproducible private
+	// cache work on ordinary errors too; preserve all public recovery material.
+	defer func() {
+		var next *AutomaticHandoff
+		if err != nil && !errors.As(err, &next) {
+			currentJournal, readErr := readAutomaticJournal(journalPath)
+			if readErr != nil || (currentJournal != nil && currentJournal.Phase != "complete") {
+				err = errors.Join(err, readErr, installer.PruneNightlyScratch(ctx))
+			} else {
+				err = errors.Join(err, installer.PruneNightlyCache(ctx, keep...))
+			}
+		}
+	}()
 	client, err := updatecheck.NewHTTPClient(60 * time.Second)
 	if err != nil {
 		return err
 	}
+	client.Transport = diagnostics.Transport{Base: client.Transport}
 	source := updatecheck.NewGitHubSource(client)
 	fmt.Fprintln(out, "1/5 Verifying the signed nightly and migration route.")
 	status, err := selectAutomaticRelease(ctx, source, *version)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "  Selected nightly %s.\n", status.LatestVersion)
+	diagnostics.Printf(ctx, 1, "  Selected nightly %s.", status.LatestVersion)
 	var target selfupdate.PreparedNightly
 	if previous != nil && previous.Phase != "complete" {
 		// An unfinished operation pins its exact authenticated target even if a
@@ -173,26 +225,37 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		if *handoff {
 			return errors.New("verified target binary does not match its signed compatibility declaration")
 		}
-		fmt.Fprintf(out, "  Handing off to the verified %s executable; it restarts the five steps.\n", target.Identity.Version)
+		diagnostics.Printf(ctx, 1, "  Handing off to the verified %s executable; it restarts the five steps.", target.Identity.Version)
 		return &AutomaticHandoff{Executable: target.BinaryPath, Arguments: []string{"upgrade", "--config", *configuration, "--target", target.Identity.Version, "--handoff"}}
 	}
-	fmt.Fprintln(out, "  Resolving the migration route from the installed release.")
-	route, err := prepareAutomaticRoute(ctx, installer, source, target, pinned, database, previous, out)
+	diagnostics.Printf(ctx, 1, "  Resolving the migration route from the installed release.")
+	route, err := prepareAutomaticRoute(ctx, installer, source, target, pinned, database, previous)
 	if err != nil {
 		return err
 	}
 	if len(route.Plan.Steps()) == 0 {
+		if err := errors.Join(installer.PruneNightlyCache(ctx, target.Identity), host.PruneCandidates()); err != nil {
+			return fmt.Errorf("Hikyo %s is already installed; temporary artifact cleanup failed: %w", target.Identity.Version, err)
+		}
 		fmt.Fprintf(out, "Hikyo %s is already installed.\n", target.Identity.Version)
-		return installer.PruneNightlyCache(target.Identity)
+		return nil
 	}
 	if previous != nil && previous.Phase != "complete" && previous.Route != route.Plan.Digest() {
 		return errors.New("unfinished upgrade route differs from current authenticated evidence")
 	}
-	fmt.Fprintf(out, "  Route has %d step(s). Staging the route bundle for the service.\n", len(route.Plan.Steps()))
+	diagnostics.Printf(ctx, 1, "  Route has %d step(s). Staging the route bundle for the service.", len(route.Plan.Steps()))
 	publicBundle, err := host.StagePublicBundle(route.Directory)
 	if err != nil {
 		return err
 	}
+	retainPublicBundle := false
+	defer func() {
+		// Journal publication can fail before rename (for example ENOSPC)
+		// or after rename during directory sync. Measure its actual reference.
+		if !retainPublicBundle {
+			err = errors.Join(err, cleanupAutomaticUnpublishedBundle(journalPath, publicBundle))
+		}
+	}()
 	if _, err := upgradebundle.Load(ctx, publicBundle, pinned, route.Bundle.Snapshot().Floor()); err != nil {
 		return err
 	}
@@ -202,7 +265,7 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		if !ok {
 			return errors.New("authenticated route executable is missing")
 		}
-		fmt.Fprintf(out, "  Staging candidate executable %s.\n", step.Target.Version)
+		diagnostics.Printf(ctx, 1, "  Staging candidate executable %s.", step.Target.Version)
 		staged[step.Target], err = host.StageCandidate(prepared.BinaryPath, string(prepared.BinarySHA256))
 		if err != nil {
 			return err
@@ -228,6 +291,7 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		if err := writeAutomaticJournal(journalPath, journal); err != nil {
 			return err
 		}
+		retainPublicBundle = true
 		fmt.Fprintln(out, "2/5 Stopping writers and creating the encrypted backup.")
 		if err := host.FenceAndStop(ctx); err != nil {
 			return err
@@ -247,15 +311,19 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 			return err
 		}
 	}
+	retainPublicBundle = true
 	if err := applyAutomaticRoute(ctx, host, automaticStore{database}, route, staged, journal, journalPath, out); err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "Hikyo %s is upgraded and ready. Encrypted backup retained at %s.\n", target.Identity.Version, journal.Runtime.CiphertextPath)
 	// The installed binary and public bundle are copies; the download cache
 	// and staged candidates behind them are now dead weight. Keep the target
 	// nightly so an immediate rerun reports "already installed" without a
 	// fresh multi-hundred-MiB download.
-	return errors.Join(installer.PruneNightlyCache(target.Identity), host.PruneCandidates())
+	if err := errors.Join(installer.PruneNightlyCache(ctx, target.Identity), host.PruneCandidates()); err != nil {
+		return fmt.Errorf("Hikyo %s is upgraded and ready; temporary artifact cleanup failed: %w", target.Identity.Version, err)
+	}
+	fmt.Fprintf(out, "Hikyo %s is upgraded and ready. Encrypted backup retained at %s.\n", target.Identity.Version, journal.Runtime.CiphertextPath)
+	return nil
 }
 
 // openAutomaticCustody unlocks the operator vault with a secret derived from
@@ -383,6 +451,20 @@ func writeAutomaticFile(path string, raw []byte, mode os.FileMode) error {
 		return err
 	}
 	return filedurability.SyncDirectory(filepath.Dir(path))
+}
+
+// cleanupAutomaticUnpublishedBundle receives only this invocation's newly
+// staged path. An unreadable journal leaves ownership uncertain, so preserve
+// the bundle and report the error rather than deleting potential recovery data.
+func cleanupAutomaticUnpublishedBundle(journalPath, bundlePath string) error {
+	journal, err := readAutomaticJournal(journalPath)
+	if err != nil {
+		return fmt.Errorf("check staged bundle journal before cleanup: %w", err)
+	}
+	if journal != nil && journal.Runtime.BundleDirectory == bundlePath {
+		return nil
+	}
+	return os.RemoveAll(bundlePath)
 }
 
 func writeAutomaticJournal(path string, journal *automaticJournal) error {

--- a/internal/app/automatic_upgrade.go
+++ b/internal/app/automatic_upgrade.go
@@ -135,7 +135,7 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	}
 	database := upgrade.Config{Engine: releaseidentity.SQLite, Path: cfg.Store.Path}
 	cache := filepath.Join(c.StateDirectory, "downloads")
-	installer, err := selfupdate.NewInstaller(selfupdate.Config{StateDir: cache, TrustRootBase64: base64.StdEncoding.EncodeToString(pinned.Root), RecoveryKeyBase64: base64.StdEncoding.EncodeToString(pinned.RecoveryPublicKey)})
+	installer, err := selfupdate.NewInstaller(selfupdate.Config{StateDir: cache, TrustRootBase64: base64.StdEncoding.EncodeToString(pinned.Root), RecoveryKeyBase64: base64.StdEncoding.EncodeToString(pinned.RecoveryPublicKey), Progress: out})
 	if err != nil {
 		return err
 	}
@@ -149,6 +149,7 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(out, "  Selected nightly %s.\n", status.LatestVersion)
 	var target selfupdate.PreparedNightly
 	if previous != nil && previous.Phase != "complete" {
 		// An unfinished operation pins its exact authenticated target even if a
@@ -172,19 +173,22 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		if *handoff {
 			return errors.New("verified target binary does not match its signed compatibility declaration")
 		}
+		fmt.Fprintf(out, "  Handing off to the verified %s executable; it restarts the five steps.\n", target.Identity.Version)
 		return &AutomaticHandoff{Executable: target.BinaryPath, Arguments: []string{"upgrade", "--config", *configuration, "--target", target.Identity.Version, "--handoff"}}
 	}
-	route, err := prepareAutomaticRoute(ctx, installer, source, target, pinned, database, previous)
+	fmt.Fprintln(out, "  Resolving the migration route from the installed release.")
+	route, err := prepareAutomaticRoute(ctx, installer, source, target, pinned, database, previous, out)
 	if err != nil {
 		return err
 	}
 	if len(route.Plan.Steps()) == 0 {
 		fmt.Fprintf(out, "Hikyo %s is already installed.\n", target.Identity.Version)
-		return nil
+		return installer.PruneNightlyCache(target.Identity)
 	}
 	if previous != nil && previous.Phase != "complete" && previous.Route != route.Plan.Digest() {
 		return errors.New("unfinished upgrade route differs from current authenticated evidence")
 	}
+	fmt.Fprintf(out, "  Route has %d step(s). Staging the route bundle for the service.\n", len(route.Plan.Steps()))
 	publicBundle, err := host.StagePublicBundle(route.Directory)
 	if err != nil {
 		return err
@@ -198,6 +202,7 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		if !ok {
 			return errors.New("authenticated route executable is missing")
 		}
+		fmt.Fprintf(out, "  Staging candidate executable %s.\n", step.Target.Version)
 		staged[step.Target], err = host.StageCandidate(prepared.BinaryPath, string(prepared.BinarySHA256))
 		if err != nil {
 			return err
@@ -246,7 +251,11 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		return err
 	}
 	fmt.Fprintf(out, "Hikyo %s is upgraded and ready. Encrypted backup retained at %s.\n", target.Identity.Version, journal.Runtime.CiphertextPath)
-	return nil
+	// The installed binary and public bundle are copies; the download cache
+	// and staged candidates behind them are now dead weight. Keep the target
+	// nightly so an immediate rerun reports "already installed" without a
+	// fresh multi-hundred-MiB download.
+	return errors.Join(installer.PruneNightlyCache(target.Identity), host.PruneCandidates())
 }
 
 // openAutomaticCustody unlocks the operator vault with a secret derived from

--- a/internal/app/backup.go
+++ b/internal/app/backup.go
@@ -39,6 +39,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -197,22 +198,32 @@ func runBackupExport(ctx context.Context, cfg *config.Config, log *slog.Logger, 
 		return errors.New("no destination: pass --out DIR or set HIKYO_BACKUP_DIR")
 	}
 
+	diagnostics.Printf(ctx, 1, "backup: validating datastore admission")
+	admissionDone := diagnostics.Time(ctx, "backup datastore admission")
 	db, err := openBackupRuntime(ctx, cfg)
+	admissionDone()
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
 	svc := &service.Backup{DB: db, Options: options}
+	diagnostics.Printf(ctx, 2, "backup: recipients=%d passphrase=%t", len(options.Recipients), options.Passphrase != "")
+	diagnostics.Printf(ctx, 1, "backup: exporting and encrypting consistent snapshot")
+	exportDone := diagnostics.Time(ctx, "backup snapshot export and encryption")
 	result, err := svc.Export(ctx, dir)
+	exportDone()
 	if err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 2, "backup: encrypted_bytes=%d engine=%s schema=%d", result.Bytes, result.Manifest.Engine, result.Manifest.SchemaVersion)
+	diagnostics.Printf(ctx, 1, "backup: recording published archive")
 	if err := svc.RecordExport(ctx, service.TriggerManual, result); err != nil {
 		// The artifact exists and is complete; only its record failed. Say
 		// exactly that rather than implying the backup did not happen.
 		return fmt.Errorf("the archive was published to %s, but its audit record could not be written: %w", result.Path, err)
 	}
+	diagnostics.Printf(ctx, 1, "backup: export complete")
 	log.Info("backup exported", "path", result.Path, "bytes", result.Bytes,
 		"engine", result.Manifest.Engine, "schema_version", result.Manifest.SchemaVersion)
 	fmt.Fprintf(stderr, "wrote %s (%d bytes, %s schema %d)\n",
@@ -341,12 +352,16 @@ func runRestoreRun(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 		return fmt.Errorf("restore staging directory: %w", err)
 	}
 	defer os.RemoveAll(work)
+	diagnostics.Printf(ctx, 1, "restore: decrypting and authenticating complete archive")
+	decryptDone := diagnostics.Time(ctx, "restore archive authentication")
 	plain, err := decryptArchive(*from, filepath.Join(work, "archive.tar"), unlock)
+	decryptDone()
 	if err != nil {
 		return err
 	}
 	defer plain.Close()
 
+	diagnostics.Printf(ctx, 1, "restore: validating manifest and empty target")
 	manifest, err := store.ReadManifest(plain)
 	if err != nil {
 		return err
@@ -355,10 +370,12 @@ func runRestoreRun(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 	if err := checkRestorable(ctx, sc, manifest); err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 2, "restore: engine=%s schema=%d", manifest.Engine, manifest.SchemaVersion)
 	if _, err := plain.Seek(0, io.SeekStart); err != nil {
 		return fmt.Errorf("rewind archive: %w", err)
 	}
 
+	diagnostics.Printf(ctx, 1, "restore: publishing data and invalidating previous credentials")
 	now := time.Now()
 	switch sc.Engine {
 	case store.EngineSQLite:
@@ -376,6 +393,7 @@ func runRestoreRun(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 
 	// Data publication never migrates or admits serving. A new current-incarnation
 	// export/drill must pass the upgrade gate before any later schema writes.
+	diagnostics.Printf(ctx, 1, "restore: reading reconciliation status")
 	var status service.Status
 	err = withReconciliation(ctx, cfg, func(s reconciliationService) error { var err error; status, err = s.Status(ctx); return err })
 	if err != nil {
@@ -384,6 +402,8 @@ func runRestoreRun(ctx context.Context, cfg *config.Config, log *slog.Logger, ar
 	log.Warn("restore complete: every pre-restore authentication artifact is now inert",
 		"engine", manifest.Engine, "credential_epoch", status.State.CredentialEpoch,
 		"restore_epoch", status.State.RestoreEpoch, "pending_principals", len(status.Pending))
+	diagnostics.Printf(ctx, 2, "restore: pending_principals=%d", len(status.Pending))
+	diagnostics.Printf(ctx, 1, "restore: data restore complete")
 	fmt.Fprintf(stderr, "restored %s (schema %d); credential epoch is now %d\n",
 		manifest.Engine, manifest.SchemaVersion, status.State.CredentialEpoch)
 	printPending(stderr, status)
@@ -475,6 +495,8 @@ func decryptArchive(source, path string, u backup.Unlock) (*os.File, error) {
 }
 
 func runRestoreStatus(ctx context.Context, cfg *config.Config, stderr io.Writer) error {
+	diagnostics.Printf(ctx, 1, "restore: reading reconciliation status")
+	defer diagnostics.Time(ctx, "restore reconciliation status")()
 	var status service.Status
 	err := withReconciliation(ctx, cfg, func(s reconciliationService) error { var err error; status, err = s.Status(ctx); return err })
 	if err != nil {
@@ -485,6 +507,7 @@ func runRestoreStatus(ctx context.Context, cfg *config.Config, stderr io.Writer)
 		fmt.Fprintln(stderr, "this instance has never been restored; no reconciliation is outstanding")
 		return nil
 	}
+	diagnostics.Printf(ctx, 2, "restore: pending_principals=%d", len(status.Pending))
 	fmt.Fprintf(stderr, "restored at %s (credential epoch %d, restore epoch %d)\n",
 		status.State.ReactivatedAt.Format(time.RFC3339), status.State.CredentialEpoch, status.State.RestoreEpoch)
 	printPending(stderr, status)
@@ -516,6 +539,8 @@ func runRestoreReconcile(ctx context.Context, cfg *config.Config, log *slog.Logg
 	if *principal == "" {
 		return errors.New("--principal is required: reconciliation is a per-principal assertion, and there is no bulk form")
 	}
+	diagnostics.Printf(ctx, 1, "restore: reconciling one approved principal")
+	defer diagnostics.Time(ctx, "restore principal reconciliation")()
 	var status service.Status
 	err := withReconciliation(ctx, cfg, func(s reconciliationService) error {
 		var err error
@@ -527,6 +552,8 @@ func runRestoreReconcile(ctx context.Context, cfg *config.Config, log *slog.Logg
 	}
 
 	log.Info("principal reconciled", "principal", *principal, "pending", len(status.Pending))
+	diagnostics.Printf(ctx, 2, "restore: pending_principals=%d", len(status.Pending))
+	diagnostics.Printf(ctx, 1, "restore: principal reconciliation complete")
 	fmt.Fprintf(stderr, "reconciled %s\n", *principal)
 	printPending(stderr, status)
 	return nil
@@ -595,7 +622,10 @@ func runRestoreDrill(ctx context.Context, cfg *config.Config, log *slog.Logger, 
 	// outlives the drill.
 	defer crypto.Zero(rootKey)
 
+	diagnostics.Printf(ctx, 1, "restore drill: hashing archive")
+	digestDone := diagnostics.Time(ctx, "restore drill archive digest")
 	digest, err := fileDigest(*from)
+	digestDone()
 	if err != nil {
 		return err
 	}
@@ -620,6 +650,7 @@ func runRestoreDrill(ctx context.Context, cfg *config.Config, log *slog.Logger, 
 	// A refused or failed drill does not establish ownership of the target.
 	// Preserve it for inspection, including any pre-existing database.
 	if *cleanup && drillErr == nil && report.OK() {
+		diagnostics.Printf(ctx, 1, "restore drill: processing scratch cleanup")
 		switch scratch.Engine {
 		case store.EngineSQLite:
 			if err := removeDrillSQLite(scratch.Path); err != nil {
@@ -638,6 +669,7 @@ func runRestoreDrill(ctx context.Context, cfg *config.Config, log *slog.Logger, 
 	// manifest existed (an unreadable archive) has nothing to record and is
 	// returned as-is.
 	if manifest.Engine != "" {
+		diagnostics.Printf(ctx, 1, "restore drill: recording verdict on live instance")
 		live, err := openBackupRuntime(ctx, cfg)
 		if err != nil {
 			return errors.Join(drillErr, err)
@@ -658,6 +690,7 @@ func runRestoreDrill(ctx context.Context, cfg *config.Config, log *slog.Logger, 
 	if !report.OK() {
 		return fmt.Errorf("restore drill failed at %q", report.FailedStep)
 	}
+	diagnostics.Printf(ctx, 1, "restore drill: recovery proof complete")
 	log.Info("restore drill passed", "archive", report.Archive, "engine", report.Engine,
 		"elapsed", report.Elapsed, "rto_target", report.RTOTarget)
 	return nil
@@ -670,18 +703,23 @@ func runRestoreDrill(ctx context.Context, cfg *config.Config, log *slog.Logger, 
 func runDrillSteps(ctx context.Context, cfg *config.Config, scratch store.Config, from string,
 	unlock backup.Unlock, rootKey []byte, principal domain.PrincipalID, scope domain.Scope, report *service.DrillReport,
 ) (store.Manifest, error) {
+	defer diagnostics.Time(ctx, "restore drill recovery proof")()
 	work, err := os.MkdirTemp("", "hikyo-drill-")
 	if err != nil {
 		report.FailedStep = "staging"
 		return store.Manifest{}, fmt.Errorf("drill staging directory: %w", err)
 	}
 	defer os.RemoveAll(work)
+	diagnostics.Printf(ctx, 1, "restore drill: decrypting and authenticating complete archive")
+	decryptDone := diagnostics.Time(ctx, "restore drill archive authentication")
 	plain, err := decryptArchive(from, filepath.Join(work, "archive.tar"), unlock)
+	decryptDone()
 	if err != nil {
 		report.FailedStep = "decrypt"
 		return store.Manifest{}, err
 	}
 	defer plain.Close()
+	diagnostics.Printf(ctx, 1, "restore drill: validating manifest and empty scratch target")
 	manifest, err := store.ReadManifest(plain)
 	if err != nil {
 		report.FailedStep = "manifest"
@@ -691,10 +729,12 @@ func runDrillSteps(ctx context.Context, cfg *config.Config, scratch store.Config
 		report.FailedStep = "preflight"
 		return manifest, err
 	}
+	diagnostics.Printf(ctx, 2, "restore drill: engine=%s schema=%d", manifest.Engine, manifest.SchemaVersion)
 	if _, err := plain.Seek(0, io.SeekStart); err != nil {
 		report.FailedStep = "restore"
 		return manifest, fmt.Errorf("rewind archive: %w", err)
 	}
+	diagnostics.Printf(ctx, 1, "restore drill: restoring isolated scratch datastore")
 	now := time.Now()
 	switch scratch.Engine {
 	case store.EngineSQLite:
@@ -710,6 +750,7 @@ func runDrillSteps(ctx context.Context, cfg *config.Config, scratch store.Config
 	}
 
 	err = withDataRecovery(ctx, cfg, scratch, func(scratchDB *store.RecoveryDB) error {
+		diagnostics.Printf(ctx, 1, "restore drill: verifying restored key hierarchy")
 		// Boot the restored data under the escrowed root key. A copy is handed to
 		// LoadKeyring (which zeroes it); the caller keeps and wipes the original.
 		existing := &keyring.RecoveryStore{DB: scratchDB}
@@ -724,6 +765,7 @@ func runDrillSteps(ctx context.Context, cfg *config.Config, scratch store.Config
 		}
 
 		backupSvc := &service.Recovery{DB: scratchDB}
+		diagnostics.Printf(ctx, 1, "restore drill: proving stored value readability")
 		readable, err := backupSvc.ProveValuesReadable(ctx, kr)
 		report.ValuesReadable = readable
 		if err != nil {
@@ -735,6 +777,7 @@ func runDrillSteps(ctx context.Context, cfg *config.Config, scratch store.Config
 		// throwaway credential in the named project to prove the recovered
 		// instance can issue new machine identity. Both use the reconciled
 		// principal's own authority.
+		diagnostics.Printf(ctx, 1, "restore drill: reconciling approved principal and proving credential issuance")
 		if _, err := (&service.Recovery{DB: scratchDB}).Reconcile(ctx, principal); err != nil {
 			report.FailedStep = "reconcile"
 			return err

--- a/internal/app/backup_admission.go
+++ b/internal/app/backup_admission.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
 	"github.com/Hikyo-Org/hikyo/internal/buildcompat"
 	"github.com/Hikyo-Org/hikyo/internal/config"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -200,6 +201,7 @@ func withReconciliation(ctx context.Context, cfg *config.Config, fn func(reconci
 }
 
 func restoreOrdinaryPostgres(ctx context.Context, cfg *config.Config, sc store.Config, plain io.ReadSeeker, manifest store.Manifest, now time.Time) error {
+	defer diagnostics.Time(ctx, "restore data publication")()
 	return withBackupOperatorCustody(ctx, cfg, func(_ *upgradegate.OperatorCustody) error {
 		return restoreOrdinaryPostgresWithCustody(ctx, cfg, sc, plain, manifest, now)
 	})
@@ -265,6 +267,7 @@ func backupRestorePlans(ctx context.Context, cfg *config.Config, sc store.Config
 	return plans, nil
 }
 func restoreOrdinarySQLite(ctx context.Context, cfg *config.Config, sc store.Config, plain io.ReadSeeker, manifest store.Manifest, now time.Time) error {
+	defer diagnostics.Time(ctx, "restore data publication")()
 	return withBackupOperatorCustody(ctx, cfg, func(_ *upgradegate.OperatorCustody) error {
 		return restoreOrdinarySQLiteWithCustody(ctx, cfg, sc, plain, manifest, now)
 	})

--- a/internal/app/backup_diagnostics_test.go
+++ b/internal/app/backup_diagnostics_test.go
@@ -1,0 +1,191 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/config"
+	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
+	"github.com/Hikyo-Org/hikyo/internal/store"
+	gatefixture "github.com/Hikyo-Org/hikyo/internal/upgradegate/testfixture"
+)
+
+func TestBackupRestoreDiagnosticsLevels(t *testing.T) {
+	source := upgradeDrillDatabase(t, store.EngineSQLite)
+	_, material := gatefixture.PrepareWithMaterial(t, backupGateConfig(source), store.MigrationsFS, "migrations/sqlite", bytes.Repeat([]byte{61}, 32))
+	identity, recipient, err := backup.GenerateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identityPath := filepath.Join(t.TempDir(), "private-identity-path-sentinel")
+	if err := os.WriteFile(identityPath, []byte(identity), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		Dev: true, Store: config.Datastore{Engine: config.EngineSQLite, Path: source.Path, DSN: "private-dsn-sentinel"},
+		Upgrade:          config.UpgradeConfiguration{StateDirectory: filepath.Dir(filepath.Dir(material.Directory))},
+		BackupRecipients: []string{recipient},
+	}
+	for level := 0; level <= 3; level++ {
+		t.Run(fmt.Sprint(level), func(t *testing.T) {
+			var diagnostic, result bytes.Buffer
+			ctx := diagnostics.With(t.Context(), level, &diagnostic)
+			destination := t.TempDir()
+			if err := RunBackup(ctx, cfg, quietLogger(), []string{"export", "--out", destination}, &result, nil, nil); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(result.String(), "wrote ") || strings.Contains(result.String(), "hikyo:") {
+				t.Fatalf("export result changed: %s", result.String())
+			}
+			assertBackupDiagnostics(t, diagnostic.String(), level,
+				"backup: exporting and encrypting consistent snapshot", "encrypted_bytes=", "backup snapshot export and encryption elapsed=",
+				identity, recipient, source.Path, cfg.Store.DSN, destination, identityPath)
+			archives, err := filepath.Glob(filepath.Join(destination, "*.age"))
+			if err != nil || len(archives) != 1 {
+				t.Fatalf("expected one encrypted archive: %v, %v", archives, err)
+			}
+			diagnostic.Reset()
+			result.Reset()
+			target := upgradeDrillDatabase(t, store.EngineSQLite)
+			if err := RunRestore(ctx, backupTargetConfig(cfg, target), quietLogger(), []string{"run", "--from", archives[0], "--identity-file", identityPath}, &result, nil, nil); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(result.String(), "restored sqlite") || strings.Contains(result.String(), "hikyo:") {
+				t.Fatalf("restore result changed: %s", result.String())
+			}
+			assertBackupDiagnostics(t, diagnostic.String(), level,
+				"restore: decrypting and authenticating complete archive", "restore: engine=sqlite", "restore data publication elapsed=",
+				identity, recipient, source.Path, cfg.Store.DSN, destination, identityPath, target.Path)
+		})
+	}
+}
+
+func TestUpgradeDrillDiagnosticsLevels(t *testing.T) {
+	for level := 0; level <= 3; level++ {
+		t.Run(fmt.Sprint(level), func(t *testing.T) {
+			f := newUpgradeDrillFixture(t, store.EngineSQLite, true, true)
+			var diagnostic bytes.Buffer
+			root := crypto.EncodeRootKey(f.request.RootKey)
+			result, err := DrillUpgrade(diagnostics.With(t.Context(), level, &diagnostic), f.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.HierarchyReadable || result.SecretProof != "existing-secret-readable" || result.CredentialProof != "reconciled-minted-revoked" {
+				t.Fatalf("drill did not prove restored capability: %+v", result)
+			}
+			assertBackupDiagnostics(t, diagnostic.String(), level,
+				"upgrade drill: proving stored value readability", "upgrade drill: pending_principals=", "upgrade drill archive authentication elapsed=",
+				f.request.Unlock.Identity, root, "synthetic-never-output-secret", string(f.request.Principal), f.archive, f.request.Scratch.Path)
+		})
+	}
+}
+
+func TestUpgradeExportDiagnosticsPreserveJSON(t *testing.T) {
+	f := newUpgradeDrillFixture(t, store.EngineSQLite, true, true)
+	identity, recipient, err := backup.GenerateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Store: config.Datastore{Engine: config.EngineSQLite, Path: f.cfg.Path}, BackupRecipients: []string{recipient}}
+	trust := TrustContext{BundleDirectory: f.bundle.Directory, Pinned: f.bundle.Pinned, Target: f.bundle.Target, OperatorPin: f.request.Operator}
+	for level := 0; level <= 3; level++ {
+		t.Run(fmt.Sprint(level), func(t *testing.T) {
+			var diagnostic, output bytes.Buffer
+			destination := t.TempDir()
+			err := RunUpgradeBackup(diagnostics.With(t.Context(), level, &diagnostic), cfg, []string{"upgrade-export", "--out", destination, "--json"}, &output, trust)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result struct {
+				Ciphertext string `json:"ciphertext"`
+				Receipt    string `json:"receipt"`
+			}
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				t.Fatalf("verbose diagnostics corrupted JSON: %v", err)
+			}
+			for _, path := range []string{result.Ciphertext, result.Receipt} {
+				info, err := os.Stat(path)
+				if err != nil || info.Size() == 0 {
+					t.Fatalf("export result artifact missing: %v", err)
+				}
+			}
+			assertBackupDiagnostics(t, diagnostic.String(), level,
+				"upgrade backup: exporting encrypted snapshot and receipt", "upgrade backup: encrypted_bytes=", "upgrade backup snapshot export and encryption elapsed=",
+				identity, recipient, f.cfg.Path, f.request.Unlock.Identity, crypto.EncodeRootKey(f.root), destination, "synthetic-never-output-secret")
+		})
+	}
+}
+
+func TestRestoreDiagnosticsAuthenticationFailureStopsBeforeTarget(t *testing.T) {
+	identity, recipient, err := backup.GenerateIdentity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	identityPath := filepath.Join(dir, "private-identity-path-sentinel")
+	archivePath := filepath.Join(dir, "private-archive-path-sentinel")
+	if err := os.WriteFile(identityPath, []byte(identity), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var encrypted bytes.Buffer
+	w, err := backup.Encrypt(&encrypted, backup.Options{Recipients: []string{recipient}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("private-payload-sentinel")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archivePath, encrypted.Bytes()[:encrypted.Len()-1], 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Store: config.Datastore{Engine: config.EngineSQLite, Path: filepath.Join(dir, "must-not-exist.db")}}
+	var diagnostic, result bytes.Buffer
+	err = RunRestore(diagnostics.With(t.Context(), 3, &diagnostic), cfg, quietLogger(), []string{"run", "--from", archivePath, "--identity-file", identityPath}, &result, nil, nil)
+	if err == nil {
+		t.Fatal("truncated archive accepted")
+	}
+	for _, suffix := range []string{"", ".lock", "-wal", "-shm"} {
+		if _, err := os.Stat(cfg.Store.Path + suffix); !os.IsNotExist(err) {
+			t.Fatalf("failed authentication touched target: %v", err)
+		}
+	}
+	if result.Len() != 0 || strings.Contains(diagnostic.String(), "validating manifest") || strings.Contains(diagnostic.String(), "publishing data") || strings.Contains(diagnostic.String(), "restore complete") {
+		t.Fatalf("failed authentication advanced restore: result=%q diagnostics=%q", result.String(), diagnostic.String())
+	}
+	assertBackupDiagnostics(t, diagnostic.String(), 3,
+		"restore: decrypting and authenticating complete archive", "restore archive authentication elapsed=", "restore archive authentication elapsed=",
+		identity, recipient, identityPath, archivePath, "private-payload-sentinel")
+}
+
+func assertBackupDiagnostics(t *testing.T, output string, level int, phase, detail, timing string, private ...string) {
+	t.Helper()
+	if level == 0 && output != "" {
+		t.Fatalf("quiet command emitted diagnostics: %s", output)
+	}
+	for _, marker := range []struct {
+		text  string
+		level int
+	}{{phase, 1}, {detail, 2}, {timing, 3}} {
+		if strings.Contains(output, marker.text) != (level >= marker.level) {
+			t.Fatalf("level %d diagnostic marker %q mismatch: %s", level, marker.text, output)
+		}
+	}
+	if level < 3 && strings.Contains(output, "elapsed=") {
+		t.Fatalf("timing exposed below level 3: %s", output)
+	}
+	for _, value := range private {
+		if value != "" && strings.Contains(output, value) {
+			t.Fatal("diagnostics exposed private input")
+		}
+	}
+}

--- a/internal/app/backup_upgrade.go
+++ b/internal/app/backup_upgrade.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/filedurability"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
@@ -72,13 +73,18 @@ func runUpgradeExport(ctx context.Context, cfg *config.Config, args []string, ou
 	if _, err := options.UpgradeRecipientFingerprints(); err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 1, "upgrade backup: verifying release bundle")
+	bundleDone := diagnostics.Time(ctx, "upgrade backup release verification")
 	bundle, err := upgradebundle.Load(ctx, *bundleDir, trust.Pinned, trust.Floor)
+	bundleDone()
 	if err != nil {
 		return err
 	}
 	database := storeConfig(cfg)
 	sourceConfig := upgrade.Config{Engine: releaseidentity.Engine(database.Engine), Path: database.Path, DSN: database.DSN}
+	diagnostics.Printf(ctx, 1, "upgrade backup: waiting for datastore lock")
 	return upgrade.WithLock(ctx, sourceConfig, func(session *upgrade.Session) error {
+		diagnostics.Printf(ctx, 1, "upgrade backup: validating installed source and export authority")
 		plan, err := inspectBackupPlan(ctx, sourceConfig, bundle, trust.Target, trust.OperatorPin.InstanceID())
 		if err != nil {
 			return err
@@ -100,13 +106,19 @@ func runUpgradeExport(ctx context.Context, cfg *config.Config, args []string, ou
 			}
 			proposal = &value
 		}
+		diagnostics.Printf(ctx, 2, "upgrade backup: recipients=%d", len(options.Recipients))
+		diagnostics.Printf(ctx, 1, "upgrade backup: exporting encrypted snapshot and receipt")
+		exportDone := diagnostics.Time(ctx, "upgrade backup snapshot export and encryption")
 		exported, err := service.ExportPreparedUpgrade(ctx, db, options, *dir, plan, proposal)
+		exportDone()
 		if err != nil {
 			return err
 		}
 		if exported.Receipt == nil || exported.Receipt.Snapshot.InstanceID != trust.OperatorPin.InstanceID() {
 			return errors.New("exported source differs from current installation operator pin")
 		}
+		diagnostics.Printf(ctx, 2, "upgrade backup: encrypted_bytes=%d engine=%s schema=%d", exported.Bytes, exported.Manifest.Engine, exported.Manifest.SchemaVersion)
+		diagnostics.Printf(ctx, 1, "upgrade backup: export complete")
 		if *jsonOutput {
 			return json.NewEncoder(out).Encode(struct {
 				Ciphertext string `json:"ciphertext"`
@@ -154,6 +166,7 @@ func runUpgradeDrill(ctx context.Context, args []string, out io.Writer, trust Tr
 	if fs.NArg() != 0 || *bundleDir == "" || *source == "" || *receiptFile == "" || *identityFile == "" || *rootFile == "" || *dir == "" || *signingKey == "" || (*sqlitePath == "") == (*postgresFile == "") {
 		return errors.New("upgrade-drill requires bundle, archive, receipt, separate custody files, signer, output and exactly one empty scratch target")
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: verifying release bundle and receipt")
 	bundle, err := upgradebundle.Load(ctx, *bundleDir, trust.Pinned, trust.Floor)
 	if err != nil {
 		return err
@@ -183,7 +196,10 @@ func runUpgradeDrill(ctx context.Context, args []string, out io.Writer, trust Tr
 	if !plan.Valid() {
 		return errors.New("receipt source absent from authenticated bundle")
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: pinning encrypted archive")
+	pinDone := diagnostics.Time(ctx, "upgrade drill archive pinning")
 	pinned, err := backupreceipt.PinCiphertext(ctx, *source, "")
+	pinDone()
 	if err != nil {
 		return err
 	}
@@ -212,14 +228,19 @@ func runUpgradeDrill(ctx context.Context, args []string, out io.Writer, trust Tr
 	if err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: signing recovery attestation")
+	signDone := diagnostics.Time(ctx, "upgrade drill attestation signing")
 	signature, err := signUpgradeStatement(ctx, *signer, *signingKey, result.Attestation, trust.OperatorPin)
+	signDone()
 	if err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: publishing signed attestation")
 	statementPath, signaturePath, err := publishUpgradeAttestation(*dir, result.Attestation, signature)
 	if err != nil {
 		return err
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: signed recovery proof complete")
 	_, err = fmt.Fprintf(out, "hierarchy: verified existing wrappers\nsecret: %s\ncredential: %s\nattestation: %s\nsignature: %s\n", result.SecretProof, result.CredentialProof, statementPath, signaturePath)
 	return err
 }

--- a/internal/app/backup_upgrade_drill.go
+++ b/internal/app/backup_upgrade_drill.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
 	"github.com/Hikyo-Org/hikyo/internal/crypto/backup"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/service"
@@ -71,7 +72,11 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 	if err := store.VerifyEmbeddedUpgradeSource(request.Plan, request.Scratch.Engine); err != nil {
 		return UpgradeDrillResult{}, err
 	}
+	defer diagnostics.Time(ctx, "upgrade drill recovery proof")()
+	diagnostics.Printf(ctx, 1, "upgrade drill: decrypting and authenticating archive against receipt")
+	authDone := diagnostics.Time(ctx, "upgrade drill archive authentication")
 	authenticated, err := backupreceipt.AuthenticateArchive(ctx, request.Ciphertext, request.Receipt, request.Plan, request.Unlock, "")
+	authDone()
 	if err != nil {
 		return UpgradeDrillResult{}, err
 	}
@@ -80,6 +85,7 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 	if err != nil {
 		return UpgradeDrillResult{}, err
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: validating manifest and empty scratch target")
 	manifest, _, err := store.ReadManifestEvidence(plain)
 	if err != nil {
 		return UpgradeDrillResult{}, err
@@ -87,6 +93,8 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 	if err := checkRestorable(ctx, request.Scratch, manifest); err != nil {
 		return UpgradeDrillResult{}, err
 	}
+	diagnostics.Printf(ctx, 2, "upgrade drill: engine=%s schema=%d", manifest.Engine, manifest.SchemaVersion)
+	diagnostics.Printf(ctx, 1, "upgrade drill: restoring isolated scratch datastore")
 	switch request.Scratch.Engine {
 	case store.EngineSQLite:
 		if _, err := tx.RestoreUpgradeSQLite(ctx, plain, request.Scratch.Path, request.Plan, service.CompleteRestore(request.Now, manifest)); err != nil {
@@ -127,6 +135,7 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 		}
 		defer scratch.Close()
 		recovery := &service.Recovery{DB: scratch}
+		diagnostics.Printf(ctx, 1, "upgrade drill: verifying restored key hierarchy")
 		existing := &keyring.RecoveryStore{DB: scratch}
 		if err := crypto.VerifyExistingHierarchy(ctx, existing, slices.Clone(request.RootKey)); err != nil {
 			return fmt.Errorf("verify restored hierarchy: %w", err)
@@ -136,6 +145,7 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 			return fmt.Errorf("open restored keyring: %w", err)
 		}
 		result = UpgradeDrillResult{HierarchyReadable: true}
+		diagnostics.Printf(ctx, 1, "upgrade drill: proving stored value readability")
 		readable, err := recovery.ProveValuesReadable(ctx, kr)
 		switch {
 		case err == nil && readable:
@@ -149,6 +159,8 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 		if err != nil {
 			return fmt.Errorf("read restored status: %w", err)
 		}
+		diagnostics.Printf(ctx, 2, "upgrade drill: pending_principals=%d", len(status.Pending))
+		diagnostics.Printf(ctx, 1, "upgrade drill: proving restored credential capability")
 		if len(status.Pending) == 0 {
 			result.CredentialProof = "authoritatively-no-unreconciled-principal"
 		} else if request.AutoCredentialProof {
@@ -174,6 +186,7 @@ func DrillUpgrade(ctx context.Context, request UpgradeDrillRequest) (UpgradeDril
 	if err != nil {
 		return UpgradeDrillResult{}, err
 	}
+	diagnostics.Printf(ctx, 1, "upgrade drill: constructing recovery attestation")
 	now := request.Now.UTC().Truncate(time.Second)
 	if now.Before(source.CreatedAt) {
 		return UpgradeDrillResult{}, errors.New("attestation clock predates backup")

--- a/internal/app/maintenance.go
+++ b/internal/app/maintenance.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/config"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/server"
 )
 
@@ -32,6 +33,7 @@ func (s *Server) serveMaintenance(ctx context.Context, ready func()) error {
 	go func() { done <- httpServer.Serve(s.operationalLn) }()
 	operationalAddr := s.OperationalAddr
 	s.log.Warn("maintenance active; tenant serving unavailable; complete local upgrade or recovery and restart", "operational_addr", operationalAddr)
+	diagnostics.Printf(ctx, 1, "Maintenance listener is accepting status requests; tenant traffic remains disabled")
 	if ready != nil {
 		ready()
 	}

--- a/internal/app/runtime_serve.go
+++ b/internal/app/runtime_serve.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 )
 
 func (o *ownerRuntime) serve(ctx context.Context, ready func()) error {
@@ -23,6 +25,7 @@ func (o *ownerRuntime) serve(ctx context.Context, ready func()) error {
 	configDone := make(chan struct{})
 	go func() { defer close(configDone); o.selfConfig.Run(configCtx) }()
 	o.server.log.Info("server ready", "version", Version, "addr", address, "operational_addr", operationalAddress)
+	diagnostics.Printf(ctx, 1, "Server is accepting requests")
 	if ready != nil {
 		ready()
 	}

--- a/internal/app/startup_diagnostics_test.go
+++ b/internal/app/startup_diagnostics_test.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
+)
+
+func TestServerDiagnosticsLevelsAndReadiness(t *testing.T) {
+	for level := 0; level <= 3; level++ {
+		t.Run(fmt.Sprint(level), func(t *testing.T) {
+			cfg := devConfig(t)
+			cfg.Store.DSN = "postgres://operator:DSN_SECRET_SENTINEL@example.invalid/database"
+			var output bytes.Buffer
+			ctx := diagnostics.With(t.Context(), level, &output)
+			srv, err := Boot(ctx, cfg, testLogger())
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Boot has acquired sockets but ServeWithReady has not started them.
+			if strings.Contains(output.String(), "Server is accepting requests") {
+				_ = srv.Close()
+				t.Fatal("boot claimed serving readiness")
+			}
+			serveCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			if err := srv.ServeWithReady(serveCtx, cancel); err != nil {
+				t.Fatal(err)
+			}
+			logged := output.String()
+			if level == 0 {
+				if logged != "" {
+					t.Fatalf("default diagnostics: %q", logged)
+				}
+				return
+			}
+			for _, want := range []string{"Loading root key", "Opening admitted datastore", "Loading encryption keyring", "Resolving managed deployment configuration", "Preparing public and operational listeners", "Preparing runtime services and providers", "Server boot finished; listeners prepared", "Server is accepting requests"} {
+				if !strings.Contains(logged, want) {
+					t.Errorf("missing phase %q: %s", want, logged)
+				}
+			}
+			if strings.Contains(logged, "Datastore pools:") != (level >= 2) {
+				t.Errorf("wrong detail level: %s", logged)
+			}
+			if strings.Contains(logged, "server boot elapsed=") != (level >= 3) {
+				t.Errorf("wrong timing level: %s", logged)
+			}
+			root, err := os.ReadFile(devRootKeyPath(cfg))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, secret := range []string{"DSN_SECRET_SENTINEL", cfg.Store.DSN, cfg.Store.Path, strings.TrimSpace(string(root))} {
+				if secret != "" && strings.Contains(logged, secret) {
+					t.Fatal("diagnostics exposed configuration or key material")
+				}
+			}
+		})
+	}
+}
+
+func TestServerDiagnosticsDoNotClaimSuccessAfterListenerFailure(t *testing.T) {
+	var output bytes.Buffer
+	ctx := diagnostics.With(t.Context(), 3, &output)
+	resources := recordingBootResources(&bootResourceRecord{})
+	injected := errors.New("LISTENER_SECRET_SENTINEL")
+	resources.listen = func(string, string) (net.Listener, error) { return nil, injected }
+	_, err := boot(ctx, devConfig(t), testLogger(), resources)
+	if !errors.Is(err, injected) {
+		t.Fatalf("changed startup error: %v", err)
+	}
+	logged := output.String()
+	if !strings.Contains(logged, "Preparing public and operational listeners") {
+		t.Fatal("missing attempted phase")
+	}
+	for _, absent := range []string{"LISTENER_SECRET_SENTINEL", "Public and operational sockets are bound", "Preparing runtime services and providers", "Server boot finished", "Server is accepting requests"} {
+		if strings.Contains(logged, absent) {
+			t.Fatalf("unexpected diagnostic %q", absent)
+		}
+	}
+}
+
+func TestMigrateDiagnosticsLevelsAndNoOp(t *testing.T) {
+	for level := 0; level <= 3; level++ {
+		t.Run(fmt.Sprint(level), func(t *testing.T) {
+			cfg := devConfig(t)
+			cfg.Store.DSN = "postgres://operator:MIGRATE_SECRET_SENTINEL@example.invalid/db"
+			var output bytes.Buffer
+			ctx := diagnostics.With(t.Context(), level, &output)
+			if err := RunMigrate(ctx, cfg, testLogger()); err != nil {
+				t.Fatal(err)
+			}
+			logged := output.String()
+			if level == 0 && logged != "" {
+				t.Fatalf("default diagnostics: %q", logged)
+			}
+			if level > 0 {
+				for _, want := range []string{"Preparing explicit schema migration", "Verifying signed release bundle", "Applying schema migrations", "Verifying migrated schema", "Schema migration finished"} {
+					if !strings.Contains(logged, want) {
+						t.Errorf("missing phase %q: %s", want, logged)
+					}
+				}
+			}
+			if strings.Contains(logged, "engine=sqlite") != (level >= 2) {
+				t.Errorf("wrong detail level: %s", logged)
+			}
+			if strings.Contains(logged, "apply schema migrations elapsed=") != (level >= 3) {
+				t.Errorf("wrong timing level: %s", logged)
+			}
+			if strings.Contains(logged, "MIGRATE_SECRET_SENTINEL") || strings.Contains(logged, cfg.Store.Path) {
+				t.Fatal("configuration exposed")
+			}
+			output.Reset()
+			if err := RunMigrate(ctx, cfg, testLogger()); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(output.String(), "Applying schema migrations") {
+				t.Fatal("no-op migrate claimed to apply SQL")
+			}
+		})
+	}
+}
+
+func TestMigrateDiagnosticsRefusalDoesNotClaimWrites(t *testing.T) {
+	cfg := devConfig(t)
+	cfg.Dev = false
+	var output bytes.Buffer
+	err := RunMigrate(diagnostics.With(t.Context(), 3, &output), cfg, testLogger())
+	if err == nil {
+		t.Fatal("untrusted migration admitted")
+	}
+	for _, absent := range []string{"Applying schema migrations", "Schema migration finished"} {
+		if strings.Contains(output.String(), absent) {
+			t.Fatalf("refused migration claimed %q", absent)
+		}
+	}
+	if _, err := os.Stat(cfg.Store.Path); !os.IsNotExist(err) {
+		t.Fatal("refused migration created database", err)
+	}
+}

--- a/internal/app/upgrade_gate.go
+++ b/internal/app/upgrade_gate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/buildcompat"
 	"github.com/Hikyo-Org/hikyo/internal/config"
 	"github.com/Hikyo-Org/hikyo/internal/devupgrade"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/store"
 	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
@@ -21,6 +22,8 @@ import (
 // databaseGate is shared by server, local administration and explicit migration.
 // The returned opaque admission is the sole runtime datastore constructor input.
 func databaseGate(ctx context.Context, cfg *config.Config, root []byte, mode upgradegate.Mode) (upgradegate.Result, error) {
+	diagnostics.Printf(ctx, 1, "Preparing datastore admission and migration evidence")
+	defer diagnostics.Time(ctx, "datastore admission")()
 	request, cleanup, err := upgradeRequest(ctx, cfg, root, mode)
 	if err != nil {
 		return upgradegate.Result{}, err

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 )
 
 // Client is the origin-bound HTTP client.
@@ -108,7 +109,7 @@ func NewClient(entry TrustEntry, bearer string) (*Client, error) {
 		Entry:  entry,
 		Bearer: bearer,
 		HTTP: &http.Client{
-			Transport: transport,
+			Transport: diagnostics.Transport{Base: transport},
 			Timeout:   30 * time.Second,
 			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
 				return failf(ExitRefused,

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -47,7 +47,11 @@ func CommandPath(args []string) []string {
 // one at a time so `values set KEY --help` shows `values set`. It returns
 // false when not even the first word is a known command.
 func Help(w io.Writer, path []string) bool {
-	return HelpFromText(w, usageText, path)
+	if !HelpFromText(w, usageText, path) {
+		return false
+	}
+	fmt.Fprint(w, verbosityHelp)
+	return true
 }
 
 // HelpFromText is Help over an arbitrary usage text laid out like usageText.

--- a/internal/cli/import_wizard.go
+++ b/internal/cli/import_wizard.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
 	"github.com/Hikyo-Org/hikyo/internal/importer"
 )
@@ -30,6 +31,8 @@ import (
 // the interactive session under the aggregate session deadline and emits the
 // project's artifacts.
 func runImportWizard(ctx context.Context, ios IO, c commonFlags, outDir string) error {
+	diagnostics.Printf(ctx, 1, "import: resolving wizard target")
+	defer diagnostics.Time(ctx, "import wizard")()
 	st, err := NewState(ios.Env)
 	if err != nil {
 		return err
@@ -56,6 +59,7 @@ func runImportWizard(ctx context.Context, ios IO, c commonFlags, outDir string) 
 		terminalPrompter: newTerminalPrompter(ios),
 		ctx:              ctx, client: client, projectBase: projectBasePath,
 	}
+	diagnostics.Printf(ctx, 1, "import: gathering source and environment choices")
 	plan, err := importer.Wizard(host, projectID)
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
@@ -67,11 +71,19 @@ func runImportWizard(ctx context.Context, ios IO, c commonFlags, outDir string) 
 	if err := ctx.Err(); err != nil {
 		return failf(ExitRefused, "the import session exceeded its %s deadline before emitting artifacts", importer.SessionDeadline)
 	}
+	diagnostics.Printf(ctx, 1, "import: writing review artifacts")
+	diagnostics.Printf(ctx, 2, "import: planned environments=%d", len(plan.Envs))
+	writeDone := diagnostics.Time(ctx, "import artifact write")
 	valuesPaths, err := writeProjectArtifacts(ios, outDir, plan)
+	writeDone()
 	if err != nil {
 		return err
 	}
-	return reportProject(ios, plan, outDir, host.sourceFiles, valuesPaths)
+	if err := reportProject(ios, plan, outDir, host.sourceFiles, valuesPaths); err != nil {
+		return err
+	}
+	diagnostics.Printf(ctx, 1, "import: review artifacts ready; values have not been applied")
+	return nil
 }
 
 // cliWizardHost is the impure WizardHost the engine calls. It never prints an
@@ -90,6 +102,8 @@ type cliWizardHost struct {
 // ReadSource performs one connector read for a gathered selector, mapping the
 // wizard's Selector onto the same Run/RunLive the flag mode uses.
 func (h *cliWizardHost) ReadSource(source string, sel importer.Selector) (importer.SourceRead, error) {
+	diagnostics.Printf(h.ctx, 1, "import: reading and parsing source")
+	defer diagnostics.Time(h.ctx, "import source read and parse")()
 	if sel.Live {
 		res, err := importer.RunLive(h.ctx, source, importer.LiveInput{
 			Context: sel.Context, Namespace: sel.Namespace, Name: sel.Name,
@@ -98,6 +112,7 @@ func (h *cliWizardHost) ReadSource(source string, sel importer.Selector) (import
 		if err != nil {
 			return importer.SourceRead{}, err
 		}
+		diagnostics.Printf(h.ctx, 2, "import: parsed records=%d skipped=%d", len(res.Records), len(res.Skipped))
 		return importer.SourceRead{Result: res, EnvSlug: sel.EnvSlug}, nil
 	}
 	in, err := importer.ReadExport(sel.File)
@@ -109,16 +124,20 @@ func (h *cliWizardHost) ReadSource(source string, sel importer.Selector) (import
 	if err != nil {
 		return importer.SourceRead{}, err
 	}
+	diagnostics.Printf(h.ctx, 2, "import: parsed records=%d skipped=%d", len(res.Records), len(res.Skipped))
 	h.sourceFiles = append(h.sourceFiles, sel.File)
 	return importer.SourceRead{Result: res, FileDigest: importer.Digest(in.Data), EnvSlug: sel.EnvSlug}, nil
 }
 
 // ExistingEnvironments lists the project's environments the actor can read.
 func (h *cliWizardHost) ExistingEnvironments() ([]importer.NamedEnv, error) {
+	diagnostics.Printf(h.ctx, 1, "import: listing existing environments")
+	defer diagnostics.Time(h.ctx, "import environment list")()
 	var list apigen.EnvironmentList
 	if err := h.client.Do(h.ctx, http.MethodGet, h.projectBase+"/environments", nil, &list); err != nil {
 		return nil, err
 	}
+	diagnostics.Printf(h.ctx, 2, "import: existing environments=%d", len(list.Items))
 	out := make([]importer.NamedEnv, 0, len(list.Items))
 	for _, e := range list.Items {
 		out = append(out, importer.NamedEnv{ID: string(e.Id), Name: e.Name})
@@ -128,6 +147,9 @@ func (h *cliWizardHost) ExistingEnvironments() ([]importer.NamedEnv, error) {
 
 // Presence reads the server's occurrence answer for one existing environment.
 func (h *cliWizardHost) Presence(envID string, candidates []importer.PlannedCandidate) (importer.ServerState, error) {
+	diagnostics.Printf(h.ctx, 1, "import: checking existing values")
+	diagnostics.Printf(h.ctx, 2, "import: candidates=%d environments=1", len(candidates))
+	defer diagnostics.Time(h.ctx, "import presence check")()
 	var occurrences apigen.ValueOccurrenceList
 	if err := h.client.Do(h.ctx, http.MethodPost,
 		h.projectBase+"/environments/"+url.PathEscape(envID)+"/values/occurrences",
@@ -169,6 +191,9 @@ func occurrenceKeys(occurrences apigen.ValueOccurrenceList) []importer.KeyState 
 func runReplayMultiEnv(ctx context.Context, ios IO, client *Client, projectBase, projectID, source string,
 	result importer.Result, fileDigest, envSlug, sourcePath string, template *importer.Template,
 	candidates []importer.PlannedCandidate, outDir string) error {
+	diagnostics.Printf(ctx, 1, "import: checking replay environments")
+	diagnostics.Printf(ctx, 2, "import: candidates=%d environments=%d", len(candidates), len(template.Environments))
+	defer diagnostics.Time(ctx, "import multi-environment replay")()
 	in := importer.ProjectPlanInput{
 		Source: source, Project: projectID, Template: template,
 	}
@@ -198,11 +223,16 @@ func runReplayMultiEnv(ctx context.Context, ios IO, client *Client, projectBase,
 		}
 		in.Envs = append(in.Envs, env)
 	}
+	diagnostics.Printf(ctx, 1, "import: building artifact plan")
 	plan, err := importer.BuildProjectPlan(in)
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
 	}
+	diagnostics.Printf(ctx, 1, "import: writing review artifacts")
+	diagnostics.Printf(ctx, 2, "import: planned environments=%d", len(plan.Envs))
+	writeDone := diagnostics.Time(ctx, "import artifact write")
 	valuesPaths, err := writeProjectArtifacts(ios, outDir, plan)
+	writeDone()
 	if err != nil {
 		return err
 	}
@@ -210,7 +240,11 @@ func runReplayMultiEnv(ctx context.Context, ios IO, client *Client, projectBase,
 	if sourcePath != "" {
 		sources = []string{sourcePath}
 	}
-	return reportProject(ios, plan, outDir, sources, valuesPaths)
+	if err := reportProject(ios, plan, outDir, sources, valuesPaths); err != nil {
+		return err
+	}
+	diagnostics.Printf(ctx, 1, "import: review artifacts ready; values have not been applied")
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cli/importer.go
+++ b/internal/cli/importer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Hikyo-Org/hikyo/api/apigen"
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
 	"github.com/Hikyo-Org/hikyo/internal/dotenv"
 	"github.com/Hikyo-Org/hikyo/internal/importer"
@@ -61,6 +62,8 @@ const (
 )
 
 func runImport(ctx context.Context, ios IO, args []string) error {
+	diagnostics.Printf(ctx, 1, "import: preparing source import")
+	defer diagnostics.Time(ctx, "source import")()
 	c, err := commonFlagsForOperation("import")
 	if err != nil {
 		return err
@@ -171,6 +174,7 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 			return failf(ExitUsage,
 				"hikyo import --mapping takes its target, mode and source selectors from the template; remove selector overrides")
 		}
+		diagnostics.Printf(ctx, 1, "import: reading mapping template")
 		raw, err := importer.ReadFile(*mapping)
 		if err != nil {
 			return failf(ExitUsage, "reading the mapping template: %v", err)
@@ -208,6 +212,8 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 	// The foreign source is read BEFORE the Hikyo session is touched, so a
 	// caller who names an invalid source or exceeds a connector bound hears
 	// about it without a Hikyo round trip carrying anything.
+	diagnostics.Printf(ctx, 1, "import: reading and parsing source")
+	readDone := diagnostics.Time(ctx, "import source read and parse")
 	var in importer.Input
 	var result importer.Result
 	sourcePath := ""
@@ -219,16 +225,20 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 	} else {
 		in, err = importer.ReadExport(*file)
 		if err != nil {
+			readDone()
 			return failf(ExitUsage, "reading the export: %v", err)
 		}
 		in.EnvSlug = *envSlug
 		result, err = importer.Run(ctx, source, in)
 		sourcePath = *file
 	}
+	readDone()
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
 	}
 
+	diagnostics.Printf(ctx, 2, "import: parsed records=%d skipped=%d", len(result.Records), len(result.Skipped))
+	diagnostics.Printf(ctx, 1, "import: preparing candidate plan")
 	// The rename transform runs BEFORE the server is asked anything: the
 	// presence read mints a token per candidate key, and it cannot do that
 	// without knowing which names this run will propose.
@@ -247,6 +257,7 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 		return failf(ExitRefused, "%v", err)
 	}
 
+	diagnostics.Printf(ctx, 1, "import: resolving authenticated target")
 	st, err := NewState(ios.Env)
 	if err != nil {
 		return err
@@ -280,6 +291,8 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 
 	// Phase 1's only server contact: read-only,
 	// `read@project AND read@environment`, no reveal, no comparison, no write.
+	diagnostics.Printf(ctx, 1, "import: checking existing values")
+	diagnostics.Printf(ctx, 2, "import: candidates=%d environments=1", len(candidates))
 	var occurrences apigen.ValueOccurrenceList
 	if err := client.Do(ctx, http.MethodPost,
 		project+"/environments/"+url.PathEscape(envID)+"/values/occurrences",
@@ -294,16 +307,24 @@ func runImport(ctx context.Context, ios IO, args []string) error {
 		Keys:                occurrenceKeys(occurrences),
 	}
 
+	diagnostics.Printf(ctx, 1, "import: building artifact plan")
 	plan, err := importer.BuildPlan(planIn)
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
 	}
 
+	diagnostics.Printf(ctx, 1, "import: writing review artifacts")
+	writeDone := diagnostics.Time(ctx, "import artifact write")
 	valuesPath, err := writeArtifacts(ios, *outDir, envID, plan)
+	writeDone()
 	if err != nil {
 		return err
 	}
-	return reportImport(ios, plan, result.Resolution, sourcePath, valuesPath, *outDir)
+	if err := reportImport(ios, plan, result.Resolution, sourcePath, valuesPath, *outDir); err != nil {
+		return err
+	}
+	diagnostics.Printf(ctx, 1, "import: review artifacts ready; values have not been applied")
+	return nil
 }
 
 func wireImportCandidates(in []importer.PlannedCandidate) []apigen.ValueOccurrenceCandidate {
@@ -538,6 +559,8 @@ func validateImportArtifactTargets(values importer.ValuesFile, project, env stri
 // movement rejects those keys by name. Without it, the verb behaves exactly as
 // locked.
 func runValuesImport(ctx context.Context, ios IO, args []string) error {
+	diagnostics.Printf(ctx, 1, "values import: preparing import")
+	defer diagnostics.Time(ctx, "values import")()
 	var valuesFile, manifestPath, overwrite, format, fromDotenv string
 	st, flags, err := parseCommon("values import", ios, args, func(fs *flag.FlagSet) {
 		fs.StringVar(&format, "o", "table", "output format: table or json")
@@ -578,15 +601,21 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 			"usage: hikyo values import --env <e> (--file <values-file> | --from-dotenv <.env>) [--manifest <run-manifest.json>] [--overwrite KEY,KEY]")
 	}
 
+	diagnostics.Printf(ctx, 1, "values import: reading and parsing values file")
+	parseDone := diagnostics.Time(ctx, "values import read and parse")
 	raw, err := importer.ReadFile(valuesFile)
 	if err != nil {
+		parseDone()
 		return failf(ExitUsage, "reading the values file: %v", err)
 	}
 	values, err := importer.ParseValuesFile(raw)
+	parseDone()
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
 	}
 
+	diagnostics.Printf(ctx, 2, "values import: entries=%d", len(values.Entries))
+	diagnostics.Printf(ctx, 1, "values import: validating import preconditions")
 	body := apigen.ImportValuesRequest{}
 	for _, e := range values.Entries {
 		body.Entries = append(body.Entries, struct {
@@ -619,6 +648,7 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 	// file is not part of. The project cross-check needs no server contact.
 	var manifest *importer.Manifest
 	if manifestPath != "" {
+		diagnostics.Printf(ctx, 1, "values import: reading and validating run manifest")
 		rawManifest, err := importer.ReadFile(manifestPath)
 		if err != nil {
 			return failf(ExitUsage, "reading the run manifest: %v", err)
@@ -770,11 +800,16 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 		}
 	}
 
+	diagnostics.Printf(ctx, 1, "values import: applying values")
+	applyDone := diagnostics.Time(ctx, "values import apply")
 	var result apigen.ImportValuesResult
 	if err := client.Do(ctx, http.MethodPost,
 		project+"/environments/"+url.PathEscape(env)+"/values/import", body, &result); err != nil {
+		applyDone()
 		return err
 	}
+	applyDone()
+	diagnostics.Printf(ctx, 2, "values import: imported=%d skipped=%d", len(result.Imported), len(result.Skipped))
 	warnFindings(ios, result.Findings)
 	// The manifest's phase-completion marker is what lets a resumed migration
 	// know where it stopped, so a run that completed says so. `applied` stays
@@ -788,7 +823,9 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 		if createdEnvFile {
 			ref = values.EnvironmentName
 		}
+		diagnostics.Printf(ctx, 1, "values import: updating run manifest")
 		if err := markImported(manifestPath, ref); err != nil {
+			diagnostics.Printf(ctx, 1, "values import: values applied; run manifest update failed")
 			fmt.Fprintf(ios.Stderr,
 				"the import landed, but the run manifest could not be updated (%v); "+
 					"a resumed migration will read it as not yet imported\n", err)
@@ -809,7 +846,11 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 	for _, k := range result.Skipped {
 		rows = append(rows, []string{k, "skipped"})
 	}
-	return Render(ios.Stdout, f, Table{Columns: []string{"KEY", "OUTCOME"}, Rows: rows, JSON: result})
+	if err := Render(ios.Stdout, f, Table{Columns: []string{"KEY", "OUTCOME"}, Rows: rows, JSON: result}); err != nil {
+		return err
+	}
+	diagnostics.Printf(ctx, 1, "values import: complete")
+	return nil
 }
 
 // runValuesImportDotenv stages a raw `.env` through the SAME strict server path
@@ -820,15 +861,21 @@ func runValuesImport(ctx context.Context, ios IO, args []string) error {
 // cross argv — only the file path does — and after a successful import the
 // operator is warned that the source `.env` is still plaintext on disk.
 func runValuesImportDotenv(ctx context.Context, ios IO, st *State, flags commonFlags, f Format, path string) error {
+	diagnostics.Printf(ctx, 1, "values import: reading and parsing dotenv source")
+	parseDone := diagnostics.Time(ctx, "values import read and parse")
 	raw, err := os.ReadFile(path)
 	if err != nil {
+		parseDone()
 		return failf(ExitUsage, "reading %s: %v", path, err)
 	}
 	entries, err := dotenv.Parse(raw)
+	parseDone()
 	if err != nil {
 		return failf(ExitRefused, "%v", err)
 	}
 
+	diagnostics.Printf(ctx, 2, "values import: entries=%d", len(entries))
+	diagnostics.Printf(ctx, 1, "values import: resolving authenticated target")
 	body := apigen.ImportValuesRequest{}
 	for _, e := range entries {
 		body.Entries = append(body.Entries, struct {
@@ -850,11 +897,16 @@ func runValuesImportDotenv(ctx context.Context, ios IO, st *State, flags commonF
 		return err
 	}
 
+	diagnostics.Printf(ctx, 1, "values import: applying values")
+	applyDone := diagnostics.Time(ctx, "values import apply")
 	var result apigen.ImportValuesResult
 	if err := client.Do(ctx, http.MethodPost,
 		project+"/environments/"+url.PathEscape(env)+"/values/import", body, &result); err != nil {
+		applyDone()
 		return err
 	}
+	applyDone()
+	diagnostics.Printf(ctx, 2, "values import: imported=%d skipped=%d", len(result.Imported), len(result.Skipped))
 	warnFindings(ios, result.Findings)
 	if len(result.Skipped) > 0 {
 		sorted := append([]string{}, result.Skipped...)
@@ -871,7 +923,11 @@ func runValuesImportDotenv(ctx context.Context, ios IO, st *State, flags commonF
 	for _, k := range result.Skipped {
 		rows = append(rows, []string{k, "skipped"})
 	}
-	return Render(ios.Stdout, f, Table{Columns: []string{"KEY", "OUTCOME"}, Rows: rows, JSON: result})
+	if err := Render(ios.Stdout, f, Table{Columns: []string{"KEY", "OUTCOME"}, Rows: rows, JSON: result}); err != nil {
+		return err
+	}
+	diagnostics.Printf(ctx, 1, "values import: complete")
+	return nil
 }
 
 // markImported rewrites a run manifest with this environment's completion

--- a/internal/cli/importer_diagnostics_test.go
+++ b/internal/cli/importer_diagnostics_test.go
@@ -1,0 +1,240 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/cli"
+	"github.com/Hikyo-Org/hikyo/internal/importer"
+)
+
+func importDiagnosticLines(output string) string {
+	var lines []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "hikyo: ") {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestValuesImportDiagnostics(t *testing.T) {
+	for _, mode := range []string{"artifact", "dotenv"} {
+		for level := 0; level <= 3; level++ {
+			t.Run(fmt.Sprintf("%s/level%d", mode, level), func(t *testing.T) {
+				calls := 0
+				ios, stdout, stderr := definitionsTestIO(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/values/import") {
+						t.Errorf("unexpected request: %s", r.Method)
+						http.NotFound(w, r)
+						return
+					}
+					calls++
+					var body apigen.ImportValuesRequest
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Error(err)
+						return
+					}
+					if len(body.Entries) != 1 || body.Entries[0].Value != "value-sentinel" {
+						t.Errorf("incorrect import payload")
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(apigen.ImportValuesResult{Imported: []string{"SECRET_SENTINEL"}})
+				}))
+				path := filepath.Join(t.TempDir(), "path-sentinel")
+				var data []byte
+				flag := "--file"
+				if mode == "dotenv" {
+					flag = "--from-dotenv"
+					data = []byte("SECRET_SENTINEL=value-sentinel\n")
+				} else {
+					var err error
+					data, err = importer.Encode(importer.ValuesFile{FormatVersion: importer.FormatVersion, Project: "prj_70", Environment: "env_70", Entries: []importer.ValuesEntry{{Key: "SECRET_SENTINEL", Value: "value-sentinel"}}})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := os.WriteFile(path, data, 0600); err != nil {
+					t.Fatal(err)
+				}
+				args := []string{"values", "import", flag, path, "--instance", "local", "--org", "org_70", "--project", "prj_70", "--env", "env_70", "-o", "json"}
+				if level > 0 {
+					args = append([]string{"-" + strings.Repeat("v", level)}, args...)
+				}
+				if code := cli.Run(t.Context(), ios, args); code != cli.ExitOK {
+					t.Fatalf("exit %d: %s", code, stderr.String())
+				}
+				if calls != 1 {
+					t.Fatalf("imports=%d", calls)
+				}
+				var result apigen.ImportValuesResult
+				if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+					t.Fatalf("stdout is not JSON: %v", err)
+				}
+				if len(result.Imported) != 1 || result.Imported[0] != "SECRET_SENTINEL" {
+					t.Fatalf("stdout changed: %s", stdout.String())
+				}
+				output := importDiagnosticLines(stderr.String())
+				for _, secret := range []string{"SECRET_SENTINEL", "value-sentinel", "path-sentinel", "env_70", "prj_70", "test-token"} {
+					if strings.Contains(output, secret) {
+						t.Fatalf("diagnostic leaked %q: %s", secret, output)
+					}
+				}
+				if level == 0 {
+					if output != "" {
+						t.Fatalf("default diagnostics: %s", output)
+					}
+					return
+				}
+				for _, phase := range []string{"values import: preparing import", "values import: reading and parsing", "values import: applying values", "values import: complete"} {
+					if !strings.Contains(output, phase) {
+						t.Errorf("missing phase %q: %s", phase, output)
+					}
+				}
+				if strings.Contains(output, "entries=1") != (level >= 2) {
+					t.Errorf("wrong detail level: %s", output)
+				}
+				if strings.Contains(output, "values import apply elapsed=") != (level >= 3) {
+					t.Errorf("wrong timing level: %s", output)
+				}
+			})
+		}
+	}
+}
+
+func TestValuesImportDiagnosticsStopOnFailure(t *testing.T) {
+	for _, failure := range []string{"parse", "apply"} {
+		t.Run(failure, func(t *testing.T) {
+			calls := 0
+			ios, stdout, stderr := definitionsTestIO(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"error":{"code":"undeclared_key","message":"rejected"}}`))
+			}))
+			body := "SECRET_SENTINEL=value-sentinel\n"
+			if failure == "parse" {
+				body = "invalid dotenv line"
+			}
+			path := filepath.Join(t.TempDir(), "path-sentinel")
+			if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+				t.Fatal(err)
+			}
+			code := cli.Run(t.Context(), ios, []string{"-vvv", "values", "import", "--from-dotenv", path, "--instance", "local", "--org", "org_70", "--project", "prj_70", "--env", "env_70"})
+			if code == cli.ExitOK {
+				t.Fatal("failed import succeeded")
+			}
+			output := importDiagnosticLines(stderr.String())
+			if strings.Contains(output, "values import: complete") || strings.Contains(output, "values import: imported=") {
+				t.Fatalf("false completion: %s", output)
+			}
+			if failure == "parse" && (calls != 0 || strings.Contains(output, "values import: applying values")) {
+				t.Fatalf("parse error reached apply: calls=%d %s", calls, output)
+			}
+			if failure == "apply" && calls != 1 {
+				t.Fatalf("apply calls=%d", calls)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("failure emitted stdout: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestSourceImportDiagnosticsAuthorArtifacts(t *testing.T) {
+	for level := 0; level <= 3; level++ {
+		t.Run(fmt.Sprintf("level%d", level), func(t *testing.T) {
+			calls := 0
+			ios, stdout, stderr := definitionsTestIO(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if !strings.HasSuffix(r.URL.Path, "/values/occurrences") {
+					t.Errorf("import attempted non-presence request")
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"definitions_revision":0,"items":[{"name":"SECRET_SENTINEL","declared":false,"set":false,"token":"occurrence-sentinel"}]}`))
+			}))
+			source := filepath.Join(t.TempDir(), "source-path-sentinel")
+			if err := os.WriteFile(source, []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: source-sentinel\nstringData:\n  SECRET_SENTINEL: value-sentinel\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			outDir := filepath.Join(t.TempDir(), "artifacts")
+			args := []string{"import", "--from", "k8s", "--file", source, "--out-dir", outDir, "--instance", "local", "--org", "org_70", "--project", "prj_70", "--environment", "env_70"}
+			if level > 0 {
+				args = append([]string{"-" + strings.Repeat("v", level)}, args...)
+			}
+			if code := cli.Run(t.Context(), ios, args); code != cli.ExitOK {
+				t.Fatalf("exit=%d: %s", code, stderr.String())
+			}
+			if calls != 1 {
+				t.Fatalf("presence requests=%d", calls)
+			}
+			if !strings.Contains(stdout.String(), "definitions-bundle.json") {
+				t.Fatalf("artifact report missing: %s", stdout.String())
+			}
+			values, err := os.ReadFile(filepath.Join(outDir, "values-env_70.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(values), "value-sentinel") {
+				t.Fatal("values artifact lost source value")
+			}
+			output := importDiagnosticLines(stderr.String())
+			for _, secret := range []string{"SECRET_SENTINEL", "value-sentinel", "source-path-sentinel", "source-sentinel", "env_70", "prj_70", "test-token"} {
+				if strings.Contains(output, secret) {
+					t.Fatalf("leaked %q: %s", secret, output)
+				}
+			}
+			if level == 0 {
+				if output != "" {
+					t.Fatalf("default diagnostics: %s", output)
+				}
+				return
+			}
+			for _, phase := range []string{"import: reading and parsing source", "import: checking existing values", "import: writing review artifacts", "import: review artifacts ready; values have not been applied"} {
+				if !strings.Contains(output, phase) {
+					t.Errorf("missing %q: %s", phase, output)
+				}
+			}
+			if strings.Contains(output, "parsed records=1") != (level >= 2) {
+				t.Errorf("wrong detail level: %s", output)
+			}
+			if strings.Contains(output, "import artifact write elapsed=") != (level >= 3) {
+				t.Errorf("wrong timing level: %s", output)
+			}
+		})
+	}
+}
+
+func TestSourceImportDiagnosticsStopOnParsingFailure(t *testing.T) {
+	calls := 0
+	ios, stdout, stderr := definitionsTestIO(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { calls++; http.NotFound(w, r) }))
+	source := filepath.Join(t.TempDir(), "source-path-sentinel")
+	if err := os.WriteFile(source, []byte("invalid source document"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(t.TempDir(), "artifacts")
+	code := cli.Run(t.Context(), ios, []string{"-vvv", "import", "--from", "k8s", "--file", source, "--out-dir", outDir, "--instance", "local", "--org", "org_70", "--project", "prj_70", "--environment", "env_70"})
+	if code == cli.ExitOK {
+		t.Fatal("invalid source succeeded")
+	}
+	output := importDiagnosticLines(stderr.String())
+	for _, phase := range []string{"import: preparing candidate plan", "import: resolving authenticated target", "import: writing review artifacts", "import: review artifacts ready"} {
+		if strings.Contains(output, phase) {
+			t.Errorf("failed source reached %q: %s", phase, output)
+		}
+	}
+	if calls != 0 || stdout.Len() != 0 {
+		t.Fatalf("failed source made requests=%d stdout=%q", calls, stdout.String())
+	}
+	if _, err := os.Stat(outDir); !os.IsNotExist(err) {
+		t.Fatalf("failed source created artifact directory: %v", err)
+	}
+}

--- a/internal/cli/testdata/help.txt
+++ b/internal/cli/testdata/help.txt
@@ -338,3 +338,9 @@ target resolution, per dimension, first hit wins:
 exit codes:
   0 success   1 internal   2 usage   3 authentication   4 refused
   5 not found (also unauthorized - indistinguishable by design)   6 unavailable
+
+global diagnostics (stderr only):
+  -v, --verbose                        phases and progress; repeat for more detail
+  -vv                                  artifact and HTTP request details
+  -vvv                                 timings as well (maximum level)
+  put verbosity before other options; arguments after -- are untouched

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/console"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/selfupdate"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
 	"github.com/gofrs/flock"
@@ -173,10 +174,13 @@ func updateSource(ios IO) (updatecheck.Source, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.Transport = diagnostics.Transport{Base: client.Transport}
 	return updatecheck.NewGitHubSource(client), nil
 }
 
 func refreshReleaseSnapshot(ctx context.Context, ios IO) error {
+	diagnostics.Printf(ctx, 1, "refreshing release metadata")
+	defer diagnostics.Time(ctx, "refresh release metadata")()
 	state, err := NewState(ios.Env)
 	if err != nil {
 		return err
@@ -206,6 +210,7 @@ func refreshReleaseSnapshot(ctx context.Context, ios IO) error {
 		}
 		current.CheckedAt = ios.now().UTC()
 		current.Releases = releases
+		diagnostics.Printf(ctx, 2, "release metadata contains %d releases", len(releases))
 		return state.putUpdatesUnlocked(current)
 	})
 }
@@ -267,6 +272,7 @@ func promptAndApplyUpdate(ctx context.Context, ios IO, status updatecheck.Status
 	if ios.BinaryUpdater == nil {
 		return false, errors.New("binary updater is unavailable")
 	}
+	diagnostics.Printf(ctx, 1, "applying verified CLI update")
 	if err := ios.BinaryUpdater.Apply(ctx, status); err != nil {
 		var staged *selfupdate.StagedNightly
 		if errors.As(err, &staged) {

--- a/internal/cli/verbosity.go
+++ b/internal/cli/verbosity.go
@@ -1,0 +1,56 @@
+package cli
+
+import "strings"
+
+// ParseVerbosity removes repeatable -v/--verbose options and -vv/-vvv groups.
+// Options may precede the command or follow command words. A non-verbosity
+// option without '=' and its next argument remain untouched because the next
+// argument may be a value, including a literal '-v'. Place verbosity before
+// other options to avoid ambiguity after boolean flags. Nothing after '--' is
+// interpreted, including the child command of hikyo run.
+func ParseVerbosity(args []string) ([]string, int) {
+	remaining := make([]string, 0, len(args))
+	level := 0
+	previousMayTakeValue := false
+	for i, arg := range args {
+		if arg == "--" {
+			remaining = append(remaining, args[i:]...)
+			break
+		}
+		count := 0
+		if arg == "--verbose" {
+			count = 1
+		} else if strings.HasPrefix(arg, "-v") && strings.Trim(arg[1:], "v") == "" {
+			count = len(arg) - 1
+		}
+		if count > 0 && !previousMayTakeValue {
+			level = min(3, level+count)
+			continue
+		}
+		remaining = append(remaining, arg)
+		// Inspect every preserved token, including possible option values.
+		// A boolean followed by a value-taking option must not hide that
+		// second option and cause its '-v' value to be consumed.
+		previousMayTakeValue = strings.HasPrefix(arg, "-") && arg != "-" && !strings.Contains(arg, "=")
+	}
+	return remaining, level
+}
+
+// WithVerbosityArguments carries the diagnostic level across process handoffs.
+// Leading options cannot be confused with values owned by the child command.
+func WithVerbosityArguments(args []string, level int) []string {
+	if level <= 0 {
+		return args
+	}
+	return append([]string{"-" + strings.Repeat("v", min(3, level))}, args...)
+}
+
+const verbosityHelp = `global diagnostics (stderr only):
+  -v, --verbose                        phases and progress; repeat for more detail
+  -vv                                  artifact and HTTP request details
+  -vvv                                 timings as well (maximum level)
+  put verbosity before other options; arguments after -- are untouched
+`
+
+// VerbosityHelp describes global diagnostics for host and client help.
+func VerbosityHelp() string { return verbosityHelp }

--- a/internal/cli/verbosity_test.go
+++ b/internal/cli/verbosity_test.go
@@ -1,0 +1,87 @@
+package cli_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/cli"
+)
+
+func TestParseVerbosityPreservesCommandArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		args, want []string
+		level      int
+	}{
+		{"leading", []string{"-vv", "upgrade"}, []string{"upgrade"}, 2},
+		{"repeated", []string{"--verbose", "upgrade", "-v", "--verbose"}, []string{"upgrade"}, 3},
+		{"saturates", []string{"-vvvv", "upgrade", "-vv"}, []string{"upgrade"}, 3},
+		{"command level", []string{"upgrade", "--target", "v1.2.3", "-vvv"}, []string{"upgrade", "--target", "v1.2.3"}, 3},
+		{"value looks verbose", []string{"values", "set", "--value", "-v"}, []string{"values", "set", "--value", "-v"}, 0},
+		{"ambiguous option chain", []string{"values", "set", "--value", "--verbose", "-vv"}, []string{"values", "set", "--value", "--verbose", "-vv"}, 0},
+		{"equals value", []string{"upgrade", "--target=-v", "-vv"}, []string{"upgrade", "--target=-v"}, 2},
+		{"unknown short option", []string{"values", "-x", "-vv"}, []string{"values", "-x", "-vv"}, 0},
+		{"mixed short group", []string{"upgrade", "-vx"}, []string{"upgrade", "-vx"}, 0},
+		{"passthrough", []string{"run", "-v", "--", "command", "--verbose", "-vvv"}, []string{"run", "--", "command", "--verbose", "-vvv"}, 1},
+		{"boundary after option", []string{"run", "--use-human-session", "--", "command", "-vv"}, []string{"run", "--use-human-session", "--", "command", "-vv"}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original := slices.Clone(tc.args)
+			got, level := cli.ParseVerbosity(tc.args)
+			if level != tc.level || !slices.Equal(got, tc.want) {
+				t.Fatalf("arguments=%q level=%d, want %q level=%d", got, level, tc.want, tc.level)
+			}
+			if !slices.Equal(tc.args, original) {
+				t.Fatal("mutated caller arguments")
+			}
+		})
+	}
+}
+
+func TestVerboseRunKeepsJSONOnStdout(t *testing.T) {
+	for _, level := range []string{"", "-v", "-vv", "-vvv"} {
+		t.Run(level, func(t *testing.T) {
+			ios, stdout, stderr := testIO(t, nil)
+			args := []string{"context", "list", "-o", "json"}
+			if level != "" {
+				args = append([]string{level}, args...)
+			}
+			if code := cli.Run(t.Context(), ios, args); code != cli.ExitOK {
+				t.Fatalf("exit=%d stderr=%s", code, stderr)
+			}
+			golden(t, "context-list-empty.json", stdout.Bytes())
+			if level == "" && stderr.Len() != 0 {
+				t.Fatalf("default diagnostics: %s", stderr)
+			}
+			if level != "" && !strings.Contains(stderr.String(), "starting context") {
+				t.Fatalf("missing phase: %s", stderr)
+			}
+			if got := strings.Contains(stderr.String(), "elapsed="); got != (level == "-vvv") {
+				t.Fatalf("timing visibility: %s", stderr)
+			}
+		})
+	}
+}
+
+func TestVerboseHelpRemainsSideEffectFree(t *testing.T) {
+	ios, stdout, stderr := testIO(t, nil)
+	ios.Env = cli.Env{Getenv: func(string) string { t.Fatal("help accessed environment"); return "" }}
+	if code := cli.Run(t.Context(), ios, []string{"-vvv", "update", "--help"}); code != cli.ExitOK {
+		t.Fatalf("exit=%d", code)
+	}
+	if stderr.Len() != 0 || !strings.Contains(stdout.String(), "-vvv") {
+		t.Fatalf("stdout=%s stderr=%s", stdout, stderr)
+	}
+}
+
+func TestVerbositySurvivesProcessHandoff(t *testing.T) {
+	args := []string{"backup", "upgrade-export", "--json", "--output", "-v"}
+	for level := 0; level <= 3; level++ {
+		forwarded := cli.WithVerbosityArguments(args, level)
+		parsed, got := cli.ParseVerbosity(forwarded)
+		if got != level || !slices.Equal(parsed, args) {
+			t.Fatalf("handoff arguments=%q level=%d", parsed, got)
+		}
+	}
+}

--- a/internal/cli/verbs.go
+++ b/internal/cli/verbs.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Hikyo-Org/hikyo/api"
 	"github.com/Hikyo-Org/hikyo/api/apigen"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/disclose"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
 )
@@ -122,6 +123,8 @@ func (ios IO) prepareDisclosure(options disclose.Options) (*disclose.PreparedSin
 // Run dispatches one invocation and returns its exit code.
 func Run(ctx context.Context, io IO, args []string) int {
 	defer io.TerminalSession.Close()
+	args, verbosity := ParseVerbosity(args)
+	ctx = diagnostics.With(ctx, diagnostics.Level(ctx)+verbosity, io.Stderr)
 	if len(args) == 0 {
 		Usage(io.Stderr)
 		return ExitUsage
@@ -147,6 +150,8 @@ func Run(ctx context.Context, io IO, args []string) int {
 			return ExitOK
 		}
 	}
+	diagnostics.Printf(ctx, 1, "starting %s", verb)
+	defer diagnostics.Time(ctx, verb)()
 	return Report(io.Stderr, handler(ctx, io, rest))
 }
 
@@ -197,6 +202,8 @@ var verbHandlers = map[string]func(context.Context, IO, []string) error{
 // is reviewed like a spec change.
 func Usage(w io.Writer) {
 	fmt.Fprint(w, usageText)
+	fmt.Fprintln(w)
+	fmt.Fprint(w, verbosityHelp)
 }
 
 // usageText is the frozen help text Usage prints and Help slices per command

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -1,0 +1,93 @@
+// Package diagnostics provides opt-in, command-scoped progress on stderr.
+// Callers must supply only public operational metadata, never credentials,
+// command arguments, environments, request bodies, or unfiltered errors.
+package diagnostics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type contextKey struct{}
+
+type output struct {
+	level  int
+	writer io.Writer
+	mu     sync.Mutex
+}
+
+// With enables up to three cumulative levels: phases, details, and timings.
+// A nil writer discards diagnostics. Child contexts retain cancellation.
+func With(ctx context.Context, level int, out io.Writer) context.Context {
+	if out == nil {
+		out = io.Discard
+	}
+	return context.WithValue(ctx, contextKey{}, &output{level: min(3, max(0, level)), writer: out})
+}
+
+// Level returns zero when diagnostics have not been enabled.
+func Level(ctx context.Context) int {
+	if out, ok := ctx.Value(contextKey{}).(*output); ok {
+		return out.level
+	}
+	return 0
+}
+
+// Printf writes one diagnostic line when its minimum level is enabled.
+// Formats and arguments must be explicitly selected non-secret metadata.
+func Printf(ctx context.Context, minimum int, format string, args ...any) {
+	out, ok := ctx.Value(contextKey{}).(*output)
+	if !ok || out.level == 0 || out.level < minimum {
+		return
+	}
+	out.mu.Lock()
+	defer out.mu.Unlock()
+	fmt.Fprintf(out.writer, "hikyo: "+format+"\n", args...)
+}
+
+// Time returns a completion callback for a named operation at level three.
+// Typical use: defer diagnostics.Time(ctx, "verify release")().
+func Time(ctx context.Context, operation string) func() {
+	if Level(ctx) < 3 {
+		return func() {}
+	}
+	start := time.Now()
+	return func() { Printf(ctx, 3, "%s elapsed=%s", operation, time.Since(start).Round(time.Millisecond)) }
+}
+
+// Transport reports request methods, destination origins and response status.
+// URL paths, queries, userinfo, headers, bodies and error strings are omitted:
+// even a failed transport error can contain an entire credential-bearing URL.
+type Transport struct{ Base http.RoundTripper }
+
+func (t Transport) base() http.RoundTripper {
+	if t.Base == nil {
+		return http.DefaultTransport
+	}
+	return t.Base
+}
+
+// CloseIdleConnections preserves http.Client's transport cleanup contract.
+func (t Transport) CloseIdleConnections() {
+	if closer, ok := t.base().(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+func (t Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	origin := req.URL.Scheme + "://" + req.URL.Host
+	Printf(ctx, 2, "HTTP %s origin=%q", req.Method, origin)
+	defer Time(ctx, "HTTP request to response headers")()
+	response, err := t.base().RoundTrip(req)
+	if err != nil {
+		Printf(ctx, 2, "HTTP %s failed", req.Method)
+	} else {
+		Printf(ctx, 2, "HTTP %s status=%d", req.Method, response.StatusCode)
+	}
+	return response, err
+}

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,85 @@
+package diagnostics
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestDiagnosticLevelsAndCancellation(t *testing.T) {
+	for level := 0; level <= 3; level++ {
+		var out bytes.Buffer
+		ctx := With(t.Context(), level, &out)
+		for minimum := 1; minimum <= 3; minimum++ {
+			Printf(ctx, minimum, "level%d", minimum)
+		}
+		if count := strings.Count(out.String(), "hikyo:"); count != level {
+			t.Fatalf("level=%d output=%q", level, out.String())
+		}
+		if ctx.Done() != t.Context().Done() {
+			t.Fatal("context cancellation lost")
+		}
+	}
+	Printf(t.Context(), 1, "disabled")
+	Printf(With(t.Context(), 3, nil), 1, "discarded")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestTransportDiagnosticsExcludeCredentialsAndPayloads(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		var out bytes.Buffer
+		ctx := With(t.Context(), 3, &out)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://username:password@example.com/secret-path?token=secret-query#secret-fragment", strings.NewReader("secret-body"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer secret-header")
+		transport := Transport{Base: roundTripFunc(func(received *http.Request) (*http.Response, error) {
+			if received != req {
+				t.Fatal("diagnostic transport changed request")
+			}
+			if fail {
+				return nil, errors.New("secret-transport-error")
+			}
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader("secret-response"))}, nil
+		})}
+		response, err := transport.RoundTrip(req)
+		if fail != (err != nil) {
+			t.Fatalf("error=%v", err)
+		}
+		if response != nil {
+			response.Body.Close()
+		}
+		for _, forbidden := range []string{"username", "password", "secret-", "Authorization", "token="} {
+			if strings.Contains(out.String(), forbidden) {
+				t.Fatalf("credential leaked: %s", out.String())
+			}
+		}
+		if !strings.Contains(out.String(), "https://example.com") || !strings.Contains(out.String(), "elapsed=") {
+			t.Fatalf("missing safe detail: %s", out.String())
+		}
+		if !fail && !strings.Contains(out.String(), "status=201") {
+			t.Fatalf("missing status: %s", out.String())
+		}
+	}
+}
+
+func TestConcurrentDiagnosticsKeepCompleteLines(t *testing.T) {
+	var out bytes.Buffer
+	ctx := With(t.Context(), 1, &out)
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Go(func() { Printf(ctx, 1, "phase") })
+	}
+	wg.Wait()
+	if out.String() != strings.Repeat("hikyo: phase\n", 20) {
+		t.Fatalf("interleaved diagnostics: %q", out.String())
+	}
+}

--- a/internal/hostupgrade/host.go
+++ b/internal/hostupgrade/host.go
@@ -564,6 +564,29 @@ func (h *Host) StageCandidate(source, digest string) (string, error) {
 	return destination, copyBinary(source, destination, digest)
 }
 
+// PruneCandidates removes every staged candidate executable. InstallBinary
+// copies the chosen candidate into place, so after a completed upgrade the
+// staging copies are dead weight of over 100 MiB each.
+func (h *Host) PruneCandidates() error {
+	if err := trustedDirectory(h.config.CandidateDirectory); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(h.config.CandidateDirectory)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasPrefix(name, "hikyo-") && !strings.HasPrefix(name, ".hikyo-binary-")) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(h.config.CandidateDirectory, name)); err != nil {
+			return err
+		}
+	}
+	return filedurability.SyncDirectory(h.config.CandidateDirectory)
+}
+
 func (h *Host) InstallBinary(ctx context.Context, candidate, digest string) error {
 	if filepath.Dir(candidate) != h.config.CandidateDirectory {
 		return errors.New("binary installation requires a staged candidate")

--- a/internal/hostupgrade/host.go
+++ b/internal/hostupgrade/host.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/filedurability"
 )
 
@@ -577,7 +578,7 @@ func (h *Host) PruneCandidates() error {
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() || (!strings.HasPrefix(name, "hikyo-") && !strings.HasPrefix(name, ".hikyo-binary-")) {
+		if entry.IsDir() || (!(strings.HasPrefix(name, "hikyo-") && validDigest(strings.TrimPrefix(name, "hikyo-"))) && !strings.HasPrefix(name, ".hikyo-binary-")) {
 			continue
 		}
 		if err := os.Remove(filepath.Join(h.config.CandidateDirectory, name)); err != nil {
@@ -745,6 +746,8 @@ func (h *Host) Complete(ctx context.Context) error {
 }
 
 func (h *Host) systemctl(ctx context.Context, args ...string) ([]byte, error) {
+	diagnostics.Printf(ctx, 2, "systemd operation %s", args[0])
+	defer diagnostics.Time(ctx, "systemd "+args[0])()
 	bounded, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 	output, err := h.run(bounded, command{path: "/usr/bin/systemctl", args: append([]string{"--no-pager", "--no-ask-password"}, args...), env: []string{"PATH=/usr/bin:/bin", "LANG=C"}})

--- a/internal/hostupgrade/host_linux_test.go
+++ b/internal/hostupgrade/host_linux_test.go
@@ -403,8 +403,10 @@ func TestLinuxPruneCandidatesRemovesStagedBinaries(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(candidates, "unrelated"), []byte("keep"), 0600); err != nil {
-		t.Fatal(err)
+	for _, name := range []string{"unrelated", "hikyo-operator-notes"} {
+		if err := os.WriteFile(filepath.Join(candidates, name), []byte("keep"), 0600); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := h.PruneCandidates(); err != nil {
 		t.Fatal(err)
@@ -413,7 +415,7 @@ func TestLinuxPruneCandidatesRemovesStagedBinaries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 || entries[0].Name() != "unrelated" {
+	if len(entries) != 2 || entries[0].Name() != "hikyo-operator-notes" || entries[1].Name() != "unrelated" {
 		t.Fatalf("candidates after prune: %v", entries)
 	}
 }

--- a/internal/hostupgrade/host_linux_test.go
+++ b/internal/hostupgrade/host_linux_test.go
@@ -394,3 +394,26 @@ func TestLinuxRuntimeFailureSavesErrorOutputForTheOperator(t *testing.T) {
 		t.Fatal("child error output must not reach the operator error string")
 	}
 }
+
+func TestLinuxPruneCandidatesRemovesStagedBinaries(t *testing.T) {
+	h := rootTestHost(t)
+	candidates := h.config.CandidateDirectory
+	for _, name := range []string{"hikyo-" + strings.Repeat("a", 64), "hikyo-" + strings.Repeat("b", 64), ".hikyo-binary-123"} {
+		if err := os.WriteFile(filepath.Join(candidates, name), []byte("binary"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(candidates, "unrelated"), []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.PruneCandidates(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "unrelated" {
+		t.Fatalf("candidates after prune: %v", entries)
+	}
+}

--- a/internal/selfupdate/nightly.go
+++ b/internal/selfupdate/nightly.go
@@ -114,6 +114,15 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 	}
 	var total int64
 	for _, candidate := range status.Assets {
+		total += candidate.Size
+	}
+	if cachedDirectory == "" {
+		i.progress("  Downloading nightly %s: %d assets, %s.", status.LatestVersion, len(status.Assets), mebibytes(total))
+	} else {
+		i.progress("  Reusing cached nightly %s; re-verifying %d assets.", status.LatestVersion, len(status.Assets))
+	}
+	total = 0
+	for _, candidate := range status.Assets {
 		if !releaseidentity.SafeName(candidate.Name) {
 			return errors.New("selfupdate: unsafe nightly payload name")
 		}
@@ -127,6 +136,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 		}
 		var raw []byte
 		if cachedDirectory == "" {
+			i.progress("    %s (%s)", asset.Name, mebibytes(asset.Size))
 			raw, err = i.download(ctx, asset, maxArchiveBytes)
 		} else {
 			raw, err = readNightlyFile(filepath.Join(cachedDirectory, asset.Name), maxArchiveBytes)
@@ -146,6 +156,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 			return err
 		}
 	}
+	i.progress("  Verifying nightly %s signatures.", status.LatestVersion)
 	release, err := upgradebundle.VerifyNightlyDirectory(ctx, stage, snapshot)
 	if err != nil {
 		return fmt.Errorf("selfupdate: authenticate complete nightly: %w", err)
@@ -180,6 +191,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 	if err := filedurability.SyncDirectory(i.config.StateDir); err != nil {
 		return err
 	}
+	i.progress("  Assembling runtime bundle for %s.", identity.Version)
 	bundleDirectory, err := i.assembleNightlyBundle(ctx, destination, material, snapshot, releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}, identity)
 	if err != nil {
 		return fmt.Errorf("selfupdate: assemble runtime bundle: %w", err)

--- a/internal/selfupdate/nightly.go
+++ b/internal/selfupdate/nightly.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/filedurability"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
@@ -43,6 +44,7 @@ func (i *Installer) stageNightly(ctx context.Context, status updatecheck.Status)
 }
 
 func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Status, expected *releaseidentity.Identity, extract bool, prepared *PreparedNightly) (err error) {
+	defer diagnostics.Time(ctx, "prepare nightly")()
 	if !status.Immutable {
 		return errors.New("selfupdate: nightly release is not immutable")
 	}
@@ -91,11 +93,6 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 	if err != nil {
 		return err
 	}
-	stage, err := os.MkdirTemp(i.config.StateDir, ".nightly-download-")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(stage)
 	// A target handoff and exact historical route reads reuse immutable cached
 	// bytes. They still match every discovery digest and re-run full signature
 	// verification against the fresh snapshot below before granting authority.
@@ -112,14 +109,24 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 			return err
 		}
 	}
+	// Reverify cache bytes in place. A handoff must not allocate another
+	// complete release merely to authenticate the same immutable inventory.
+	stage := cachedDirectory
+	if stage == "" {
+		stage, err = os.MkdirTemp(i.config.StateDir, ".nightly-download-")
+		if err != nil {
+			return err
+		}
+		defer func() { err = errors.Join(err, os.RemoveAll(stage)) }()
+	}
 	var total int64
 	for _, candidate := range status.Assets {
 		total += candidate.Size
 	}
 	if cachedDirectory == "" {
-		i.progress("  Downloading nightly %s: %d assets, %s.", status.LatestVersion, len(status.Assets), mebibytes(total))
+		diagnostics.Printf(ctx, 1, "  Downloading nightly %s: %d assets, %s.", status.LatestVersion, len(status.Assets), mebibytes(total))
 	} else {
-		i.progress("  Reusing cached nightly %s; re-verifying %d assets.", status.LatestVersion, len(status.Assets))
+		diagnostics.Printf(ctx, 1, "  Reusing cached nightly %s; re-verifying %d assets.", status.LatestVersion, len(status.Assets))
 	}
 	total = 0
 	for _, candidate := range status.Assets {
@@ -136,7 +143,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 		}
 		var raw []byte
 		if cachedDirectory == "" {
-			i.progress("    %s (%s)", asset.Name, mebibytes(asset.Size))
+			diagnostics.Printf(ctx, 2, "    %s (%s)", asset.Name, mebibytes(asset.Size))
 			raw, err = i.download(ctx, asset, maxArchiveBytes)
 		} else {
 			raw, err = readNightlyFile(filepath.Join(cachedDirectory, asset.Name), maxArchiveBytes)
@@ -147,6 +154,9 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 		if err != nil {
 			return err
 		}
+		if cachedDirectory != "" {
+			continue
+		}
 		file, err := os.OpenFile(filepath.Join(stage, asset.Name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 		if err != nil {
 			return err
@@ -156,7 +166,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 			return err
 		}
 	}
-	i.progress("  Verifying nightly %s signatures.", status.LatestVersion)
+	diagnostics.Printf(ctx, 1, "  Verifying nightly %s signatures.", status.LatestVersion)
 	release, err := upgradebundle.VerifyNightlyDirectory(ctx, stage, snapshot)
 	if err != nil {
 		return fmt.Errorf("selfupdate: authenticate complete nightly: %w", err)
@@ -191,7 +201,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 	if err := filedurability.SyncDirectory(i.config.StateDir); err != nil {
 		return err
 	}
-	i.progress("  Assembling runtime bundle for %s.", identity.Version)
+	diagnostics.Printf(ctx, 1, "  Assembling runtime bundle for %s.", identity.Version)
 	bundleDirectory, err := i.assembleNightlyBundle(ctx, destination, material, snapshot, releasetrust.PinnedTrust{Root: rootRaw, RecoveryPublicKey: recovery}, identity)
 	if err != nil {
 		return fmt.Errorf("selfupdate: assemble runtime bundle: %w", err)

--- a/internal/selfupdate/nightly_bundle.go
+++ b/internal/selfupdate/nightly_bundle.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/Hikyo-Org/hikyo/internal/definitions"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
 	"github.com/Hikyo-Org/hikyo/internal/upgradeassembly"
 	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
 )
 
 // assembleNightlyBundle retains the already authenticated snapshot and fetches
@@ -25,6 +26,7 @@ func (i *Installer) assembleNightlyBundle(ctx context.Context, nightly string, m
 }
 
 func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []PreparedNightly, material releasetrust.SnapshotMaterial, snapshot releasetrust.Snapshot, pinned releasetrust.PinnedTrust) (string, error) {
+	defer diagnostics.Time(ctx, "assemble nightly evidence")()
 	if len(evidence) == 0 || len(evidence) > upgradecompat.MaxReleases {
 		return "", errors.New("selfupdate: nightly route exceeds release bound")
 	}
@@ -63,8 +65,11 @@ func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []Prep
 				return "", err
 			}
 		}
-		return destination, nil
+		return destination, i.pruneOtherBundles(ctx, destination)
 	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if err := i.pruneOtherBundles(ctx, destination); err != nil {
 		return "", err
 	}
 	stage, err := os.MkdirTemp(i.config.StateDir, ".nightly-bundle-inputs-")

--- a/internal/selfupdate/nightly_prepare_test.go
+++ b/internal/selfupdate/nightly_prepare_test.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -158,57 +159,65 @@ func TestPrepareExactOlderNightlyPreservesHighestAndChecksIdentity(t *testing.T)
 }
 
 func TestNightlyRouteReauthenticatesAllExactEvidence(t *testing.T) {
-	installer, status, _, trust, _, _ := preparedNightlyFixture(t, nil)
-	target, err := installer.PrepareNightly(t.Context(), status)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, declaration, err := buildcompat.Development()
-	if err != nil {
-		t.Fatal(err)
-	}
-	declaration.Profile, declaration.Version, declaration.Sequence, declaration.Commit = releaseidentity.NightlyV1, "1.0.0-nightly.1", 1, strings.Repeat("a", 40)
-	claim := testfixture.JSON(t, declaration)
-	material := trust.SignNightly(claim, declaration.Version, declaration.Sequence)
-	source := PreparedNightly{Directory: t.TempDir(), Identity: releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)}}
-	for name, reader := range material.Artifacts {
-		raw, err := io.ReadAll(reader)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(source.Directory, name), raw, 0600); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for name, raw := range map[string][]byte{"release-manifest.json": material.Manifest, "release-manifest.sigstore.json": material.Bundle} {
-		if err := os.WriteFile(filepath.Join(source.Directory, name), raw, 0600); err != nil {
-			t.Fatal(err)
-		}
-	}
-	directory, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{source})
-	if err != nil {
-		t.Fatal(err)
-	}
-	bundle, err := upgradebundle.Load(t.Context(), directory, trust.Pinned, releaseidentity.SnapshotFloor{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, identity := range []releaseidentity.Identity{target.Identity, source.Identity} {
-		if _, err := bundle.Release(identity); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if _, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{target}); err == nil {
-		t.Fatal("duplicate route inventory accepted")
-	}
-	if _, err := installer.AssembleNightlyRoute(t.Context(), target, make([]PreparedNightly, upgradecompat.MaxReleases)); err == nil {
-		t.Fatal("unbounded route accepted")
-	}
-	if err := os.WriteFile(filepath.Join(source.Directory, "checksums.txt"), []byte("tampered"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{source}); err == nil {
-		t.Fatal("modified source accepted through cached route")
+	for _, transient := range []bool{false, true} {
+		t.Run(fmt.Sprintf("transient=%t", transient), func(t *testing.T) {
+			installer, status, _, trust, _, _ := preparedNightlyFixture(t, nil)
+			installer.config.TransientBundles = transient
+			target, err := installer.PrepareNightly(t.Context(), status)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, declaration, err := buildcompat.Development()
+			if err != nil {
+				t.Fatal(err)
+			}
+			declaration.Profile, declaration.Version, declaration.Sequence, declaration.Commit = releaseidentity.NightlyV1, "1.0.0-nightly.1", 1, strings.Repeat("a", 40)
+			claim := testfixture.JSON(t, declaration)
+			material := trust.SignNightly(claim, declaration.Version, declaration.Sequence)
+			source := PreparedNightly{Directory: t.TempDir(), Identity: releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)}}
+			for name, reader := range material.Artifacts {
+				raw, err := io.ReadAll(reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(source.Directory, name), raw, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for name, raw := range map[string][]byte{"release-manifest.json": material.Manifest, "release-manifest.sigstore.json": material.Bundle} {
+				if err := os.WriteFile(filepath.Join(source.Directory, name), raw, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			directory, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{source})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(target.BundleDirectory); transient != os.IsNotExist(err) {
+				t.Fatalf("superseded bundle retention: transient=%t err=%v", transient, err)
+			}
+			bundle, err := upgradebundle.Load(t.Context(), directory, trust.Pinned, releaseidentity.SnapshotFloor{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, identity := range []releaseidentity.Identity{target.Identity, source.Identity} {
+				if _, err := bundle.Release(identity); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{target}); err == nil {
+				t.Fatal("duplicate route inventory accepted")
+			}
+			if _, err := installer.AssembleNightlyRoute(t.Context(), target, make([]PreparedNightly, upgradecompat.MaxReleases)); err == nil {
+				t.Fatal("unbounded route accepted")
+			}
+			if err := os.WriteFile(filepath.Join(source.Directory, "checksums.txt"), []byte("tampered"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installer.AssembleNightlyRoute(t.Context(), target, []PreparedNightly{source}); err == nil {
+				t.Fatal("modified source accepted through cached route")
+			}
+		})
 	}
 }
 
@@ -303,5 +312,41 @@ func TestNightlyExtractorRejectsHardlinks(t *testing.T) {
 	}
 	if _, err := extractNightlyBinary("release.tar.gz", out.Bytes()); err == nil {
 		t.Fatal("hardlink accepted as regular executable")
+	}
+}
+
+func TestAutomaticCacheCleanupKeepsTargetAndReauthenticatesWithoutDownload(t *testing.T) {
+	installer, status, _, _, _, responses := preparedNightlyFixture(t, nil)
+	installer.config.TransientBundles = true
+	prepared, err := installer.PrepareNightly(t.Context(), status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(installer.config.StateDir, "nightly-trust.json")
+	before, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := installer.PruneNightlyCache(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(statePath)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatal("cleanup modified anti-rollback state", err)
+	}
+	if _, err := os.Stat(prepared.BundleDirectory); !os.IsNotExist(err) {
+		t.Fatal("retained private bundle", err)
+	}
+	for _, asset := range status.Assets {
+		responses[asset.URL] = nil
+	}
+	if _, err := installer.PrepareNightly(t.Context(), status); err != nil {
+		t.Fatal("cache retry downloaded release again", err)
+	}
+	if err := os.WriteFile(filepath.Join(prepared.Directory, status.Assets[0].Name), []byte("tampered"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installer.PrepareNightly(t.Context(), status); err == nil {
+		t.Fatal("cache retry skipped authentication")
 	}
 }

--- a/internal/selfupdate/nightly_prune.go
+++ b/internal/selfupdate/nightly_prune.go
@@ -1,11 +1,14 @@
 package selfupdate
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/filedurability"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/gofrs/flock"
@@ -17,7 +20,18 @@ import (
 // with intermediate hops multiplies that, so the cache is trimmed after each
 // completed upgrade. The trust state and lock files are never touched: the
 // state carries the rollback floor and the highest observed release.
-func (i *Installer) PruneNightlyCache(keep ...releaseidentity.Identity) (err error) {
+func (i *Installer) PruneNightlyCache(ctx context.Context, keep ...releaseidentity.Identity) error {
+	return i.pruneNightlyCache(ctx, false, keep...)
+}
+
+// PruneNightlyScratch keeps all verified releases and executables while an
+// unfinished journal may still require their exact bytes to resume.
+// Derived private bundles can be rebuilt from those retained releases.
+func (i *Installer) PruneNightlyScratch(ctx context.Context) error {
+	return i.pruneNightlyCache(ctx, true)
+}
+
+func (i *Installer) pruneNightlyCache(ctx context.Context, scratchOnly bool, keep ...releaseidentity.Identity) (err error) {
 	if i == nil || i.config.StateDir == "" {
 		return errors.New("selfupdate: installer is not configured")
 	}
@@ -36,6 +50,15 @@ func (i *Installer) PruneNightlyCache(keep ...releaseidentity.Identity) (err err
 		return errors.New("selfupdate: another nightly verification is running")
 	}
 	defer func() { err = errors.Join(err, lock.Unlock()) }()
+	// Preserve the most recently observed release for target handoff/retry.
+	// Reading malformed trust state fails closed before deleting anything.
+	known, err := readNightlyState(filepath.Join(i.config.StateDir, "nightly-trust.json"))
+	if err != nil {
+		return err
+	}
+	if known.Release.Validate() == nil {
+		keep = append(keep, known.Release)
+	}
 	retained := map[string]bool{}
 	for _, identity := range keep {
 		if identity.Validate() != nil {
@@ -44,6 +67,36 @@ func (i *Installer) PruneNightlyCache(keep ...releaseidentity.Identity) (err err
 		retained["nightly-"+string(identity.ManifestSHA256)] = true
 		retained["executable-"+string(identity.ManifestSHA256)+"-"] = true
 	}
+	return i.pruneNightlyEntries(ctx, func(name string) bool {
+		if scratchOnly && (strings.HasPrefix(name, "nightly-") || strings.HasPrefix(name, "executable-")) {
+			return false
+		}
+		return generatedNightlyEntry(name) && !retained[name] && !retainedExecutable(retained, name)
+	})
+}
+
+var nightlyCacheName = regexp.MustCompile(`^(nightly-[0-9a-f]{64}|bundle-[0-9a-f]{64}-[0-9a-f]{64}|executable-[0-9a-f]{64}-[a-z0-9]+-[a-z0-9]+)$`)
+
+func generatedNightlyEntry(name string) bool {
+	if nightlyCacheName.MatchString(name) {
+		return true
+	}
+	for _, prefix := range []string{".nightly-download-", ".nightly-bundle-inputs-", ".nightly-executable-", ".nightly-trust-", ".hikyo-upgrade-assembly-"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// Called while the nightly trust lock is held. Root-relative removal never
+// follows a symlink outside the cache; unrelated names and trust state survive.
+func (i *Installer) pruneNightlyEntries(ctx context.Context, remove func(string) bool) error {
+	root, err := os.OpenRoot(i.config.StateDir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
 	entries, err := os.ReadDir(i.config.StateDir)
 	if err != nil {
 		return err
@@ -51,14 +104,11 @@ func (i *Installer) PruneNightlyCache(keep ...releaseidentity.Identity) (err err
 	removed := 0
 	for _, entry := range entries {
 		name := entry.Name()
-		generated := strings.HasPrefix(name, "nightly-") || strings.HasPrefix(name, "bundle-") || strings.HasPrefix(name, "executable-") || strings.HasPrefix(name, ".nightly-")
-		if !generated || name == "nightly-trust.json" || name == "nightly-trust.lock" {
+		if !remove(name) {
 			continue
 		}
-		if retained[name] || retainedExecutable(retained, name) {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(i.config.StateDir, name)); err != nil {
+		diagnostics.Printf(ctx, 2, "Removing cached artifact %s", name)
+		if err := root.RemoveAll(name); err != nil {
 			return err
 		}
 		removed++
@@ -66,8 +116,19 @@ func (i *Installer) PruneNightlyCache(keep ...releaseidentity.Identity) (err err
 	if removed == 0 {
 		return nil
 	}
-	i.progress("  Removed %d cached nightly artifacts no longer needed.", removed)
+	diagnostics.Printf(ctx, 1, "Removed %d cached nightly artifacts no longer needed.", removed)
 	return filedurability.SyncDirectory(i.config.StateDir)
+}
+
+// pruneOtherBundles runs under the nightly trust lock, only for the private
+// automatic coordinator cache. Public runtime and manual staging are separate.
+func (i *Installer) pruneOtherBundles(ctx context.Context, keep string) error {
+	if !i.config.TransientBundles {
+		return nil
+	}
+	return i.pruneNightlyEntries(ctx, func(name string) bool {
+		return strings.HasPrefix(name, "bundle-") && nightlyCacheName.MatchString(name) && name != filepath.Base(keep)
+	})
 }
 
 // retainedExecutable matches executable-<manifest>-<os>-<arch> against the

--- a/internal/selfupdate/nightly_prune.go
+++ b/internal/selfupdate/nightly_prune.go
@@ -1,0 +1,82 @@
+package selfupdate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Hikyo-Org/hikyo/internal/filedurability"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/gofrs/flock"
+)
+
+// PruneNightlyCache removes verified nightly directories, assembled bundles,
+// extracted executables and abandoned staging directories that no kept
+// identity references. Every full nightly is several hundred MiB, and a route
+// with intermediate hops multiplies that, so the cache is trimmed after each
+// completed upgrade. The trust state and lock files are never touched: the
+// state carries the rollback floor and the highest observed release.
+func (i *Installer) PruneNightlyCache(keep ...releaseidentity.Identity) (err error) {
+	if i == nil || i.config.StateDir == "" {
+		return errors.New("selfupdate: installer is not configured")
+	}
+	if err := realNightlyDirectory(i.config.StateDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	lock := flock.New(filepath.Join(i.config.StateDir, "nightly-trust.lock"))
+	locked, err := lock.TryLock()
+	if err != nil {
+		return err
+	}
+	if !locked {
+		return errors.New("selfupdate: another nightly verification is running")
+	}
+	defer func() { err = errors.Join(err, lock.Unlock()) }()
+	retained := map[string]bool{}
+	for _, identity := range keep {
+		if identity.Validate() != nil {
+			return errors.New("selfupdate: retained nightly identity is invalid")
+		}
+		retained["nightly-"+string(identity.ManifestSHA256)] = true
+		retained["executable-"+string(identity.ManifestSHA256)+"-"] = true
+	}
+	entries, err := os.ReadDir(i.config.StateDir)
+	if err != nil {
+		return err
+	}
+	removed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		generated := strings.HasPrefix(name, "nightly-") || strings.HasPrefix(name, "bundle-") || strings.HasPrefix(name, "executable-") || strings.HasPrefix(name, ".nightly-")
+		if !generated || name == "nightly-trust.json" || name == "nightly-trust.lock" {
+			continue
+		}
+		if retained[name] || retainedExecutable(retained, name) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(i.config.StateDir, name)); err != nil {
+			return err
+		}
+		removed++
+	}
+	if removed == 0 {
+		return nil
+	}
+	i.progress("  Removed %d cached nightly artifacts no longer needed.", removed)
+	return filedurability.SyncDirectory(i.config.StateDir)
+}
+
+// retainedExecutable matches executable-<manifest>-<os>-<arch> against the
+// retained executable-<manifest>- prefixes.
+func retainedExecutable(retained map[string]bool, name string) bool {
+	for prefix := range retained {
+		if strings.HasPrefix(prefix, "executable-") && strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/selfupdate/nightly_prune_test.go
+++ b/internal/selfupdate/nightly_prune_test.go
@@ -1,0 +1,53 @@
+package selfupdate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+)
+
+func TestPruneNightlyCacheKeepsRetainedIdentityAndTrustState(t *testing.T) {
+	state := t.TempDir()
+	keep := releaseidentity.Identity{Profile: releaseidentity.NightlyV1, Version: "1.1.0-nightly.3", Sequence: 3, Commit: strings.Repeat("b", 40), CompatibilitySHA256: releaseidentity.Hash([]byte("claim")), ManifestSHA256: releaseidentity.Hash([]byte("keep"))}
+	stale := releaseidentity.Hash([]byte("stale"))
+	for _, dir := range []string{"nightly-" + string(keep.ManifestSHA256), "nightly-" + string(stale), "bundle-route-snapshot", ".nightly-download-abandoned", ".nightly-bundle-inputs-abandoned"} {
+		if err := os.MkdirAll(filepath.Join(state, dir, "inner"), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, file := range []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "executable-" + string(stale) + "-linux-amd64", "nightly-trust.json", "nightly-trust.lock", "unrelated"} {
+		if err := os.WriteFile(filepath.Join(state, file), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var progress bytes.Buffer
+	installer := newInstaller(nil, nil)
+	installer.config = Config{StateDir: state, Progress: &progress}
+	if err := installer.PruneNightlyCache(keep); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	want := []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "nightly-" + string(keep.ManifestSHA256), "nightly-trust.json", "nightly-trust.lock", "unrelated"}
+	slices.Sort(want)
+	if !slices.Equal(names, want) {
+		t.Fatalf("after prune: %v, want %v", names, want)
+	}
+	if !strings.Contains(progress.String(), "Removed 5 cached nightly artifacts") {
+		t.Fatalf("progress: %q", progress.String())
+	}
+	if err := installer.PruneNightlyCache(releaseidentity.Identity{}); err == nil {
+		t.Fatal("accepted an invalid retained identity")
+	}
+}

--- a/internal/selfupdate/nightly_prune_test.go
+++ b/internal/selfupdate/nightly_prune_test.go
@@ -8,27 +8,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/gofrs/flock"
 )
 
 func TestPruneNightlyCacheKeepsRetainedIdentityAndTrustState(t *testing.T) {
 	state := t.TempDir()
 	keep := releaseidentity.Identity{Profile: releaseidentity.NightlyV1, Version: "1.1.0-nightly.3", Sequence: 3, Commit: strings.Repeat("b", 40), CompatibilitySHA256: releaseidentity.Hash([]byte("claim")), ManifestSHA256: releaseidentity.Hash([]byte("keep"))}
 	stale := releaseidentity.Hash([]byte("stale"))
-	for _, dir := range []string{"nightly-" + string(keep.ManifestSHA256), "nightly-" + string(stale), "bundle-route-snapshot", ".nightly-download-abandoned", ".nightly-bundle-inputs-abandoned"} {
+	for _, dir := range []string{"nightly-" + string(keep.ManifestSHA256), "nightly-" + string(stale), "bundle-" + strings.Repeat("a", 64) + "-" + strings.Repeat("b", 64), ".nightly-download-abandoned", ".nightly-bundle-inputs-abandoned"} {
 		if err := os.MkdirAll(filepath.Join(state, dir, "inner"), 0700); err != nil {
 			t.Fatal(err)
 		}
 	}
-	for _, file := range []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "executable-" + string(stale) + "-linux-amd64", "nightly-trust.json", "nightly-trust.lock", "unrelated"} {
+	for _, file := range []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "executable-" + string(stale) + "-linux-amd64", "nightly-trust.lock", "unrelated"} {
 		if err := os.WriteFile(filepath.Join(state, file), []byte("x"), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
 	var progress bytes.Buffer
 	installer := newInstaller(nil, nil)
-	installer.config = Config{StateDir: state, Progress: &progress}
-	if err := installer.PruneNightlyCache(keep); err != nil {
+	installer.config = Config{StateDir: state}
+	if err := installer.PruneNightlyCache(diagnostics.With(t.Context(), 1, &progress), keep); err != nil {
 		t.Fatal(err)
 	}
 	entries, err := os.ReadDir(state)
@@ -39,7 +41,7 @@ func TestPruneNightlyCacheKeepsRetainedIdentityAndTrustState(t *testing.T) {
 	for _, entry := range entries {
 		names = append(names, entry.Name())
 	}
-	want := []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "nightly-" + string(keep.ManifestSHA256), "nightly-trust.json", "nightly-trust.lock", "unrelated"}
+	want := []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "nightly-" + string(keep.ManifestSHA256), "nightly-trust.lock", "unrelated"}
 	slices.Sort(want)
 	if !slices.Equal(names, want) {
 		t.Fatalf("after prune: %v, want %v", names, want)
@@ -47,7 +49,97 @@ func TestPruneNightlyCacheKeepsRetainedIdentityAndTrustState(t *testing.T) {
 	if !strings.Contains(progress.String(), "Removed 5 cached nightly artifacts") {
 		t.Fatalf("progress: %q", progress.String())
 	}
-	if err := installer.PruneNightlyCache(releaseidentity.Identity{}); err == nil {
+	if err := installer.PruneNightlyCache(t.Context(), releaseidentity.Identity{}); err == nil {
 		t.Fatal("accepted an invalid retained identity")
+	}
+}
+
+func TestPruneNightlyCacheRefusesBusyCacheAndPreservesSymlinkTargets(t *testing.T) {
+	state := t.TempDir()
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "keep")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	name := "nightly-" + strings.Repeat("a", 64)
+	if err := os.Symlink(outside, filepath.Join(state, name)); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"nightly-not-generated", "bundle-operator-notes"} {
+		if err := os.WriteFile(filepath.Join(state, name), []byte("keep"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	installer := newInstaller(nil, nil)
+	installer.config.StateDir = state
+	lock := flock.New(filepath.Join(state, "nightly-trust.lock"))
+	if err := lock.Lock(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lock.Unlock() })
+	if err := installer.PruneNightlyCache(t.Context()); err == nil {
+		t.Fatal("pruned active cache")
+	}
+	if _, err := os.Lstat(filepath.Join(state, name)); err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	if err := installer.PruneNightlyCache(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(state, name)); !os.IsNotExist(err) {
+		t.Fatal("stale symlink retained", err)
+	}
+	for _, path := range []string{sentinel, filepath.Join(state, "nightly-not-generated"), filepath.Join(state, "bundle-operator-notes")} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPruneNightlyCachePreservesMalformedTrustState(t *testing.T) {
+	state := t.TempDir()
+	path := filepath.Join(state, ".hikyo-upgrade-assembly-abandoned")
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(state, "nightly-trust.json"), []byte("broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	installer := newInstaller(nil, nil)
+	installer.config.StateDir = state
+	if err := installer.PruneNightlyCache(t.Context()); err == nil {
+		t.Fatal("ignored malformed trust state")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("deleted before trust validation", err)
+	}
+}
+
+func TestPruneNightlyScratchKeepsInterruptedRouteReleases(t *testing.T) {
+	state := t.TempDir()
+	installer := newInstaller(nil, nil)
+	installer.config.StateDir = state
+	for _, name := range []string{"nightly-" + strings.Repeat("a", 64), "nightly-" + strings.Repeat("b", 64), "executable-" + strings.Repeat("a", 64) + "-linux-amd64", "bundle-" + strings.Repeat("a", 64) + "-" + strings.Repeat("b", 64), ".hikyo-upgrade-assembly-abandoned"} {
+		if err := os.Mkdir(filepath.Join(state, name), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := installer.PruneNightlyScratch(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("lost interrupted route or retained scratch: %v", entries)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "bundle-") || strings.HasPrefix(entry.Name(), ".") {
+			t.Fatal("retained derived bundle", entry.Name())
+		}
 	}
 }

--- a/internal/selfupdate/nightly_route.go
+++ b/internal/selfupdate/nightly_route.go
@@ -70,6 +70,7 @@ func (i *Installer) AssembleNightlyRoute(ctx context.Context, target PreparedNig
 			highest = item.Identity
 		}
 	}
+	i.progress("  Assembling route bundle across %d releases.", len(evidence))
 	directory, err := i.assembleNightlyEvidence(ctx, evidence, material, snapshot, pinned)
 	if err != nil {
 		return "", fmt.Errorf("selfupdate: assemble nightly route: %w", err)

--- a/internal/selfupdate/nightly_route.go
+++ b/internal/selfupdate/nightly_route.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
 	"github.com/Hikyo-Org/hikyo/internal/upgradecompat"
@@ -70,7 +71,7 @@ func (i *Installer) AssembleNightlyRoute(ctx context.Context, target PreparedNig
 			highest = item.Identity
 		}
 	}
-	i.progress("  Assembling route bundle across %d releases.", len(evidence))
+	diagnostics.Printf(ctx, 1, "  Assembling route bundle across %d releases.", len(evidence))
 	directory, err := i.assembleNightlyEvidence(ctx, evidence, material, snapshot, pinned)
 	if err != nil {
 		return "", fmt.Errorf("selfupdate: assemble nightly route: %w", err)

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -36,6 +36,20 @@ type Config struct {
 	StateDir          string
 	TrustRootBase64   string
 	RecoveryKeyBase64 string
+	// Progress receives one line per download, verification and assembly
+	// step so a long nightly preparation is visible. nil discards them.
+	Progress io.Writer
+}
+
+func (i *Installer) progress(format string, args ...any) {
+	if i == nil || i.config.Progress == nil {
+		return
+	}
+	fmt.Fprintf(i.config.Progress, format+"\n", args...)
+}
+
+func mebibytes(n int64) string {
+	return fmt.Sprintf("%.0f MiB", float64(n)/(1<<20))
 }
 
 // Installer downloads, validates, and atomically replaces one Hikyo binary.

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
 	"github.com/Masterminds/semver/v3"
 )
@@ -36,16 +37,9 @@ type Config struct {
 	StateDir          string
 	TrustRootBase64   string
 	RecoveryKeyBase64 string
-	// Progress receives one line per download, verification and assembly
-	// step so a long nightly preparation is visible. nil discards them.
-	Progress io.Writer
-}
-
-func (i *Installer) progress(format string, args ...any) {
-	if i == nil || i.config.Progress == nil {
-		return
-	}
-	fmt.Fprintf(i.config.Progress, format+"\n", args...)
+	// TransientBundles lets the host coordinator discard superseded private
+	// bundles while resolving a route. Manual staging keeps published locators.
+	TransientBundles bool
 }
 
 func mebibytes(n int64) string {
@@ -66,6 +60,7 @@ func NewInstaller(config Config) (*Installer, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.Transport = diagnostics.Transport{Base: client.Transport}
 	installer := newInstaller(client, os.Executable)
 	installer.config = config
 	return installer, nil
@@ -223,6 +218,10 @@ func assetDigest(asset updatecheck.Asset) ([]byte, error) {
 }
 
 func (i *Installer) download(ctx context.Context, asset updatecheck.Asset, limit int64) ([]byte, error) {
+	started := time.Now()
+	defer func() {
+		diagnostics.Printf(ctx, 3, "Download %s finished in %s", asset.Name, time.Since(started).Round(time.Millisecond))
+	}()
 	if asset.Size > limit {
 		return nil, fmt.Errorf("selfupdate: asset %s exceeds size limit", asset.Name)
 	}

--- a/internal/upgradegate/gate.go
+++ b/internal/upgradegate/gate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Hikyo-Org/hikyo/internal/backupreceipt"
 	"github.com/Hikyo-Org/hikyo/internal/buildcompat"
 	"github.com/Hikyo-Org/hikyo/internal/crypto"
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
 	"github.com/Hikyo-Org/hikyo/internal/store/upgrade"
@@ -98,6 +99,9 @@ func run(ctx context.Context, request Request, build []byte, domain upgrade.Trus
 	if request.Mode == Boot && len(request.RootKey) != crypto.KeySize {
 		return Result{}, crypto.ErrRootKeyFormat
 	}
+	diagnostics.Printf(ctx, 1, "Inspecting installed schema and release trust")
+	diagnostics.Printf(ctx, 2, "Datastore admission: engine=%s mode=%s auto_migrate=%t", request.Store.Engine, request.Mode, request.AllowMigrations)
+	defer diagnostics.Time(ctx, "verify schema and release admission")()
 	root := bytes.Clone(request.RootKey)
 	defer crypto.Zero(root)
 	control, err := upgrade.InspectControl(ctx, request.Store)
@@ -113,6 +117,7 @@ func run(ctx context.Context, request Request, build []byte, domain upgrade.Trus
 		}
 		floor = control.Floor
 	}
+	diagnostics.Printf(ctx, 1, "Verifying signed release bundle and embedded migrations")
 	bundle, err := upgradebundle.Load(ctx, request.BundleDirectory, request.Pinned, floor)
 	if err != nil {
 		return Result{}, err
@@ -151,6 +156,7 @@ func run(ctx context.Context, request Request, build []byte, domain upgrade.Trus
 		}
 	}
 	var result Result
+	diagnostics.Printf(ctx, 2, "Acquiring exclusive migration lock")
 	err = upgrade.WithLock(ctx, request.Store, func(session *upgrade.Session) error {
 		current, readErr := session.Read(ctx)
 		if absent {
@@ -427,9 +433,14 @@ func execute(ctx context.Context, session *upgrade.Session, request Request, nod
 		request.observe(boundaryWriteStarted)
 	}
 	if state.Pending.Phase == upgrade.SchemaWriteStarted {
-		if err := session.ApplyMigrations(ctx, state, request.Migrations, request.MigrationDirectory); err != nil {
-			return fmt.Errorf("schema write did not complete; maintenance retained: %w", err)
+		diagnostics.Printf(ctx, 1, "Applying schema migrations")
+		applied := diagnostics.Time(ctx, "apply schema migrations")
+		applyErr := session.ApplyMigrations(ctx, state, request.Migrations, request.MigrationDirectory)
+		applied()
+		if applyErr != nil {
+			return fmt.Errorf("schema write did not complete; maintenance retained: %w", applyErr)
 		}
+		diagnostics.Printf(ctx, 1, "Verifying migrated schema")
 		request.observe(boundarySQLComplete)
 		if err := verifyCatalog(ctx, session, node, request.Store.Engine); err != nil {
 			return err


### PR DESCRIPTION
CLI operations now support repeatable `-v`/`--verbose`, `-vv`, and `-vvv` for phases, operational details, and timings. Diagnostics go to stderr, preserve JSON/help contracts and child-command arguments, and follow the verified upgrade coordinator handoff. Upgrade, backup/restore, import, migration, and server startup expose their actual progress without logging secret material.

The upgrader previously retained downloaded releases, duplicate route bundles, and staged executables. It now prunes obsolete cache work before downloads and after completion/no-op runs, verifies cache hits in place, and discards superseded private bundles during route preparation. Failed and interrupted operations preserve referenced recovery artifacts and trust state. Unpublished public bundles are removed according to the persisted journal, including failures around journal publication; post-completion cleanup errors do not stop a healthy service. Full signed inventories still require temporary working space.

Validation:
- Full affected Go suites, including app, upgrade gate, CLI, self-update, host adapter, diagnostics and architecture checks, passed.
- Targeted race tests and `go vet` passed; root Linux adapter tests passed in the isolated container.
- Regression coverage includes cache tampering, interrupted recovery, cleanup/publication failures, verbosity levels, secret exclusion, JSON/help output and truthful no-op/failure phases.
- Docs check/build passed. Inherited upgrade code completed native review with final `CLEAN`; startup/migration review and combined implementation review were clean.
- Both commits have cryptographic signatures and matching DCO sign-offs.
