### PR TITLE
fix(ci): exempt dependabot from DCO sign-off

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,19 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # GitHub sets the PR actor from the authenticated opener; it cannot be
+          # spoofed by commit metadata. Only then do we exempt Dependabot's
+          # author identity from the sign-off requirement (it cannot produce a
+          # parseable trailer). Any other opener gets the full check, even for
+          # commits that forge Dependabot's git author header.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           trusted_dco="$RUNNER_TEMP/check-dco.sh"
           git show "$BASE_SHA:scripts/ci/check-dco.sh" >"$trusted_dco"
           chmod +x "$trusted_dco"
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            export DCO_EXEMPT_AUTHOR='dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>'
+          fi
           "$trusted_dco" "$BASE_SHA" "$HEAD_SHA"
 
   supply-chain-checks:

--- a/scripts/ci/check-dco.sh
+++ b/scripts/ci/check-dco.sh
@@ -20,15 +20,38 @@ base=$(git -C "$repo" merge-base "$base" "$head") \
 commits=$(git -C "$repo" rev-list --no-merges --reverse "$base..$head")
 [ -n "$commits" ] || { printf 'DCO check: empty commit range\n' >&2; exit 2; }
 
+# A single author identity may be exempted from the sign-off requirement via the
+# DCO_EXEMPT_AUTHOR env var. This exists for Dependabot, which cannot produce a
+# parseable Signed-off-by (its messages place the sign-off after the "---"
+# metadata separator, which git interpret-trailers treats as the end of the
+# trailer block) and for which the DCO — a human-contributor attestation — is
+# meaningless. The git author header is attacker-controlled, so this is NOT a
+# trust decision: the caller must set DCO_EXEMPT_AUTHOR only after verifying
+# non-spoofable provenance (the GitHub PR actor), and leave it empty otherwise.
+# Default-closed — an unset var exempts nobody.
+exempt_author=${DCO_EXEMPT_AUTHOR:-}
+
 failed=0
+signed=0
+exempt=0
 for commit in $commits; do
 	identity=$(git -C "$repo" show -s --format='%an <%ae>' "$commit")
+	if [ -n "$exempt_author" ] && [ "$identity" = "$exempt_author" ]; then
+		exempt=$((exempt + 1))
+		continue
+	fi
 	trailers=$(git -C "$repo" show -s --format='%B' "$commit" | git -C "$repo" interpret-trailers --parse)
 	if ! printf '%s\n' "$trailers" | grep -F -i -x "Signed-off-by: $identity" >/dev/null; then
 		printf 'DCO check: %s missing Signed-off-by: %s\n' "$commit" "$identity" >&2
 		failed=1
+	else
+		signed=$((signed + 1))
 	fi
 done
 
 [ "$failed" -eq 0 ] || exit 1
-printf 'DCO check: %s commits signed\n' "$(printf '%s\n' "$commits" | wc -l | tr -d ' ')"
+if [ "$exempt" -gt 0 ]; then
+	printf 'DCO check: %s commits signed, %s exempt (%s)\n' "$signed" "$exempt" "$exempt_author"
+else
+	printf 'DCO check: %s commits signed\n' "$signed"
+fi

--- a/scripts/ci/check-dco_test.sh
+++ b/scripts/ci/check-dco_test.sh
@@ -39,4 +39,45 @@ if "$(dirname "$0")/check-dco.sh" "$signed" "$unsigned" "$repo" >/dev/null 2>&1;
 	exit 1
 fi
 
-printf 'DCO fixture: signed, behind-base, and merge commits accepted; unsigned refused\n'
+# Build a commit carrying Dependabot's exact author identity and no parseable
+# sign-off (a real dependabot message, whose sign-off sits after the "---"
+# metadata separator that git interpret-trailers cannot see).
+git -C "$repo" switch -q --detach "$signed"
+printf 'bumped\n' >>"$repo/file"
+git -C "$repo" commit -q -am 'chore(deps): bump something
+
+---
+updated-dependencies:
+- dependency-name: something
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>' \
+	--author='dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>'
+dependabot=$(git -C "$repo" rev-parse HEAD)
+
+# Default-closed: with DCO_EXEMPT_AUTHOR unset, that identity is NOT exempt. A
+# forged git author header alone buys nothing — this is the attack the exemption
+# must not enable.
+if "$(dirname "$0")/check-dco.sh" "$signed" "$dependabot" "$repo" >/dev/null 2>&1; then
+	printf 'DCO fixture failed: forged dependabot author exempt with no opt-in\n' >&2
+	exit 1
+fi
+
+# Opt-in: only when the trusted caller sets DCO_EXEMPT_AUTHOR (gated in CI on the
+# non-spoofable GitHub PR actor) is that exact identity exempt.
+DCO_EXEMPT_AUTHOR='dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>' \
+	"$(dirname "$0")/check-dco.sh" "$signed" "$dependabot" "$repo" >/dev/null
+
+# The opt-in is scoped to the exact identity: a look-alike author (same name,
+# different email) is still refused even with the exemption active.
+printf 'spoof\n' >>"$repo/file"
+git -C "$repo" commit -q -am 'chore: lookalike' \
+	--author='dependabot[bot] <attacker@example.com>'
+lookalike=$(git -C "$repo" rev-parse HEAD)
+if DCO_EXEMPT_AUTHOR='dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>' \
+	"$(dirname "$0")/check-dco.sh" "$dependabot" "$lookalike" "$repo" >/dev/null 2>&1; then
+	printf 'DCO fixture failed: dependabot look-alike accepted\n' >&2
+	exit 1
+fi
+
+printf 'DCO fixture: signed/behind-base/merge accepted; unsigned, forged-without-opt-in, and look-alike refused; exact identity accepted only on opt-in\n'


### PR DESCRIPTION
## Problem
`validation / dco` rejected every dependabot PR (#138, #139, #577, #715, #716 each needed a manual message rewrite). Root cause: dependabot places its `Signed-off-by:` **after** the `---` metadata separator in the commit message. `git interpret-trailers --parse` (used by `scripts/ci/check-dco.sh`) treats `---` as the format-patch message/diff boundary, so the sign-off is invisible and reported missing. The email mismatch (`support@github.com` vs the noreply author) was a red herring — the trailer was never parsed at all.

## Fix
Exempt **exactly** dependabot's fixed GitHub app identity (`dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>`) from the sign-off requirement. The DCO certifies a human contributor and is meaningless for a bot whose commits are already gated by trusted-ci and commit-signature checks.

Scope is deliberately narrow:
- Human commits remain subject to the full check (unchanged).
- A look-alike author (same name, different email) with no valid sign-off is **still refused** — proven by a new fixture case.

## Test
`scripts/ci/check-dco_test.sh` extended: a real dependabot message (sign-off after `---`) is accepted; a spoofed `dependabot[bot] <attacker@example.com>` is refused. Runs green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)