### PR TITLE
test(app): remove minute-boundary flake from HA restore admission

### DIFF
--- a/docs/handoff/ci-34328354454-shared-admission.md
+++ b/docs/handoff/ci-34328354454-shared-admission.md
@@ -1,0 +1,36 @@
+# Shared-admission CI timing failure
+
+Source: [CI run 34328354454, race shard 0](https://github.com/Hikyo-Org/Hikyo/actions/runs/34328354454/job/102391372130).
+
+`TestSingletonHARestoreBootRetainsCoordinationThroughSourceRepair/initial-ha`
+failed with `repaired owner did not retain shared admission`. The job did not
+report a Go data race. The test expected request 61 to be refused after 60
+requests, but shared admission uses fixed wall-clock minute windows. Requests
+spanning a minute boundary legitimately leave allowance in the new window.
+
+The test now checks the repaired owner's durable discovery-counter total across
+all windows for its unique source IP. This proves the real runtime retained
+shared admission without assuming the requests finish within one minute.
+Admission package tests retain coverage of cross-node rate enforcement and
+window reset behavior. Production code and rate-limit policy are unchanged.
+
+Investigation evidence:
+
+- A controlled clock rollover reproduced the original assertion failure three
+  times; the same-window control passed.
+- The original PostgreSQL topology test passed locally under the race detector.
+- The replacement assertion passed an actual PostgreSQL restore boot with a
+  deliberately forced minute rollover midway through the requests.
+- Disconnecting the repaired limiter's shared backend made the replacement
+  assertion fail with `shared admission hits = 0, want 60`.
+- All temporary clock probes and backend mutations were removed.
+
+Focused verification requires an isolated PostgreSQL instance:
+
+```sh
+HIKYO_TEST_POSTGRES_DSN='postgres://USER@HOST:PORT/postgres?sslmode=disable' \
+  go test -race ./internal/app \
+  -run '^TestSingletonHARestoreBootRetainsCoordinationThroughSourceRepair$' \
+  -count=3 -timeout=5m
+go test -race ./internal/admission
+```

--- a/internal/app/self_config_topology_repair_test.go
+++ b/internal/app/self_config_topology_repair_test.go
@@ -211,20 +211,21 @@ func TestSingletonHARestoreBootRetainsCoordinationThroughSourceRepair(t *testing
 			if err := wrong.owner.haCoord.UpsertNode(t.Context(), store.HANode{NodeID: cfg.NodeID, StartedAt: now, HeartbeatAt: now}); err == nil {
 				t.Fatal("restored-away template renewed heartbeat")
 			}
-			// A fresh independent limiter must observe the actual owner's consumption.
-			// A local-only repair graph would allow the extra request below.
-			_, peerLimiter, err := AuthComponents(graph.cfg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			peerLimiter.UseShared(coordinator, testLogger())
+			// Observe the real owner's durable consumption across all minute windows.
+			// A local-only repair graph would leave no shared counter rows.
 			for range admission.MetaPerIPPerMinute {
 				if !graph.limiter.AllowDiscovery("192.0.2.87") {
 					t.Fatal("shared admission refused before its allowance")
 				}
 			}
-			if peerLimiter.AllowDiscovery("192.0.2.87") {
-				t.Fatal("repaired owner did not retain shared admission")
+			var hits int64
+			if err := restored.db.PG().QueryRow(t.Context(),
+				`SELECT COALESCE(SUM(hits), 0) FROM admission_counters WHERE bucket = $1 AND subject = $2`,
+				"meta", "192.0.2.87").Scan(&hits); err != nil {
+				t.Fatal(err)
+			}
+			if hits != admission.MetaPerIPPerMinute {
+				t.Fatalf("repaired owner shared admission hits = %d, want %d", hits, admission.MetaPerIPPerMinute)
 			}
 		})
 	}


### PR DESCRIPTION
The HA restore test could fail with `repaired owner did not retain shared admission` when its 60 requests crossed a clock-minute boundary. Shared admission legitimately resets its allowance in the new window, so checking whether the peer admits request 61 depended on timing.

Assert the repaired runtime's durable discovery-counter total across all windows instead. This still detects loss of shared admission without changing production behavior, rate limits, or CI timeouts. Cross-node rate enforcement remains covered by the admission package tests.

Validation:

- `go test -race ./internal/app -run '^TestSingletonHARestoreBootRetainsCoordinationThroughSourceRepair$' -count=3 -timeout=5m` with isolated PostgreSQL.
- `go test -race ./internal/admission`.
- Controlled rollover reproduced the old assertion failure three times; the replacement passed an actual PostgreSQL restore boot with forced rollover.
- A temporary mutation disconnecting the shared backend correctly failed the replacement assertion with `shared admission hits = 0, want 60`. All probes and mutations were removed.
- Formatting, diff hygiene, and focused code review passed.

Failure: https://github.com/Hikyo-Org/Hikyo/actions/runs/34328354454/job/102391372130

Handoff: `docs/handoff/ci-34328354454-shared-admission.md`.
