### PR TITLE
fix(mcp): audit against 2026-07-28 best practices; uniform 401 and Mcp-Name sentinel

### DIFF
--- a/docs/adr/mcp-server.md
+++ b/docs/adr/mcp-server.md
@@ -1,5 +1,7 @@
 # Hikyo MCP phase 1 (ADR, locked 2026-09-04)
 
+> **Declared amendment (2026-09-10, [mcp-best-practices-audit-2026-09-10.md](../reports/mcp-best-practices-audit-2026-09-10.md), per the [oss-mechanics.md](./oss-mechanics.md) amendment procedure):** (a) the authentication-failure disposition is spelled out as the REST one: a `tools/call` whose presented bearer is not a live artifact (invalid, expired, or revoked) receives the same uniform HTTP `401` with `WWW-Authenticate: Bearer` and no body detail that a missing bearer receives, byte-identical across the four cases and with no audit row; a live artifact that is refused (wrong class, or no grant) keeps the indistinguishable safe tool error. (b) The `Mcp-Name` mirror comparison decodes the protocol's `=?base64?...?=` sentinel before comparing, as the pinned protocol requires; the pinned SDK does not, so the adapter owns that decode. Everything else stands unamended.
+
 Context: the implementation research in
 [hikyo-mcp-server.md](../research/hikyo-mcp-server.md) established that Hikyo
 can expose a useful remote Model Context Protocol surface without another
@@ -55,7 +57,8 @@ Transport is Streamable HTTP with these fixed properties:
 - `JSONResponse: true`. Ordinary replies are JSON, not SSE. Request-scoped SSE,
   resumability, and server-initiated streams are out.
 - One JSON-RPC request or notification per POST. Protocol headers and body
-  metadata must match exactly as required by the pinned protocol.
+  metadata must match exactly as required by the pinned protocol, including
+  decoding the `=?base64?...?=` header sentinel before comparison.
 - Notifications return `202` without a body. Unsupported versions, missing or
   mismatched headers, and unknown methods use the pinned MCP error contract.
 - Client disconnect and request cancellation cancel service work and the
@@ -115,8 +118,13 @@ reviewed disposition for a proof-scoped pure read. An authenticated
 authorization refusal emits the existing `grant.denied` event with the exact
 operation and formula, now carrying `origin=mcp`. Invalid or missing bearer
 presentations, including expired or revoked service-account credentials, retain
-the existing silent, non-enumerating authentication-failure disposition. A
-valid bearer of a disallowed class emits existing
+the existing silent, non-enumerating authentication-failure disposition: the
+uniform HTTP `401` with `WWW-Authenticate: Bearer` and no body detail that the
+REST surface returns for `domain.ErrUnauthenticated`, byte-identical whether the
+bearer is missing, malformed, unknown, expired, or revoked, and with no audit
+row. It is a transport status, never a JSON-RPC result, so an MCP client can
+surface an authentication problem instead of handing the model a retryable tool
+error. A valid bearer of a disallowed class emits existing
 `auth.artifact_class_refused` with `origin=mcp`. Thus authentication failure is
 silent, artifact-class refusal is `auth.artifact_class_refused`, and capability
 denial is `grant.denied`.
@@ -245,7 +253,10 @@ length-bounded, wrapped in the existing redacting artifact type, never copied
 into structured telemetry, never returned, and never forwarded. Transport
 metadata and tool annotations cannot select a principal or capability. Missing,
 invalid, expired, revoked, wrong-class, and unauthorized artifacts disclose no
-tenant fact. Cookies never authenticate MCP. Token passthrough to a downstream
+tenant fact. The first four share one uniform `401`, which says only that the
+presented credential is not live, a fact its presenter already controls; the
+last two share one safe tool error, so a live credential learns nothing about
+scopes it cannot read. Cookies never authenticate MCP. Token passthrough to a downstream
 service, another Hikyo endpoint, a callback, a tool result, or an error is
 forbidden.
 

--- a/docs/adr/mcp-server.md
+++ b/docs/adr/mcp-server.md
@@ -1,6 +1,6 @@
 # Hikyo MCP phase 1 (ADR, locked 2026-09-04)
 
-> **Declared amendment (2026-09-10, [mcp-best-practices-audit-2026-09-10.md](../reports/mcp-best-practices-audit-2026-09-10.md), per the [oss-mechanics.md](./oss-mechanics.md) amendment procedure):** (a) the authentication-failure disposition is spelled out as the REST one: a `tools/call` whose presented bearer is not a live artifact (invalid, expired, or revoked) receives the same uniform HTTP `401` with `WWW-Authenticate: Bearer` and no body detail that a missing bearer receives, byte-identical across the four cases and with no audit row; a live artifact that is refused (wrong class, or no grant) keeps the indistinguishable safe tool error. (b) The `Mcp-Name` mirror comparison decodes the protocol's `=?base64?...?=` sentinel before comparing, as the pinned protocol requires; the pinned SDK does not, so the adapter owns that decode. Everything else stands unamended.
+> **Declared amendment (2026-09-10, [mcp-best-practices-audit-2026-09-10.md](../reports/mcp-best-practices-audit-2026-09-10.md), per the [oss-mechanics.md](./oss-mechanics.md) amendment procedure):** (a) the authentication-failure disposition is spelled out as the REST one: a `tools/call` whose presented bearer is not a live artifact (invalid, expired, or revoked) receives the same uniform HTTP `401` with `WWW-Authenticate: Bearer` and no body detail that a missing bearer receives, byte-identical across the four cases and with no audit row, and a `tools/call` sent as a notification is refused with `400` before the bearer is read; a live artifact that is refused (wrong class, or no grant) keeps the indistinguishable safe tool error. (b) The `Mcp-Name` mirror comparison decodes the protocol's `=?base64?...?=` sentinel before comparing, as the pinned protocol requires; the pinned SDK does not, so the adapter owns that decode. Everything else stands unamended.
 
 Context: the implementation research in
 [hikyo-mcp-server.md](../research/hikyo-mcp-server.md) established that Hikyo
@@ -59,8 +59,12 @@ Transport is Streamable HTTP with these fixed properties:
 - One JSON-RPC request or notification per POST. Protocol headers and body
   metadata must match exactly as required by the pinned protocol, including
   decoding the `=?base64?...?=` header sentinel before comparison.
-- Notifications return `202` without a body. Unsupported versions, missing or
-  mismatched headers, and unknown methods use the pinned MCP error contract.
+- A validated `server/discover` or `tools/list` notification returns `202`
+  without a body. `tools/call` is a request; sent without an id it is malformed
+  and is refused with `400` before any bearer is read, so no tool runs and a
+  missing and a presented bearer receive the same response. Unsupported
+  versions, missing or mismatched headers, and unknown methods use the pinned
+  MCP error contract.
 - Client disconnect and request cancellation cancel service work and the
   transaction. No handler starts detached work.
 

--- a/docs/handoff/mcp-best-practices-audit.md
+++ b/docs/handoff/mcp-best-practices-audit.md
@@ -49,8 +49,10 @@ limits, and output sanitisation. Two findings, both fixed in this branch.
 
 ## Open items
 
-- File the `Mcp-Name` sentinel omission upstream against
-  `modelcontextprotocol/go-sdk` (v1.7.0 decodes only `Mcp-Param-*`).
+- The `Mcp-Name` sentinel omission is already fixed upstream on go-sdk
+  `main` (#1242, #1246, 2026-09-06/07) but is in no release as of
+  v1.8.0-pre.2. Nothing to file. Hikyo's own decode stays because its mirror
+  check runs before the SDK validator.
 - When go-sdk v1.8.0 goes stable, re-run conformance and interop per the ADR
   upgrade rule; consider a non-zero `ttlMs` on the static catalog via
   `SetCacheable`.

--- a/docs/handoff/mcp-best-practices-audit.md
+++ b/docs/handoff/mcp-best-practices-audit.md
@@ -30,6 +30,9 @@ limits, and output sanitisation. Two findings, both fixed in this branch.
 - **B1, `Mcp-Name` sentinel.** `handler.go` decodes `=?base64?...?=` before
   comparing `Mcp-Name` to the body and writes the decoded value back so the
   pinned SDK validator (which does not decode `Mcp-Name`) agrees.
+- A `tools/call` sent as a notification (no id) is refused with 400 before
+  the bearer is read, so missing and presented bearers cannot be told apart
+  on that path either (Codex R1 finding).
 - `internal/server/metrics.go` reads the tool label after the adapter runs so
   an encoded name lands on the right label.
 - `scripts/mcp-public-smoke` now asserts the 401 disposition and has a

--- a/docs/handoff/mcp-best-practices-audit.md
+++ b/docs/handoff/mcp-best-practices-audit.md
@@ -1,0 +1,54 @@
+# Handoff: MCP best-practices audit and fixes (2026-09-10)
+
+**Branch:** `t3code/audit-mcp-best-practices`
+**Ask:** "Is our MCP implementation following best practices?" against the
+2026-07-28 spec, the official security tutorial, Snyk, an unofficial mirror,
+a YouTube video, and any other source no older than three months.
+
+## What was produced
+
+- `docs/research/mcp-best-practices-sources-2026-09-09.md`: 31 sources with
+  dates, primary/secondary flags, every server-side MUST/SHOULD from the
+  2026-07-28 spec, go-sdk release and advisory status, and a checklist.
+- `docs/reports/mcp-best-practices-audit-2026-09-10.md`: practice-by-practice
+  table (Met / Deliberate deviation / Gap) with code and test evidence, two
+  findings, and their resolution.
+
+## Verdict
+
+Compliant, and stronger than the SDK default on Origin, Host, cursors, rate
+limits, and output sanitisation. Two findings, both fixed in this branch.
+
+## What changed in code
+
+- **A2, uniform 401.** A `tools/call` whose bearer is not live (invalid,
+  expired, revoked) now gets the same 401 with `WWW-Authenticate: Bearer` that
+  a missing bearer gets. Before, it got HTTP 200 with a tool error. Live but
+  refused artifacts (wrong class, no grant) keep the safe tool error.
+  `internal/mcpserver/registry.go` marks `domain.ErrUnauthenticated`;
+  `internal/mcpserver/handler.go` writes the response.
+- **B1, `Mcp-Name` sentinel.** `handler.go` decodes `=?base64?...?=` before
+  comparing `Mcp-Name` to the body and writes the decoded value back so the
+  pinned SDK validator (which does not decode `Mcp-Name`) agrees.
+- `internal/server/metrics.go` reads the tool label after the adapter runs so
+  an encoded name lands on the right label.
+- `scripts/mcp-public-smoke` now asserts the 401 disposition and has a
+  negative test rejecting the old tool-error denial.
+- ADR `docs/adr/mcp-server.md` amended by banner; user docs `mcp.mdx` updated.
+
+## Verified
+
+- `go test` for `internal/mcpserver`, `internal/server`, `internal/service`,
+  `scripts/mcp-public-smoke`, and `internal/isolation -run MCP`: green.
+- `scripts/ci/check-mcp-conformance.sh` (upstream 2026-07-28 suite, Node
+  26.7.0): baseline passed.
+- `go vet`, `go build ./...`, GOROOT `gofmt -l .`: clean.
+
+## Open items
+
+- File the `Mcp-Name` sentinel omission upstream against
+  `modelcontextprotocol/go-sdk` (v1.7.0 decodes only `Mcp-Param-*`).
+- When go-sdk v1.8.0 goes stable, re-run conformance and interop per the ADR
+  upgrade rule; consider a non-zero `ttlMs` on the static catalog via
+  `SetCacheable`.
+- The YouTube source was not watched (metadata only). Nothing depends on it.

--- a/docs/reports/mcp-best-practices-audit-2026-09-10.md
+++ b/docs/reports/mcp-best-practices-audit-2026-09-10.md
@@ -1,0 +1,254 @@
+# MCP implementation audit against current best practices
+
+**Date:** 2026-09-10
+**Scope:** `internal/mcpserver`, its wiring in `internal/app/generation.go` and
+`internal/server`, the MCP admission service, deployment fixtures, and CI.
+**Sources:** the primary-source catalogue in
+[mcp-best-practices-sources-2026-09-09.md](../research/mcp-best-practices-sources-2026-09-09.md)
+(source ids S1 to S31 below refer to that file). The user-supplied URLs are S13
+(official tutorial), S29 (Snyk), S30 (modelcontextprotocol.info), and S31
+(YouTube). Additional in-window sources (published on or after 2026-06-09) are
+S14, S15, S16, S20 to S25.
+**Method:** every checkable practice was classified as Met (code plus the test
+that proves it), Deliberate deviation (locked by
+[mcp-server ADR](../adr/mcp-server.md) with a tracking issue), or Gap. Only
+Gaps are findings. Both findings were fixed in the same change.
+
+## Verdict
+
+The implementation meets or exceeds every normative MUST in the 2026-07-28
+specification that applies to a stateless, tools-only server using its own
+bearer scheme, and exceeds the non-normative guidance on cursors, rate
+limiting, output sanitisation, and tool-list stability. Two findings were
+identified and both were fixed in the same change as this report (options A2
+and B1 below, chosen 2026-09-10). Neither was exploitable.
+
+## Source caveats
+
+- `modelcontextprotocol.info` (S30) is not the official site. It is undated,
+  labels 2024-11-05 as current, and contains no transport-specific guidance. It
+  was weighted low.
+- The YouTube video (S31, Neon Postgres, published 2026-09-08) was not watched.
+  Only its title, channel, date, and description were recorded. Its subject is
+  tool ergonomics, not security.
+- The Snyk article (S29) is dated 2025-05-27 and is outside the three-month
+  window. It targets stdio JavaScript servers; its transferable items are
+  covered below.
+- In-window best-practice material beyond the specification itself is thin.
+  The spec pages, the MCP project blog, the go-sdk releases, and a handful of
+  vendor and incident posts are the whole set. Older material (CSA, OWASP,
+  Anthropic, Snyk) is cited only where it is still the canonical reference and
+  is labelled as out of window.
+
+## Practice table
+
+Evidence cites the code and the test that proves it. "ADR" means the practice
+is fixed by the locked mcp-server ADR.
+
+### Transport (S1, S2, S18)
+
+| Practice | Source | Bucket | Evidence |
+| --- | --- | --- | --- |
+| Single POST endpoint; GET and DELETE return 405 with `Allow: POST` | S1 `#earlier-streamable-http-revisions` SHOULD | Met | `handler.go:157` delegates non-POST to the stateless SDK; `handler_test.go:260` asserts status and `Allow` |
+| `Origin` validated, 403 on invalid | S1 `#security--endpoint` MUST | Met, exceeds | SDK v1.7.0 performs no Origin check by default (S18). Hikyo checks first: `handler.go:153` and `validOrigin` at `handler.go:461`; exact allowlist, `null` and `*` refused at construction `handler.go:107`; `handler_test.go:272`, `:343` |
+| Host validated against configured authority, not learned from request | S18 (DNS rebinding, GHSA-xw59-hvm2-8pj6) | Met, exceeds | `validHost` at `handler.go:445` compares to `HIKYO_EXTERNAL_ORIGIN`; trusted-proxy forwarded authority must be single and exact; `handler_test.go:297`. SDK loopback protection left enabled |
+| `MCP-Protocol-Version` header required; mismatch with `_meta` is 400 and -32020 | S1 `#protocol-version-header`, `#server-validation` MUST | Met | `handler.go:188`; probe confirmed a header-less request gets 400 -32020; `handler_test.go:357`. Stricter than the SDK default, which accepts a header-less request as 2025-03-26 |
+| Unsupported version is 400 and -32022 with `supported` list | S1, S6 MUST | Met | `handler.go:217` and `:223`; `handler_test.go:558` sends `2025-11-25` |
+| `Mcp-Method` and `Mcp-Name` required and must match body | S1 `#standard-request-headers` REQUIRED | Met | `handler.go:194`; `handler_test.go:357` |
+| `=?base64?...?=` sentinel decoded before header comparison | S1 `#server-validation` MUST | Met (finding B, fixed) | `decodeHeaderSentinel` in `handler.go` decodes `Mcp-Name` and writes the decoded value back so the SDK validator (which does not decode `Mcp-Name`, `streamable_headers.go:380`) sees it; `handler_test.go` `TestBase64SentinelMcpNameIsDecodedBeforeComparison`. See finding B |
+| `Mcp-Param-*` headers with invalid characters rejected | S1 `#server-behavior-for-custom-headers` MUST | Met | No tool marks `x-mcp-header`, so no param headers are expected; the SDK validator rejects malformed ones after Hikyo's checks pass |
+| No `x-mcp-header` on sensitive parameters | S7 `#x-mcp-header` SHOULD NOT | Met | Not used anywhere in `tools.go` |
+| Unknown method is 404 and -32601 | S1 MUST | Met | `handler.go:230`; `handler_test.go:558` |
+| Notification returns 202 with no body | S1 `#sending-messages` MUST | Met | `serveValidatedStaticNotification` at `handler.go:279`; `handler_test.go:525` |
+| No `Mcp-Session-Id` minted, echoed, or accepted | S1 SHOULD, S12 (SEP-2567) | Met, exceeds | `Stateless: true`; presented session id refused at `handler.go:234`; `handler_test.go:160`, `:679` |
+| `Content-Type` and `Accept` enforced | S1 MUST | Met | `handler.go:161` then SDK 415 and 400 paths |
+| Request body bounded | S18 | Met | 256 KiB at `handler.go:26`, enforced at `handler.go:166` before parsing and again via SDK `MaxRequestBodyBytes` |
+| Client disconnect cancels work | S1 `#cancellation` SHOULD | Met | `PropagateRequestCancellation: true` at `handler.go:128`; 30 s deadline at `handler.go:270`; `handler_test.go:636` proves cancellation reaches the operation |
+| TLS in front; plain HTTP only for loopback in dev mode | S4 `#communication-security`, S26 | Met | ADR Decision section; `deploy/mcp/nginx.conf`; `scripts/ci/check-mcp-deployment.sh` |
+| JSON messages are UTF-8, one message per POST, no batches | S2 | Met | `decodeOne` at `handler.go:413` rejects trailing values; batch arrays fail envelope decode |
+
+### Authorization (S3, S4, S13, S19)
+
+| Practice | Source | Bucket | Evidence |
+| --- | --- | --- | --- |
+| Token only in `Authorization: Bearer`; never query string, cookie, or body | S3 `#token-requirements` MUST | Met | `parseBearer` at `handler.go:393` is the only source; exactly one header; 4 KiB bound; `handler_test.go:473` |
+| Only tokens issued for this server are accepted; no passthrough or transit | S3 `#token-handling`, S4, S13 `#token-passthrough` MUST | Met | Only `hikyo-token` service-account artifacts resolve; no outbound calls; `registry_test.go:116` proves no store, SQL, or crypto import; `Bearer` type redacts on format `registry.go:53`, `handler_test.go:695` |
+| Token verified on every request; revocation immediate | S3 MUST | Met, exceeds | No caching; each page re-resolves and re-authorizes in a fresh transaction (`mcp_admission.go:37` then the page service); `mcp_e2e_test.go:428` proves revoked token is refused on the next call |
+| Missing token is 401 with `WWW-Authenticate` | S3 `#error-handling` MUST | Met | `handler.go:265` |
+| Invalid or expired token is 401 | S3 `#token-handling` MUST when the OAuth framework is adopted; otherwise REST parity and client ergonomics | Met (finding A, fixed) | Uniform 401 via `markUnauthenticated` in `registry.go` and `writeUnauthorized` in `handler.go`; `handler_test.go` `TestUnauthenticatedBearerUsesUniformHTTP401`; `mcp_e2e_test.go` asserts invalid, missing, and revoked are byte-identical 401s |
+| Insufficient permission is 403 or an equivalent safe refusal | S3 `#error-handling` | Deliberate deviation | ADR "Threat-model controls": unauthorized is indistinguishable from nonexistent, so an ungranted principal receives the same safe tool error. A 403 would confirm scope existence. Accepted |
+| RFC 9728 protected-resource metadata and `resource_metadata` challenge | S3, S5 MUST when the OAuth framework is adopted | Deliberate deviation | Authorization is OPTIONAL (S3 `#protocol-requirements`); Hikyo uses its own bearer scheme, which S9 `#auth` permits. OAuth necessity is tracked in #631. `docs/site/.../mcp.mdx:14` tells operators that OAuth buttons will not work |
+| Tokens never logged | S4 `#token-theft` MUST, S21, S26 | Met | `metrics.go:368` logs method, tool, status, duration only; `audit.Context` carries IP and user agent, not the bearer |
+| Audience binding | S3, S20 | Met by construction | Hikyo tokens are minted by Hikyo for Hikyo; there is no second audience |
+
+### Tools (S7, S20, S22, S25, S28)
+
+| Practice | Source | Bucket | Evidence |
+| --- | --- | --- | --- |
+| `tools` capability declared; nothing else advertised | S7 `#capabilities` MUST | Met | `handler.go:122`; `handler_test.go:160` asserts exactly one capability |
+| `tools/list` deterministic, static, never varies with call count or client | S7 MUST NOT vary per connection; S22 rug-pull defence | Met, exceeds | Registry frozen at boot `registry.go:227`; sorted by name; `listChanged` not advertised; `handler_test.go:205`, `tools_test.go:444` pins the five rows |
+| Non-null `inputSchema`; unknown fields rejected | S7 `#tool` | Met | `additionalProperties: false` inferred; `tools_test.go:271` sends an unknown field and gets an error; `tools_test.go:481` asserts the schema text |
+| Inputs validated server-side; no shell or SQL concatenation | S7 `#security-considerations` MUST, S25 | Met | SDK validates against schema before the handler; ids are typed `domain.Scope`; page size re-checked in `normalizePageSize` at `tools.go:233`; store uses sqlc queries |
+| Annotations reflect real behaviour | S7, S26, S28 | Met | `readOnlyHint`, `idempotentHint` true, `destructiveHint`, `openWorldHint` false at `registry.go:190`; `Register` refuses any authorization operation that is not an audited-none read `registry.go:145` |
+| Descriptions factual, no model instructions, no secrets | S25, S20, S22 | Met | Each description in `tools.go` states operation, scope, and what is never returned |
+| `structuredContent` conforms to `outputSchema` | S7 `#output-schema` MUST | Met | SDK validates output against the pinned schema; result bound at `registry.go:216` |
+| Serialized JSON mirrored into a `TextContent` block | S7 `#structured-content` SHOULD | Deliberate deviation | ADR "Pagination and output bounds": 4 KiB summary only, never a duplicate row set. Rationale is token economy and a single bound. Pre-SEP-2106 clients cannot recover data from text; all named clients in `mcp.mdx` read `structuredContent` |
+| Tool execution errors carry `isError: true` with actionable text; protocol errors use JSON-RPC codes; internals not leaked | S7 `#error-handling`, S28, S30 | Met | Named safe errors (`invalid_cursor`, `invalid_argument`, `traversal_limit_reached`, `result_item_too_large`) at `cursor.go:33`; everything else collapses to `Hikyo operation refused` at `registry.go:213`; `handler_test.go:595` |
+| Outputs sanitised: no secrets, env, tokens, paths | S7 MUST, S23 CVE-2026-67357, S24 | Met, exceeds | `mapConfiguration` at `tools.go:498` and `mapPending` keep plaintext only for `config` classification; canary secret fixture in `mcp_e2e_test.go:167`, `mcp_pagination_test.go:190`, `tools_test.go:284` |
+| Rate limiting on `tools/call` | S7 MUST, S21, S26 | Met, exceeds | Datastore-coordinated token bucket 60/min, burst 20, concurrency 4 per principal, 8 per org, 64 per instance (`mcp_admission.go:62`); uniform 429 with `Retry-After` (`handler.go:325`); per-IP admission on discovery (`handler.go:243`); `tools_test.go:245`, `handler_test.go:411`, `:615` |
+| Rate limiting charged only after authorization, so guessed ids cannot occupy tenant budgets | ADR, S21 | Met | `MCPAdmission.Acquire` authorizes before claiming capacity; `mcp_e2e_test.go:305` proves an unauthorized principal consumes zero buckets |
+| Pre-authentication flood on `tools/call` with a bogus bearer | S7, S21 | Met, parity with REST | Bounded by the 64 instance slots (`handler.go:257`), the 30 s deadline, and the global 512-request cap. Token lookup is a hash-verifier read, not a KDF (`machine.go:66`), so the cost per probe is one indexed read. REST applies its per-IP `Enter` limiter only to password and factor paths, so MCP matches the REST bearer path exactly |
+| Cross-call handles are random, opaque, bound, expiring | S13 `#state-handle-hijacking`, S7 `#stateful-tools` | Met, exceeds | Cursors are AEAD-sealed under a keyring-derived key, bound to tool, scope ids, and page size, expire in 15 minutes without renewal, and carry no bearer or principal (`cursor.go:88`); `tools_test.go:193`, `:210`, `:223`, `cursor_test.go` |
+| Human in the loop is a client obligation; server keeps read-only tools genuinely read-only | S7 `#user-interaction-model` | Met | Registry refuses non-read operations at construction |
+| Untrusted tenant text in outputs stays typed data, never instructions | S25, S20 | Met | ADR "Secret and model-context boundary": descriptions and notes are structured fields, never concatenated into `instructions`; no `instructions` field is served |
+
+### Pagination and caching (S8, S11, S24)
+
+| Practice | Source | Bucket | Evidence |
+| --- | --- | --- | --- |
+| Cursors opaque, stable, integrity-protected, never a path or raw offset | S8 SHOULD, S24 | Met, exceeds | See cursor row above; keyset position not offset (`paginate.go`) |
+| Invalid cursor handled gracefully | S8 SHOULD | Met | One named `invalid_cursor` tool error for tampered, expired, or wrong-scope, without saying which |
+| `ttlMs >= 0` and `cacheScope` on `server/discover` and `tools/list` | S11 MUST | Met | Probe confirmed `ttlMs: 0`, `cacheScope: "public"` on both. Public is correct because the catalog is tenant-free and identical for every token |
+| Chain bounds prevent bulk extraction through small pages | ADR | Met, exceeds | 10 pages, 1000 items, 1 MiB per chain (`cursor.go:22`); `tools_test.go:339`, `:402` |
+
+### Protocol hygiene (S6, S9, S10)
+
+| Practice | Source | Bucket | Evidence |
+| --- | --- | --- | --- |
+| `server/discover` implemented with `supportedVersions` | S10 MUST | Met | `handler.go:344` forces the pinned list; `handler_test.go:160` |
+| Missing `_meta` fields produce 400 and -32602 | S9 `#_meta` MUST | Met | `handler.go:210` hands the SDK the schema check; `handler_test.go:396` |
+| `resultType` and `serverInfo` in every result | S9 MUST and SHOULD | Met | Probe confirmed both on discover, list, and call |
+| No emission of -32002, -32042, or private codes outside the defined set | S9 `#error-codes` MUST NOT | Met | Hikyo emits only -32020, -32022, -32601; SDK v1.7.0 maps resource-not-found to -32602 by default |
+| JSON Schema 2020-12; no network `$ref`; bounded complexity | S9 | Met | Schemas are inferred from Go structs at boot and contain no `$ref` |
+| JSON nesting depth bounded | S16 (v1.8.0-pre.1 adds a 1000-level cap) | Met by other means | 256 KiB body bound plus Go's `encoding/json` 10 000-level limit. Watch item, see follow-ups |
+
+### Supply chain and operations (S16, S17, S26, S29)
+
+| Practice | Source | Bucket | Evidence |
+| --- | --- | --- | --- |
+| go-sdk at or above v1.4.1; all four GHSAs patched | S17 | Met | v1.7.0 pinned exactly; `registry_test.go:137` fails CI on drift. No go-sdk advisory since 2026-06-09 |
+| Dependency vulnerability scanning | S29, S26 | Met | `govulncheck` on the release-shaped binary in `ci.yml:873` and `:961`; local run today: zero reachable vulnerabilities in `internal/mcpserver` (five unreachable in `x/crypto` and `x/mod`) |
+| SBOM | S29, S26 | Met | `anchore/sbom-action` SPDX in `ci.yml:230` |
+| Dependency updates | S26 | Met | Dependabot is active (PRs #715, #716 on this branch's history) |
+| Upstream conformance suite in CI | S15 (conformance testing priority) | Met, exceeds | `scripts/ci/check-mcp-conformance.sh` runs the 2026-07-28 upstream suite against a fixture that still uses Hikyo's real host, origin, and header adapters (`conformance.go`) |
+| Named-client interoperability | ADR evidence item 5 | Met | `client_interop_test.go`; Claude Code, Codex CLI, and others in `mcp.mdx` |
+| Structured request logging with identity, tool, outcome, duration; arguments redacted | S21, S25, S26 | Met | Metrics and debug log per call; audit events `grant.denied` and `auth.artifact_class_refused` carry `origin=mcp` and the operation; arguments are ids only and are not logged |
+| Container packaging; digest-pinned image | S29, S26 | Met | `deploy/mcp/compose.yaml`; `check-mcp-deployment.sh` |
+
+### Tool design ergonomics (S28, S31; out of window and non-security)
+
+Anthropic's guidance (2025-09) and the Neon video description (2026-09-08)
+both favour fewer workflow-shaped tools and search over list-all. Hikyo ships
+five list tools with no filter argument. For a read-only phase-1 surface this
+is fine and keeps the closed-registry proof simple. If clients are observed
+paging through definitions to find one key, a `key_name` filter on
+`hikyo_inspect_configuration` would be the smallest ergonomic step. Not a
+finding.
+
+## Findings
+
+### A. Invalid or expired bearer returns 200 with a tool error instead of 401
+
+**What happens.** A `tools/call` with a missing bearer gets 401 with
+`WWW-Authenticate: Bearer` (`handler.go:265`). A `tools/call` with a present
+but invalid, expired, or revoked bearer reaches the service, fails
+`domain.ErrUnauthenticated` inside the transaction, and is collapsed to the
+tool-level `Hikyo operation refused` with HTTP 200 and `isError: true`
+(`registry.go:213`). This is deliberate: `mcp_e2e_test.go:428` asserts that a
+revoked token and a garbage token produce byte-identical bodies, and the ADR
+"Threat-model controls" section groups invalid, expired, revoked, and
+unauthorized under one non-disclosing disposition.
+
+**Why it is worth a decision.** Three pressures point the other way.
+
+- The MCP authorization spec says invalid or expired tokens MUST receive 401
+  (S3 `#token-handling`). That section is conditional on adopting the OAuth
+  framework, which Hikyo has not, so this is guidance rather than a violation.
+- REST parity: the REST surface maps `ErrUnauthenticated` to 401
+  `authentication required` (`errors.go:71`, `:225`) with no audit event. The
+  ADR sentence "retain the existing silent, non-enumerating
+  authentication-failure disposition" names that REST behaviour.
+- Client ergonomics: named clients (Claude Code, Codex CLI) surface a 401 as an
+  authentication problem to the user. A 200 with `isError` is handed to the
+  model as a retryable tool failure, so a rotated or expired token produces
+  retries and a confusing transcript instead of a clear prompt to fix the
+  credential.
+
+**Counter-argument.** A 401 tells whoever holds a leaked token whether it is
+still live. The uniform tool error does not. REST already discloses this, so
+parity does not add exposure, but it is the one property the current
+behaviour protects and Marc should weigh it explicitly.
+
+**Not affected either way.** Authorization denial for a live token (no grant,
+or wrong artifact class) stays the safe tool error. That is the
+unauthorized-equals-nonexistent property and it is correct.
+
+**Resolution (2026-09-10): A2 implemented.** `domain.ErrUnauthenticated` from
+a tool handler now sets the call state and the transport writes the same
+uniform 401 a missing bearer receives. Revoked, expired, unknown, and missing
+are byte-identical. ADR amended by banner. The public smoke probe
+(`scripts/mcp-public-smoke`) and the e2e suite assert the new disposition and
+the probe has a negative test that rejects the old tool-error denial.
+
+**Options considered.**
+
+- A1: keep as is; record the parity divergence and the client-ergonomics cost
+  in the ADR so it is a documented choice.
+- A2 (recommended): map `domain.ErrUnauthenticated` from the tool handler to a
+  uniform 401 with `WWW-Authenticate: Bearer` and no body detail, using the
+  same `callState` mechanism that already turns `ErrRateLimited` into a
+  uniform 429 (`handler.go:74`, `:325`). Revoked and invalid stay
+  byte-identical, now both 401. Requires an ADR amendment sentence and updates
+  to the two e2e assertions.
+
+### B. `Mcp-Name` base64 sentinel is not decoded before comparison
+
+**What happens.** The spec allows a client to wrap any header value in
+`=?base64?...?=` and requires servers to decode it before comparing to the body
+(S1 `#server-validation` MUST). Hikyo's mirror check at `handler.go:201`
+compares the raw header string. The pinned SDK does the same for `Mcp-Name`
+(`streamable_headers.go:380`) and decodes only `Mcp-Param-*` values
+(`decodeHeaderValue` at `streamable_headers.go:490`), so removing Hikyo's
+check would not close the gap. An encoded `Mcp-Name` is refused with 400 and
+-32020 by both layers.
+
+**Why it is small.** Hikyo tool names are `[A-Za-z0-9_.-]`, so no compliant
+client needs to encode them; the official Go client encodes only values with
+non-token characters or surrounding whitespace. The failure is a clean 400,
+not a bypass.
+
+**Resolution (2026-09-10): B1 implemented.** `decodeHeaderSentinel` in
+`handler.go` mirrors the SDK's `decodeHeaderValue` rule and the decoded name is
+written back to the request header before the SDK validator runs. Upstream
+omission for `Mcp-Name` still to be filed against go-sdk.
+
+**Options considered.**
+
+- B1 (recommended): decode the sentinel in `handler.go` before the `Mcp-Name`
+  comparison, mirroring the SDK's `decodeHeaderValue` rule (strict base64,
+  reject on decode failure), and add one test with an encoded name. Roughly
+  ten lines. File the `Mcp-Name` omission upstream against go-sdk.
+- B2: accept and track; revisit when go-sdk v1.8.0 stabilises and check
+  whether the upstream validator gained the decode.
+
+## Follow-ups that are not findings
+
+- **go-sdk v1.8.0.** Pre-releases from 2026-09-04 add a JSON nesting cap,
+  `ServerOptions.SupportedProtocolVersions`, `SetCacheable` for non-zero
+  `ttlMs`, and remove four `MCPGODEBUG` flags. None is required for
+  compliance. When it goes stable, the ADR's upgrade rule applies: reviewed
+  changelog plus the full conformance, security, and interop suite.
+- **`ttlMs: 0` on a static catalog.** Compliant, but a non-zero TTL would let
+  clients cache the five-tool list. Optional after v1.8.0 exposes the hook.
+- **Text mirroring.** If a pre-SEP-2106 client is ever named as supported, the
+  summary-only deviation would need revisiting. No such client is named today.
+
+## What this audit did not do
+
+- Production code changed only for findings A and B; no other change.
+- The YouTube video was not watched.
+- The OWASP guide PDF body and the three August CVE records were not fetched;
+  their data comes from the Adversa digest (S23).
+- Spec section anchors in the source catalogue were inferred from headings by
+  a summarising fetch and should be spot-checked before being quoted in an
+  ADR amendment.

--- a/docs/reports/mcp-best-practices-audit-2026-09-10.md
+++ b/docs/reports/mcp-best-practices-audit-2026-09-10.md
@@ -59,7 +59,7 @@ is fixed by the locked mcp-server ADR.
 | `Mcp-Param-*` headers with invalid characters rejected | S1 `#server-behavior-for-custom-headers` MUST | Met | No tool marks `x-mcp-header`, so no param headers are expected; the SDK validator rejects malformed ones after Hikyo's checks pass |
 | No `x-mcp-header` on sensitive parameters | S7 `#x-mcp-header` SHOULD NOT | Met | Not used anywhere in `tools.go` |
 | Unknown method is 404 and -32601 | S1 MUST | Met | `handler.go:230`; `handler_test.go:558` |
-| Notification returns 202 with no body | S1 `#sending-messages` MUST | Met | `serveValidatedStaticNotification` at `handler.go:279`; `handler_test.go:525` |
+| Notification returns 202 with no body; a malformed notification returns an HTTP error | S1 `#sending-messages` MUST | Met | `serveValidatedStaticNotification` at `handler.go:279`; `handler_test.go:525`. A `tools/call` without an id is refused with 400 before the bearer is read, so missing and presented bearers are identical there too (`TestToolCallNotificationIsRefusedBeforeBearerHandling`) |
 | No `Mcp-Session-Id` minted, echoed, or accepted | S1 SHOULD, S12 (SEP-2567) | Met, exceeds | `Stateless: true`; presented session id refused at `handler.go:234`; `handler_test.go:160`, `:679` |
 | `Content-Type` and `Accept` enforced | S1 MUST | Met | `handler.go:161` then SDK 415 and 400 paths |
 | Request body bounded | S18 | Met | 256 KiB at `handler.go:26`, enforced at `handler.go:166` before parsing and again via SDK `MaxRequestBodyBytes` |
@@ -186,7 +186,7 @@ unauthorized-equals-nonexistent property and it is correct.
 **Resolution (2026-09-10): A2 implemented.** `domain.ErrUnauthenticated` from
 a tool handler now sets the call state and the transport writes the same
 uniform 401 a missing bearer receives. Revoked, expired, unknown, and missing
-are byte-identical. ADR amended by banner. The public smoke probe
+are byte-identical (the e2e suite mints an actually expired credential). ADR amended by banner. The public smoke probe
 (`scripts/mcp-public-smoke`) and the e2e suite assert the new disposition and
 the probe has a negative test that rejects the old tool-error denial.
 

--- a/docs/reports/mcp-best-practices-audit-2026-09-10.md
+++ b/docs/reports/mcp-best-practices-audit-2026-09-10.md
@@ -50,31 +50,31 @@ is fixed by the locked mcp-server ADR.
 | Practice | Source | Bucket | Evidence |
 | --- | --- | --- | --- |
 | Single POST endpoint; GET and DELETE return 405 with `Allow: POST` | S1 `#earlier-streamable-http-revisions` SHOULD | Met | `handler.go:157` delegates non-POST to the stateless SDK; `handler_test.go:260` asserts status and `Allow` |
-| `Origin` validated, 403 on invalid | S1 `#security--endpoint` MUST | Met, exceeds | SDK v1.7.0 performs no Origin check by default (S18). Hikyo checks first: `handler.go:153` and `validOrigin` at `handler.go:461`; exact allowlist, `null` and `*` refused at construction `handler.go:107`; `handler_test.go:272`, `:343` |
-| Host validated against configured authority, not learned from request | S18 (DNS rebinding, GHSA-xw59-hvm2-8pj6) | Met, exceeds | `validHost` at `handler.go:445` compares to `HIKYO_EXTERNAL_ORIGIN`; trusted-proxy forwarded authority must be single and exact; `handler_test.go:297`. SDK loopback protection left enabled |
+| `Origin` validated, 403 on invalid | S1 `#security--endpoint` MUST | Met, exceeds | SDK v1.7.0 performs no Origin check by default (S18). Hikyo checks first: `handler.go:153` and `validOrigin` at `handler.go:472`; exact allowlist, `null` and `*` refused at construction `handler.go:107`; `handler_test.go:272`, `:343` |
+| Host validated against configured authority, not learned from request | S18 (DNS rebinding, GHSA-xw59-hvm2-8pj6) | Met, exceeds | `validHost` at `handler.go:456` compares to `HIKYO_EXTERNAL_ORIGIN`; trusted-proxy forwarded authority must be single and exact; `handler_test.go:297`. SDK loopback protection left enabled |
 | `MCP-Protocol-Version` header required; mismatch with `_meta` is 400 and -32020 | S1 `#protocol-version-header`, `#server-validation` MUST | Met | `handler.go:188`; probe confirmed a header-less request gets 400 -32020; `handler_test.go:357`. Stricter than the SDK default, which accepts a header-less request as 2025-03-26 |
-| Unsupported version is 400 and -32022 with `supported` list | S1, S6 MUST | Met | `handler.go:217` and `:223`; `handler_test.go:558` sends `2025-11-25` |
+| Unsupported version is 400 and -32022 with `supported` list | S1, S6 MUST | Met | `handler.go:220` and `:226`; `handler_test.go:558` sends `2025-11-25` |
 | `Mcp-Method` and `Mcp-Name` required and must match body | S1 `#standard-request-headers` REQUIRED | Met | `handler.go:194`; `handler_test.go:357` |
 | `=?base64?...?=` sentinel decoded before header comparison | S1 `#server-validation` MUST | Met (finding B, fixed) | `decodeHeaderSentinel` in `handler.go` decodes `Mcp-Name` and writes the decoded value back so the SDK validator (which does not decode `Mcp-Name`, `streamable_headers.go:380`) sees it; `handler_test.go` `TestBase64SentinelMcpNameIsDecodedBeforeComparison`. See finding B |
 | `Mcp-Param-*` headers with invalid characters rejected | S1 `#server-behavior-for-custom-headers` MUST | Met | No tool marks `x-mcp-header`, so no param headers are expected; the SDK validator rejects malformed ones after Hikyo's checks pass |
 | No `x-mcp-header` on sensitive parameters | S7 `#x-mcp-header` SHOULD NOT | Met | Not used anywhere in `tools.go` |
-| Unknown method is 404 and -32601 | S1 MUST | Met | `handler.go:230`; `handler_test.go:558` |
-| Notification returns 202 with no body; a malformed notification returns an HTTP error | S1 `#sending-messages` MUST | Met | `serveValidatedStaticNotification` at `handler.go:279`; `handler_test.go:525`. A `tools/call` without an id is refused with 400 before the bearer is read, so missing and presented bearers are identical there too (`TestToolCallNotificationIsRefusedBeforeBearerHandling`) |
-| No `Mcp-Session-Id` minted, echoed, or accepted | S1 SHOULD, S12 (SEP-2567) | Met, exceeds | `Stateless: true`; presented session id refused at `handler.go:234`; `handler_test.go:160`, `:679` |
+| Unknown method is 404 and -32601 | S1 MUST | Met | `handler.go:233`; `handler_test.go:558` |
+| Notification returns 202 with no body; a malformed notification returns an HTTP error | S1 `#sending-messages` MUST | Met | `serveValidatedStaticNotification` at `handler.go:290`; `handler_test.go:525`. A `tools/call` without an id is refused with 400 before the bearer is read, so missing and presented bearers are identical there too (`TestToolCallNotificationIsRefusedBeforeBearerHandling`) |
+| No `Mcp-Session-Id` minted, echoed, or accepted | S1 SHOULD, S12 (SEP-2567) | Met, exceeds | `Stateless: true`; presented session id refused at `handler.go:237`; `handler_test.go:160`, `:679` |
 | `Content-Type` and `Accept` enforced | S1 MUST | Met | `handler.go:161` then SDK 415 and 400 paths |
 | Request body bounded | S18 | Met | 256 KiB at `handler.go:26`, enforced at `handler.go:166` before parsing and again via SDK `MaxRequestBodyBytes` |
-| Client disconnect cancels work | S1 `#cancellation` SHOULD | Met | `PropagateRequestCancellation: true` at `handler.go:128`; 30 s deadline at `handler.go:270`; `handler_test.go:636` proves cancellation reaches the operation |
+| Client disconnect cancels work | S1 `#cancellation` SHOULD | Met | `PropagateRequestCancellation: true` at `handler.go:128`; 30 s deadline at `handler.go:281`; `handler_test.go:636` proves cancellation reaches the operation |
 | TLS in front; plain HTTP only for loopback in dev mode | S4 `#communication-security`, S26 | Met | ADR Decision section; `deploy/mcp/nginx.conf`; `scripts/ci/check-mcp-deployment.sh` |
-| JSON messages are UTF-8, one message per POST, no batches | S2 | Met | `decodeOne` at `handler.go:413` rejects trailing values; batch arrays fail envelope decode |
+| JSON messages are UTF-8, one message per POST, no batches | S2 | Met | `decodeOne` at `handler.go:424` rejects trailing values; batch arrays fail envelope decode |
 
 ### Authorization (S3, S4, S13, S19)
 
 | Practice | Source | Bucket | Evidence |
 | --- | --- | --- | --- |
-| Token only in `Authorization: Bearer`; never query string, cookie, or body | S3 `#token-requirements` MUST | Met | `parseBearer` at `handler.go:393` is the only source; exactly one header; 4 KiB bound; `handler_test.go:473` |
+| Token only in `Authorization: Bearer`; never query string, cookie, or body | S3 `#token-requirements` MUST | Met | `parseBearer` at `handler.go:404` is the only source; exactly one header; 4 KiB bound; `handler_test.go:473` |
 | Only tokens issued for this server are accepted; no passthrough or transit | S3 `#token-handling`, S4, S13 `#token-passthrough` MUST | Met | Only `hikyo-token` service-account artifacts resolve; no outbound calls; `registry_test.go:116` proves no store, SQL, or crypto import; `Bearer` type redacts on format `registry.go:53`, `handler_test.go:695` |
 | Token verified on every request; revocation immediate | S3 MUST | Met, exceeds | No caching; each page re-resolves and re-authorizes in a fresh transaction (`mcp_admission.go:37` then the page service); `mcp_e2e_test.go:428` proves revoked token is refused on the next call |
-| Missing token is 401 with `WWW-Authenticate` | S3 `#error-handling` MUST | Met | `handler.go:265` |
+| Missing token is 401 with `WWW-Authenticate` | S3 `#error-handling` MUST | Met | `handler.go:276` |
 | Invalid or expired token is 401 | S3 `#token-handling` MUST when the OAuth framework is adopted; otherwise REST parity and client ergonomics | Met (finding A, fixed) | Uniform 401 via `markUnauthenticated` in `registry.go` and `writeUnauthorized` in `handler.go`; `handler_test.go` `TestUnauthenticatedBearerUsesUniformHTTP401`; `mcp_e2e_test.go` asserts invalid, missing, and revoked are byte-identical 401s |
 | Insufficient permission is 403 or an equivalent safe refusal | S3 `#error-handling` | Deliberate deviation | ADR "Threat-model controls": unauthorized is indistinguishable from nonexistent, so an ungranted principal receives the same safe tool error. A 403 would confirm scope existence. Accepted |
 | RFC 9728 protected-resource metadata and `resource_metadata` challenge | S3, S5 MUST when the OAuth framework is adopted | Deliberate deviation | Authorization is OPTIONAL (S3 `#protocol-requirements`); Hikyo uses its own bearer scheme, which S9 `#auth` permits. OAuth necessity is tracked in #631. `docs/site/.../mcp.mdx:14` tells operators that OAuth buttons will not work |
@@ -95,9 +95,9 @@ is fixed by the locked mcp-server ADR.
 | Serialized JSON mirrored into a `TextContent` block | S7 `#structured-content` SHOULD | Deliberate deviation | ADR "Pagination and output bounds": 4 KiB summary only, never a duplicate row set. Rationale is token economy and a single bound. Pre-SEP-2106 clients cannot recover data from text; all named clients in `mcp.mdx` read `structuredContent` |
 | Tool execution errors carry `isError: true` with actionable text; protocol errors use JSON-RPC codes; internals not leaked | S7 `#error-handling`, S28, S30 | Met | Named safe errors (`invalid_cursor`, `invalid_argument`, `traversal_limit_reached`, `result_item_too_large`) at `cursor.go:33`; everything else collapses to `Hikyo operation refused` at `registry.go:213`; `handler_test.go:595` |
 | Outputs sanitised: no secrets, env, tokens, paths | S7 MUST, S23 CVE-2026-67357, S24 | Met, exceeds | `mapConfiguration` at `tools.go:498` and `mapPending` keep plaintext only for `config` classification; canary secret fixture in `mcp_e2e_test.go:167`, `mcp_pagination_test.go:190`, `tools_test.go:284` |
-| Rate limiting on `tools/call` | S7 MUST, S21, S26 | Met, exceeds | Datastore-coordinated token bucket 60/min, burst 20, concurrency 4 per principal, 8 per org, 64 per instance (`mcp_admission.go:62`); uniform 429 with `Retry-After` (`handler.go:325`); per-IP admission on discovery (`handler.go:243`); `tools_test.go:245`, `handler_test.go:411`, `:615` |
+| Rate limiting on `tools/call` | S7 MUST, S21, S26 | Met, exceeds | Datastore-coordinated token bucket 60/min, burst 20, concurrency 4 per principal, 8 per org, 64 per instance (`mcp_admission.go:62`); uniform 429 with `Retry-After` (`handler.go:336`); per-IP admission on discovery (`handler.go:246`); `tools_test.go:245`, `handler_test.go:411`, `:615` |
 | Rate limiting charged only after authorization, so guessed ids cannot occupy tenant budgets | ADR, S21 | Met | `MCPAdmission.Acquire` authorizes before claiming capacity; `mcp_e2e_test.go:305` proves an unauthorized principal consumes zero buckets |
-| Pre-authentication flood on `tools/call` with a bogus bearer | S7, S21 | Met, parity with REST | Bounded by the 64 instance slots (`handler.go:257`), the 30 s deadline, and the global 512-request cap. Token lookup is a hash-verifier read, not a KDF (`machine.go:66`), so the cost per probe is one indexed read. REST applies its per-IP `Enter` limiter only to password and factor paths, so MCP matches the REST bearer path exactly |
+| Pre-authentication flood on `tools/call` with a bogus bearer | S7, S21 | Met, parity with REST | Bounded by the 64 instance slots (`handler.go:268`), the 30 s deadline, and the global 512-request cap. Token lookup is a hash-verifier read, not a KDF (`machine.go:66`), so the cost per probe is one indexed read. REST applies its per-IP `Enter` limiter only to password and factor paths, so MCP matches the REST bearer path exactly |
 | Cross-call handles are random, opaque, bound, expiring | S13 `#state-handle-hijacking`, S7 `#stateful-tools` | Met, exceeds | Cursors are AEAD-sealed under a keyring-derived key, bound to tool, scope ids, and page size, expire in 15 minutes without renewal, and carry no bearer or principal (`cursor.go:88`); `tools_test.go:193`, `:210`, `:223`, `cursor_test.go` |
 | Human in the loop is a client obligation; server keeps read-only tools genuinely read-only | S7 `#user-interaction-model` | Met | Registry refuses non-read operations at construction |
 | Untrusted tenant text in outputs stays typed data, never instructions | S25, S20 | Met | ADR "Secret and model-context boundary": descriptions and notes are structured fields, never concatenated into `instructions`; no `instructions` field is served |
@@ -115,8 +115,8 @@ is fixed by the locked mcp-server ADR.
 
 | Practice | Source | Bucket | Evidence |
 | --- | --- | --- | --- |
-| `server/discover` implemented with `supportedVersions` | S10 MUST | Met | `handler.go:344` forces the pinned list; `handler_test.go:160` |
-| Missing `_meta` fields produce 400 and -32602 | S9 `#_meta` MUST | Met | `handler.go:210` hands the SDK the schema check; `handler_test.go:396` |
+| `server/discover` implemented with `supportedVersions` | S10 MUST | Met | `handler.go:355` forces the pinned list; `handler_test.go:160` |
+| Missing `_meta` fields produce 400 and -32602 | S9 `#_meta` MUST | Met | `handler.go:213` hands the SDK the schema check; `handler_test.go:396` |
 | `resultType` and `serverInfo` in every result | S9 MUST and SHOULD | Met | Probe confirmed both on discover, list, and call |
 | No emission of -32002, -32042, or private codes outside the defined set | S9 `#error-codes` MUST NOT | Met | Hikyo emits only -32020, -32022, -32601; SDK v1.7.0 maps resource-not-found to -32602 by default |
 | JSON Schema 2020-12; no network `$ref`; bounded complexity | S9 | Met | Schemas are inferred from Go structs at boot and contain no `$ref` |
@@ -150,7 +150,7 @@ finding.
 ### A. Invalid or expired bearer returns 200 with a tool error instead of 401
 
 **What happens.** A `tools/call` with a missing bearer gets 401 with
-`WWW-Authenticate: Bearer` (`handler.go:265`). A `tools/call` with a present
+`WWW-Authenticate: Bearer` (`handler.go:276`). A `tools/call` with a present
 but invalid, expired, or revoked bearer reaches the service, fails
 `domain.ErrUnauthenticated` inside the transaction, and is collapsed to the
 tool-level `Hikyo operation refused` with HTTP 200 and `isError: true`
@@ -197,7 +197,7 @@ the probe has a negative test that rejects the old tool-error denial.
 - A2 (recommended): map `domain.ErrUnauthenticated` from the tool handler to a
   uniform 401 with `WWW-Authenticate: Bearer` and no body detail, using the
   same `callState` mechanism that already turns `ErrRateLimited` into a
-  uniform 429 (`handler.go:74`, `:325`). Revoked and invalid stay
+  uniform 429 (`handler.go:74`, `:336`). Revoked and invalid stay
   byte-identical, now both 401. Requires an ADR amendment sentence and updates
   to the two e2e assertions.
 
@@ -220,16 +220,19 @@ not a bypass.
 **Resolution (2026-09-10): B1 implemented.** `decodeHeaderSentinel` in
 `handler.go` mirrors the SDK's `decodeHeaderValue` rule and the decoded name is
 written back to the request header before the SDK validator runs. Upstream
-omission for `Mcp-Name` still to be filed against go-sdk.
+fixed the same omission in go-sdk #1242 (2026-09-06) and #1246 (2026-09-07),
+after v1.8.0-pre.2; no release carries it yet, so nothing needs filing. The
+adapter keeps its own decode because its mirror check runs before the SDK.
 
 **Options considered.**
 
 - B1 (recommended): decode the sentinel in `handler.go` before the `Mcp-Name`
   comparison, mirroring the SDK's `decodeHeaderValue` rule (strict base64,
   reject on decode failure), and add one test with an encoded name. Roughly
-  ten lines. File the `Mcp-Name` omission upstream against go-sdk.
+  ten lines.
 - B2: accept and track; revisit when go-sdk v1.8.0 stabilises and check
-  whether the upstream validator gained the decode.
+  whether the upstream validator gained the decode (it did, on `main`, in
+  #1242).
 
 ## Follow-ups that are not findings
 

--- a/docs/research/mcp-best-practices-sources-2026-09-09.md
+++ b/docs/research/mcp-best-practices-sources-2026-09-09.md
@@ -1,0 +1,355 @@
+# MCP server best practices: primary-source catalogue (2026-09-09)
+
+Purpose: checkable practices for auditing a Go MCP server (official go-sdk v1.7.0, Streamable HTTP, stateless, JSON responses, protocol 2026-07-28, bearer-token auth, tools only, read-only). External sources only; repo code was not read.
+
+Freshness window: sources published on or after 2026-06-09 are marked "yes". Everything else is marked "no" and is NOT relabelled as new.
+
+RFC keywords (MUST / SHOULD / MAY) are quoted only where the source is normative. Section anchors are given as `#anchor` on the cited page.
+
+## 1. Source table
+
+| # | Source | URL | Publisher | Publication date | Primary / secondary | In window (>= 2026-06-09)? |
+|---|---|---|---|---|---|---|
+| S1 | MCP spec 2026-07-28: Streamable HTTP transport | https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http | MCP project (modelcontextprotocol.io) | 2026-07-28 (revision date) | primary, normative | yes |
+| S2 | MCP spec 2026-07-28: Transports overview | https://modelcontextprotocol.io/specification/2026-07-28/basic/transports | MCP project | 2026-07-28 | primary, normative | yes |
+| S3 | MCP spec 2026-07-28: Authorization | https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization | MCP project | 2026-07-28 | primary, normative | yes |
+| S4 | MCP spec 2026-07-28: Authorization Security Considerations | https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/security-considerations | MCP project | 2026-07-28 | primary, normative | yes |
+| S5 | MCP spec 2026-07-28: Authorization Server Discovery | https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/authorization-server-discovery | MCP project | 2026-07-28 | primary, normative | yes |
+| S6 | MCP spec 2026-07-28: Versioning and Compatibility (the `basic/lifecycle` URL resolves here) | https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning | MCP project | 2026-07-28 | primary, normative | yes |
+| S7 | MCP spec 2026-07-28: Tools | https://modelcontextprotocol.io/specification/2026-07-28/server/tools | MCP project | 2026-07-28 | primary, normative | yes |
+| S8 | MCP spec 2026-07-28: Pagination | https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/pagination | MCP project | 2026-07-28 | primary, normative | yes |
+| S9 | MCP spec 2026-07-28: Base protocol overview (statelessness, `_meta`, error codes, JSON Schema) | https://modelcontextprotocol.io/specification/2026-07-28/basic/index | MCP project | 2026-07-28 | primary, normative | yes |
+| S10 | MCP spec 2026-07-28: Discovery (`server/discover`) | https://modelcontextprotocol.io/specification/2026-07-28/server/discover | MCP project | 2026-07-28 | primary, normative | yes |
+| S11 | MCP spec 2026-07-28: Caching (`ttlMs`, `cacheScope`) | https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching | MCP project | 2026-07-28 | primary, normative | yes |
+| S12 | MCP spec 2026-07-28: Changelog | https://modelcontextprotocol.io/specification/2026-07-28/changelog | MCP project | 2026-07-28 | primary | yes |
+| S13 | Security Best Practices (tutorial page; the `specification/.../basic/security_best_practices` URL serves the identical document) | https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices | MCP project | 2026-07-28 (versioned with the spec; no separate date shown) | primary; normative standing unclear, see caveats | yes |
+| S14 | MCP blog: The 2026-07-28 Specification | https://blog.modelcontextprotocol.io/posts/2026-07-28/ | MCP project (D. Soria Parra, D. Delimarsky) | 2026-07-28 | primary (project blog) | yes |
+| S15 | MCP blog: The New MCP Roadmap | https://blog.modelcontextprotocol.io/posts/mcp-roadmap/ | MCP project (D. Soria Parra, D. Delimarsky) | 2026-08-22 | primary (project blog) | yes |
+| S16 | go-sdk releases page | https://github.com/modelcontextprotocol/go-sdk/releases | MCP project / Google | v1.7.0 on 2026-07-28; v1.8.0-pre.1 and pre.2 on 2026-09-04 | primary | yes |
+| S17 | go-sdk security advisories | https://github.com/modelcontextprotocol/go-sdk/security/advisories | MCP project | latest advisory 2026-03-30 | primary | no (all four advisories predate the window) |
+| S18 | go-sdk v1.7.0 `mcp/streamable.go` (source) | https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/v1.7.0/mcp/streamable.go | MCP project | 2026-07-28 (tag date) | primary | yes |
+| S19 | go-sdk v1.7.0 `auth/auth.go` (source) | https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/v1.7.0/auth/auth.go | MCP project | 2026-07-28 (tag date) | primary | yes |
+| S20 | Microsoft Security Blog: The state of MCP security in 2026 | https://techcommunity.microsoft.com/blog/microsoft-security-blog/the-state-of-mcp-security-in-2026/4531327 | Microsoft (J. Thakur, S. Pradhan) | 2026-06-26 (updated 2026-06-30) | secondary | yes |
+| S21 | Cloudflare blog: MCP security updates | https://blog.cloudflare.com/mcp-security-updates/ | Cloudflare (K. Johnson) | 2026-08-14 (modified 2026-08-18) | secondary | yes |
+| S22 | Pillar Security: Deadbugz, currently active MCP supply chain campaign | https://www.pillar.security/blog/deadbugz-currently-active-mcp-supply-chain-campaign | Pillar Security (A. Fogel) | 2026-08-12 | secondary (incident primary source) | yes |
+| S23 | Adversa AI: Top MCP security resources, September 2026 | https://adversa.ai/blog/top-mcp-security-resources-september-2026/ | Adversa AI (S. Malenkovich) | 2026-09-07 | secondary (digest) | yes |
+| S24 | arXiv 2608.00150: Exposed by Design (internet-facing MCP audit) | https://arxiv.org/abs/2608.00150 | N. Padilla | 2026-07-31 (v1) | primary (research) | yes |
+| S25 | mcpservers.org: MCP Security Best Practices, practical guide for 2026 | https://blog.mcpservers.org/posts/mcp-security-best-practices | mcpservers.org (M. Webb) | 2026-07-10 | secondary | yes |
+| S26 | Cloud Security Alliance: Agentic MCP Security Best Practices Guide v1 (marked draft) | https://labs.cloudsecurityalliance.org/agentic/agentic-mcp-security-best-practices-v1/ | CSA | 2026-03-27 | secondary | no |
+| S27 | OWASP GenAI: A Practical Guide for Secure MCP Server Development | https://genai.owasp.org/resource/a-practical-guide-for-secure-mcp-server-development/ | OWASP GenAI Security Project | 2026-02-16 | secondary | no |
+| S28 | Anthropic Engineering: Writing effective tools for agents | https://www.anthropic.com/engineering/writing-tools-for-agents | Anthropic | 2025-09-11 | secondary | no |
+| S29 | Snyk: 5 best practices for building MCP servers | https://snyk.io/articles/5-best-practices-for-building-mcp-servers/ | Snyk (L. Tal) | 2025-05-27 | secondary | no |
+| S30 | modelcontextprotocol.info: MCP Best Practices (unofficial mirror site) | https://modelcontextprotocol.info/docs/best-practices/ | ModelContextProtocol.Info (third party) | undated (footer "2024") | secondary, unofficial | no |
+| S31 | YouTube: MCP Just Got a Whole Lot Better | https://youtu.be/BqRhBq-_kgE | Neon Postgres (YouTube channel) | 2026-09-08 | secondary; video NOT watched | yes (metadata only) |
+
+Sources that were searched for but not fetched or not found: an official MCP blog post specifically on security in the window (none exists; the blog posts in window are S14 and S15). OWASP has no MCP-specific release in the window (their 2026-09-02 announcement covers LLM Top 10 2026 and an Agent Control Standard, not MCP servers: https://www.prnewswire.com/news-releases/owasp-genai-security-project-releases-2026-top-10-for-llm-applications-debuts-agent-control-standard-and-new-resources-for-securing-generative-and-agentic-ai-302867085.html).
+
+## 2. Normative spec requirements (2026-07-28), server side
+
+### 2.1 Statelessness and `_meta` (S9)
+
+- Servers MUST NOT rely on prior requests over the same connection to establish context (capabilities, protocol version, client identity). `#statelessness`
+- State spanning requests MUST be referenced by an explicit identifier the client passes on each request. `#statelessness`
+- Every request MUST carry `_meta["io.modelcontextprotocol/protocolVersion"]` and `_meta["io.modelcontextprotocol/clientCapabilities"]`; a request missing either is malformed and the server MUST reject it with JSON-RPC `-32602`; on HTTP the status MUST be `400`. `#_meta`
+- Server MUST NOT rely on capabilities the client has not declared; if a capability is required and absent, return `MissingRequiredClientCapabilityError` (`-32021`) with HTTP `400`. `#_meta`
+- Servers SHOULD include `_meta["io.modelcontextprotocol/serverInfo"]` in every result. `#_meta`
+- `clientInfo`/`serverInfo` are self-reported; implementations SHOULD NOT use them for behaviour or security decisions. `#_meta`
+- Every result MUST include `resultType` (`"complete"` for ordinary results). `#result-responses`
+- Error codes: `-32020` HeaderMismatch, `-32021` MissingRequiredClientCapability, `-32022` UnsupportedProtocolVersion. Implementations MUST NOT emit codes in `-32020..-32099` other than those defined; MUST NOT emit `-32002` (resource not found is now `-32602`) or `-32042`; new implementations SHOULD NOT use `-32000..-32019`. `#error-codes`
+- JSON Schema: MUST support 2020-12 as default dialect; MUST NOT auto-dereference network `$ref`s (opt-in only, disabled by default, allowlist or reject loopback/link-local/private ranges, timeouts, size limits, logging); SHOULD bound schema depth / subschema count / validation time to prevent DoS. `#json-schema-usage`, `#ref-resolution`, `#composition-keyword-resource-use`
+
+### 2.2 Versioning and discovery (S6, S10)
+
+- No handshake; every request declares its version. Unsupported version: server MUST respond with `UnsupportedProtocolVersionError` (`-32022`) listing `supported` versions. `#protocol-version-negotiation`
+- Servers MUST implement `server/discover`. Result includes `supportedVersions`, `capabilities`, optional `instructions`; servers SHOULD include `serverInfo` in `_meta`. (S10 `#response`, `#discoverresult`)
+- A modern-only server SHOULD name the protocol versions it supports in any error it returns to a legacy `initialize` request. (S6 `#backward-compatibility-with-initialization-based-versions`)
+- Legacy client hitting a modern HTTP server: request lacks required headers and is rejected with `400` per server validation. (S6 compatibility matrix)
+
+### 2.3 Streamable HTTP transport (S1, S2)
+
+Security and endpoint (`#security--endpoint`):
+- Server MUST provide a single MCP endpoint path that supports POST.
+- Servers MUST validate the `Origin` header on all incoming connections to prevent DNS rebinding. If `Origin` is present and invalid, servers MUST respond `403 Forbidden` (body MAY be an id-less JSON-RPC error).
+- When running locally, servers SHOULD bind only to `127.0.0.1`, not `0.0.0.0`.
+- Servers SHOULD implement proper authentication for all connections.
+
+Sending messages (`#sending-messages`):
+- Client MUST send `Accept` listing both `application/json` and `text/event-stream`.
+- Body MUST be a single JSON-RPC request or notification; no batches, no client-sent responses.
+- Notification accepted: server MUST return `202 Accepted` with no body. Not accepted: MUST return an HTTP error status (e.g. `400`).
+- Request: server MUST return `Content-Type: application/json` (single JSON object) or `Content-Type: text/event-stream`. Either is compliant; a JSON-only server is allowed.
+- No client-to-server notifications are defined in this revision on HTTP; `notifications/cancelled` is stdio only.
+
+Receiving / SSE (`#receiving-messages`): only relevant if SSE is used. Notifications on an SSE stream MUST relate to the originating request; server MUST NOT send independent JSON-RPC requests; final response SHOULD terminate the stream; SHOULD send `X-Accel-Buffering: no`; `Last-Event-ID` resumability is not supported.
+
+Cancellation (`#cancellation`): closing the response stream MUST be treated as cancellation; server SHOULD stop work as soon as practical and MUST NOT send further messages for it.
+
+Request metadata (`#request-metadata`, `#protocol-version-header`, `#standard-request-headers`, `#server-validation`):
+- Every POST MUST include `MCP-Protocol-Version`; the value MUST match `_meta` protocolVersion; on mismatch the server MUST reject with `400` and `-32020 HeaderMismatch`.
+- Unsupported version: MUST respond `400` with `UnsupportedProtocolVersionError`.
+- Unknown RPC method: MUST respond `404 Not Found` with JSON-RPC `-32601`.
+- Missing `MCP-Protocol-Version`: server MAY treat as `2025-03-26` only if it supports pre-2025-06-18 clients; otherwise MUST reject per server validation.
+- `Mcp-Method` (all requests) and `Mcp-Name` (`tools/call`, `resources/read`, `prompts/get`) are REQUIRED for compliance.
+- Servers that process the body MUST reject requests where header values do not match body values, returning `400` and JSON-RPC `-32020`. Failure conditions: required standard header missing; header/body mismatch (after Base64 sentinel decoding for `Mcp-Name` and `Mcp-Param-*`); invalid characters.
+- Servers MUST decode `=?base64?...?=` sentinel values before comparison. Integer `Mcp-Param-*` values SHOULD be compared numerically.
+- Header names MUST be compared case-insensitively; values are case-sensitive. `#case-sensitivity`
+- `x-mcp-header` is optional for servers (MAY). If used: value MUST be non-empty, token syntax, no CR/LF, case-insensitively unique, primitive types only (no `number`), statically reachable via `properties` chain. Server developers SHOULD NOT mark sensitive parameters (passwords, keys, tokens, PII) with `x-mcp-header` (S7 `#x-mcp-header`).
+- Servers MUST reject requests with a recognized `Mcp-Param-*` header containing invalid characters. `#server-behavior-for-custom-headers`
+
+Backward compatibility (`#earlier-streamable-http-revisions`): a server supporting only this revision SHOULD respond to GET or DELETE on the MCP endpoint with `405 Method Not Allowed`; SHOULD ignore `Mcp-Session-Id` and never mint or echo session ids; SHOULD ignore `Last-Event-ID`. HTTP+SSE (2024-11-05) is Deprecated; new implementations SHOULD NOT adopt it.
+
+Transports overview (S2): JSON-RPC messages MUST be UTF-8. Body is the source of truth; bindings that mirror metadata define how mismatches are rejected. `#messages`, `#request-metadata`
+
+### 2.4 Authorization (S3, S4, S5)
+
+Scope note for the audit: "Authorization is OPTIONAL for MCP implementations. When supported: implementations using an HTTP-based transport SHOULD conform to this specification." (S3 `#protocol-requirements`). The framework is OAuth 2.1 resource-server behaviour. A server that authenticates with a pre-shared static bearer token is not implementing the OAuth framework, so the RFC 9728 / discovery MUSTs below are conditional on adopting it. Servers and clients "MAY negotiate their own custom authentication and authorization strategies" (S9 `#auth`). The audience-binding and no-passthrough rules are the ones that transfer directly to any bearer scheme.
+
+If the OAuth framework is adopted:
+- MCP servers MUST implement OAuth 2.0 Protected Resource Metadata (RFC 9728). (S3 `#overview` item 4)
+- PRM document MUST include `authorization_servers` with at least one entry. (S5 `#authorization-server-location`)
+- Servers MUST implement at least one discovery mechanism: `WWW-Authenticate: Bearer resource_metadata="..."` on `401`, or the well-known URI (path-aware `/.well-known/oauth-protected-resource/<path>` or root). (S5 `#protected-resource-metadata-discovery-requirements`)
+- Servers SHOULD include `scope` in the `WWW-Authenticate` challenge. (S3 `#scope-selection-strategy`)
+- Servers SHOULD NOT include `offline_access` in `WWW-Authenticate` scope or `scopes_supported`. (S3 `#refresh-tokens`)
+
+Applies to any bearer-token server:
+- Access token MUST be in the `Authorization: Bearer` header on every request; MUST NOT be in the URI query string. (S3 `#token-requirements`)
+- MCP servers MUST validate access tokens per OAuth 2.1 section 5.2; MUST validate the token was issued specifically for them as audience (RFC 8707); invalid or expired tokens MUST receive `401`. (S3 `#token-handling`)
+- MCP servers MUST only accept tokens valid for their own resources and MUST NOT accept or transit any other tokens. (S3 `#token-handling`; S4 `#access-token-privilege-restriction`; S13 `#token-passthrough`)
+- If the server calls upstream APIs it MUST NOT pass through the token it received from the client. (S4 `#access-token-privilege-restriction`)
+- Servers MUST return `401` (authorization required or token invalid), `403` (invalid scopes / insufficient permissions), `400` (malformed authorization request). (S3 `#error-handling`)
+- Insufficient scope at runtime: server SHOULD respond `403` with `WWW-Authenticate: Bearer error="insufficient_scope", scope="...", resource_metadata="..."`, optional `error_description`; SHOULD include all scopes required for the operation in a single challenge; SHOULD be consistent. (S3 `#runtime-insufficient-scope-errors`)
+- Servers MUST account for scope hierarchies when deciding token sufficiency. (S3 `#step-up-authorization-flow`)
+- Clients and servers MUST implement secure token storage; tokens cached or logged on the server are a theft vector. (S4 `#token-theft`)
+- All authorization server endpoints MUST be HTTPS. (S4 `#communication-security`)
+- Implementors MUST follow OAuth 2.1 section 7 security considerations. (S4 intro)
+
+### 2.5 Tools (S7)
+
+- Servers that support tools MUST declare the `tools` capability. `#capabilities`
+- `tools/list` MUST return the set currently available to the requesting client; MUST NOT vary per-connection or as a side effect of other requests; MAY vary by the authorization presented on the request. `#capabilities`
+- Servers SHOULD return tools in deterministic order. `#capabilities`
+- Every request MUST include required `_meta` fields (page note).
+- `inputSchema` MUST be a valid JSON Schema object (not `null`). For no-parameter tools the recommended form is `{"type":"object","additionalProperties":false}`. `#tool`
+- Clients MUST treat annotations as untrusted unless the server is trusted (so annotations are hints only; the server's actual behaviour must match). `#tool`
+- Tool names SHOULD be 1..128 chars, case-sensitive, only `A-Za-z0-9_-.`, SHOULD NOT contain spaces/commas, SHOULD be unique within the server. `#tool-names`
+- Structured content: if `outputSchema` is provided, servers MUST return `structuredContent` conforming to it; a tool returning structured content SHOULD also return the serialized JSON in a `TextContent` block. `#structured-content`, `#output-schema`
+- Errors: protocol errors (unknown tool, malformed request, server error) are JSON-RPC errors (`-32602` for unknown tool); tool execution errors (API failure, input validation, business logic) go in the result with `isError: true` and actionable text. `#error-handling`
+- Security Considerations, servers MUST: validate all tool inputs; implement proper access controls; rate limit tool invocations; sanitize tool outputs. `#security-considerations`
+- Human in the loop: there SHOULD always be a human with the ability to deny tool invocations (client-side obligation, but the server should not assume auto-approval). `#user-interaction-model`
+- Stateful tools (non-normative): handle is a name, not a capability; validate caller authorization against the handle on every call; opaque, high-entropy, bounded lifetime; state retention policy in tool description; expired handle returns a tool execution error. `#stateful-tools`
+
+### 2.6 Pagination (S8)
+
+- Cursor is an opaque string; page size is server-determined. `#pagination-model`
+- Servers SHOULD provide stable cursors and handle invalid cursors gracefully. `#implementation-guidelines`
+- Invalid cursors SHOULD return `-32602` (Invalid params). `#error-handling`
+- `tools/list` is a paginated operation. `#operations-supporting-pagination`
+- Related security data point: arXiv 2608.00150 (S24) found "path traversal via cursor manipulation" in production servers, so cursors that encode file paths or offsets without integrity protection are a real-world bug class.
+
+### 2.7 Caching (S11)
+
+- Servers MUST include `ttlMs` (>= 0) and `cacheScope` on `resultType: "complete"` results of `server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, `resources/read`. `#cacheable-results`, `#time-to-live-ttl-field`
+- `cacheScope` MUST be the same across all pages of one list request. `#interaction-with-pagination`
+- Security: `"public"` results may be shared across authorization contexts even from an authenticated endpoint. Servers MUST apply per-primitive access controls and MUST NOT rely on `cacheScope` alone. If `tools/list` output varies by token, it must be `"private"`. `#security-considerations`
+
+### 2.8 Security Best Practices document (S13), server-relevant items
+
+- Token passthrough: MCP servers MUST NOT accept any tokens not explicitly issued for the MCP server. `#token-passthrough`
+- State handle hijacking: servers that implement authorization MUST verify all inbound requests; MUST NOT treat possession of a state handle as authentication; SHOULD use secure random non-deterministic handles; SHOULD bind handles server-side to the authenticated user (`<user_id>:<handle>`, user id from the verified token). `#state-handle-hijacking`
+- Local servers over HTTP SHOULD require an authorization token or use unix sockets / IPC. `#local-mcp-server-compromise`
+- Scope minimization: minimal initial scope set; precise scope challenges; log elevation events with correlation ids; do not treat claimed scopes as sufficient without server-side authorization logic. `#scope-minimization`
+- Not applicable to a tools-only, read-only, non-proxy server: confused deputy consent flow (`#confused-deputy-problem`), SSRF during OAuth discovery (client obligation, `#server-side-request-forgery-ssrf`), OAuth authorization URL validation (client), stdio proxy escalation, mix-up attacks (client), CIMD trust policies (authorization server).
+
+### 2.9 Changelog highlights relevant to the audit (S12)
+
+- Sessions and `Mcp-Session-Id` removed (SEP-2567); `initialize` handshake removed, `_meta` per request (SEP-2575); `server/discover` MUST (SEP-2575); GET endpoint replaced by `subscriptions/listen` (SEP-2575); `ping`, `logging/setLevel` removed; servers MUST NOT emit `notifications/message` for requests without `logLevel` in `_meta`; SSE resumability removed; `resultType` required (SEP-2322); `Mcp-Method`/`Mcp-Name` required and `x-mcp-header` added (SEP-2243); `ttlMs`/`cacheScope` required (SEP-2549); resource-not-found `-32002` to `-32602`; error code partition with renumbering to `-32020/-32021/-32022`; Roots, Sampling, Logging deprecated (SEP-2577); HTTP+SSE deprecated; DCR deprecated in favour of CIMD.
+
+## 3. Per-source practices (non-normative sources)
+
+### S14 MCP blog, The 2026-07-28 Specification (2026-07-28)
+- Streamable HTTP requests must include `Mcp-Method`, `Mcp-Name`, and `MCP-Protocol-Version: 2026-07-28`; gateways can route and rate-limit on headers rather than bodies.
+- Cross-call state: mint an explicit handle from a tool and have the model pass it back.
+- All four Tier 1 SDKs (TypeScript, Python, Go, C#) support 2026-07-28 as of release day; expect migration effort for servers that depended on session ids.
+- DCR deprecated in favour of CIMD; issuer validation (RFC 9207, SEP-2468); issuer-bound client credentials (SEP-2352).
+
+### S15 MCP blog, The New MCP Roadmap (2026-08-22)
+- Priority areas: agentic messaging primitives, HTTP-native transport unification, agent identity and enterprise security (DPoP RFC 9449 finalisation, workload identity federation via spec PR #1933, token exchange), improved primitives (one contract for `tools/call` result forms, progressive discovery), SDK DX and conformance testing.
+- No next revision date given. Nothing here changes 2026-07-28 server obligations; DPoP is forward-looking.
+
+### S20 Microsoft, The state of MCP security in 2026 (2026-06-26)
+- Treat tool descriptions and tool outputs as untrusted input.
+- Treat MCP servers as OAuth 2.0 resource servers; audience-bound tokens; identity-aware gateway in front of every server rejecting calls lacking a valid audience-bound token; example validates issuer, audience, expiry.
+- Least privilege per resource, narrow scopes, short-lived tokens; a governable identity per agent.
+- Approval cannot be a one-time event: pin tool definitions, alert on drift (rug-pull tripwire), registry as known-good baseline.
+- Sandbox local stdio servers; block outbound by default; validate and sanitize every input and output; never pass raw shell commands or unsanitized paths; keep SDKs patched (called one of the largest MCP vulnerability classes this year).
+
+### S21 Cloudflare, MCP security updates (2026-08-14)
+- `MCP-Protocol-Version` is the strong network fingerprint; 2026-07-28 traffic is trivially identifiable by inspecting proxies. Absence proves nothing.
+- Three control points: client hooks, network gateway, the server itself (richest context, last chance to deny).
+- Server-side middleware should authorize the caller per tool, rate limit, inspect arguments, and record outcomes before invoking the handler.
+- Tool risk tiers (read-only through critical); reads pass, writes get attribution plus audit event, critical blocked before handler.
+- Tool arguments are the most sensitive element of a call for logging purposes; logging only after execution explains but cannot prevent.
+- Origins should reject direct requests that bypass a gateway (Access policy, source-IP restriction, or enterprise authorization).
+- DCR deprecation means many providers require pre-registered clients with fixed credentials.
+
+### S22 Pillar Security, Deadbugz (2026-08-12) and S23 Adversa digest (2026-09-07)
+- Runtime-gated metadata poisoning: server serves benign tool descriptions until the third `tools/call`, then swaps `tools/list` / `prompts/get` content to exfiltrate credentials. Advertises `tools.listChanged` so clients refresh.
+- Defences: tool descriptions and schemas are a security boundary; fingerprint tool definitions at approval and diff on every reconnect; treat any change to an approved server's definitions as a security event requiring re-approval; keep sensitive actions policy-enforced, not metadata-driven.
+- For a server author the checkable mirror image: tool list and descriptions must be deterministic, static, and not vary on call count or client (this is also the spec MUST NOT in S7 `#capabilities`).
+- August 2026 CVEs cited by S23: CVE-2026-73498 Atlassian MCP (client-supplied path into `open()`, arbitrary file read, CVSS 7.7, fixed 0.22.0); CVE-2026-67357 ArcadeDB MCP (settings tool returned HA cluster token in cleartext, CVSS 7.7, fixed 26.7.3); CVE-2026-19956 facebook-ads-mcp-server (SSRF in `fetch_pagination_url`, CVSS 5.3). All three are classic web flaws, none model-specific. Primary records: https://nvd.nist.gov/vuln/detail/CVE-2026-73498 , https://www.cve.org/CVERecord?id=CVE-2026-67357 , https://www.cve.org/CVERecord?id=CVE-2026-19956 (CVE pages not fetched; data as reported by S23).
+- S23 guidance: watch tool metadata for post-approval drift; reconstruct full agent action chains; put a token-validating, scoped authorization layer in front of MCP servers; red-team it.
+
+### S24 arXiv 2608.00150, Exposed by Design (2026-07-31, N. Padilla)
+- 21,000+ MCP instances visible; 640 confirmed production servers; 414 audited; 68 reportable vulnerabilities (SQL injection, SSRF to cloud metadata, prompt template injection, path traversal via cursor manipulation); 91.8% lack OAuth authentication; 687 tool instances expose shell execution without access control; 41.6% churn within three days.
+- Checkable takeaways: pagination cursors must not be trusted as paths or offsets; tool outputs that echo secrets (config, env, tokens) are a recurring finding; unauthenticated exposure is the norm, so bearer auth is already above baseline.
+
+### S25 mcpservers.org, MCP Security Best Practices (2026-07-10)
+- Implement OAuth 2.1; do not build a custom auth scheme.
+- No token passthrough; validate audience; mint or exchange audience-scoped downstream credentials.
+- Session/handle ids: cryptographically random; bind to user identity; never treat an id as authentication.
+- Tool descriptions narrow, factual, free of anything that reads like an instruction to the model.
+- Wrap untrusted external content in tool output with clear delimiters, labelled as data (reduces, does not solve, prompt injection).
+- Treat every tool argument as untrusted; validate types, ranges, formats server-side; never concatenate into shell or SQL.
+- Start clients on minimal read-only scopes; short-lived scoped tokens.
+- Log tool invocations, arguments, caller identity, outcome; note that logging full bodies leaks tokens (no explicit redaction guidance given).
+- Does not discuss the HTTP `Origin` header. References `/specification/latest`, not a dated revision.
+
+### S26 CSA, Agentic MCP Security Best Practices Guide (2026-03-27, marked draft; out of window)
+- TLS 1.2+ mandatory, 1.3 preferred; CA-issued certificates; no plaintext HTTP; beware tunnel subdomain reuse (ngrok style).
+- OAuth 2.1 with PKCE; validate RFC 8414 metadata; scopes at tool level; per-invocation authorization checks.
+- Access tokens <= 1 hour; never store tokens in plaintext files or env vars; fetch from secret managers.
+- Sign or hash tool descriptions; treat definitions as versioned immutable artifacts; surface changes visibly.
+- Logging: agent identity, tool name, parameters with sensitive values redacted, timestamp, status, duration; central SIEM; >= 90 days retention; append-only audit log at top maturity.
+- Supply chain: curated registry, SBOM, continuous dependency monitoring, remediation windows (30 days High/Critical; 72 hours CVSS >= 9.0).
+- Least privilege: minimal service account; read-only tools must not carry write/delete scopes; tenant id as mandatory filter on data access.
+- Rate limiting: per-execution CPU/memory quotas; hard timeouts; gateway-enforced rate limits with alerting.
+- Sandboxing: containers or micro-VMs; filesystem and outbound network deny by default.
+- Maps to OWASP ASI01..ASI06, CSA AICM controls, MITRE ATLAS technique ids.
+
+### S27 OWASP GenAI, A Practical Guide for Secure MCP Server Development (2026-02-16; out of window)
+- Only the listing page was fetched; the guide body (PDF) was not. Listing summary: MCP servers run with delegated user permissions, dynamic tool-based architectures, and chained tool calls, raising the impact of a single compromise. Companion cheat sheet for third-party servers dated 2025-11-04: https://genai.owasp.org/resource/cheatsheet-a-practical-guide-for-securely-using-third-party-mcp-servers-1-0/
+
+### S28 Anthropic, Writing effective tools for agents (2025-09-11; out of window)
+- Fewer, workflow-shaped tools over one-tool-per-endpoint; prefer search tools over list-all tools.
+- Namespace with service/resource prefixes; test prefix vs suffix with evals.
+- Return high-signal fields; resolve opaque ids to names; choose output format by evaluation.
+- Token efficiency: `response_format` enum (concise/detailed), pagination, filtering, truncation with guidance; Claude Code caps tool responses at 25,000 tokens by default.
+- Descriptions written as for a new hire; unambiguous parameter names (`user_id`, not `user`); strict data models; use MCP annotations to flag open-world or destructive tools.
+- Error messages: specific, actionable, show correct input format instead of tracebacks.
+- Build evals from realistic multi-step tasks; read raw transcripts.
+
+### S29 Snyk, 5 best practices (2025-05-27; out of window)
+- Tool names: no spaces, dots, parentheses; prefer snake_case.
+- Logging: never `console.log` to stdout on stdio; log to file. (HTTP logging not covered.)
+- Do not lead search-tool results with "not found" text; the model anchors on it.
+- Scan own code (command injection, path traversal) and dependencies; SBOM.
+- Package as a container.
+- Examples are JavaScript with zod; no protocol version cited.
+
+### S30 modelcontextprotocol.info, MCP Best Practices (undated; unofficial; out of window)
+- Not the official site (official is modelcontextprotocol.io). Footer says "2024"; navigation labels 2024-11-05 as "Current"; no protocol version cited in the body; code samples are pseudo-code with undefined helpers and no SDK.
+- Content is generic distributed-systems advice: single responsibility per server; bind to localhost; JWT auth; capability-based authorization; strict input schema validation; output sanitization; circuit breakers; token-bucket rate limiting; structured error categories with generic `INTERNAL_ERROR` to callers and full stack traces only in logs; connection pooling; multi-level caching; Prometheus metrics; structured JSON logs with method, duration, client id, result size; health and readiness probes; Kubernetes rolling updates; contract, load, and chaos tests.
+- Nothing MCP-transport-specific (no Origin, session, header, or tool-schema guidance). Treat as low-weight.
+
+### S31 YouTube, MCP Just Got a Whole Lot Better (Neon Postgres, 2026-09-08)
+- Title: "MCP Just Got a Whole Lot Better". Channel: Neon Postgres (https://www.youtube.com/@neondatabase). Published 2026-09-08 per page metadata; ~4.1K views at fetch time.
+- Description (paraphrased from the page): modern MCP clients use progressive tool discovery and code mode, so servers should expose ergonomic workflow tools instead of one tool per endpoint; covers layered discovery (search, inspect, execute), programmatic tool calling, and Neon's `createWithCompute`-style consolidation of three API calls into one tool. Chapters run 00:00 to 05:14.
+- The video content itself was NOT reviewed (yt-dlp unavailable); only page metadata was fetched. No claims about its content beyond the description are made here.
+
+## 4. go-sdk status (github.com/modelcontextprotocol/go-sdk)
+
+- Latest stable: v1.7.0, released 2026-07-28, the first release with full 2026-07-28 protocol support (S16). It is still marked "Latest" on GitHub.
+- Pre-releases: v1.8.0-pre.1 and v1.8.0-pre.2, both 2026-09-04 (S16). No new protocol revision; hardening and leak fixes:
+  - JSON nesting capped at 1000 levels; `MaxEventSize` on client transports; `StdioTransport.MaxLineLength`; OAuth DCR responses bounded to 1 MB; OAuth discovery metadata validated.
+  - New `ServerOptions.SupportedProtocolVersions` (narrow only; unknown versions panic at construction).
+  - Stateful handler receiving a 2026-07-28 request now returns JSON-RPC `-32022` instead of plain-text 400.
+  - New `ServerOptions.SetCacheable` hook for `ttlMs`/`cacheScope` per result.
+  - pre.2 removes MCPGODEBUG flags `seterroroverwrite`, `enableoriginverification`, `disablecontenttypecheck`, `disablelocalhostprotection`.
+  - Fixes: ServerSession leaks on stateful servers, `Client.Connect` leaks, `subscriptions/listen` close deadlock, ListTools panic on malformed tools, tolerate 404 on `subscriptions/listen` in stateless mode.
+- v1.7.0 behaviour confirmed from source (S18, S19), with spec comparison:
+  - `Stateless: true` is required to accept 2026-07-28; stateful sessions negotiate down to 2025-11-25 (S16). Stateless mode: GET and DELETE return `405` with `Allow: POST` (matches S1 SHOULD); `Mcp-Session-Id` ignored unless `MCPGODEBUG=allowsessionsinstateless=1`.
+  - Origin validation: `CrossOriginProtection` is nil by default, meaning NO `Origin` check runs. The field is deprecated; auto-population only happens with `MCPGODEBUG=enableoriginverification=1`, and that flag is deleted in v1.8.0-pre.2. Documented replacement: wrap the handler with `http.NewCrossOriginProtection().Handler(h)` (Go 1.25+). Check before shipping: that type rejects requests whose `Origin` host differs from the request `Host`, so browser-hosted MCP clients with a foreign `Origin` would get 403 unless trusted origins are registered (verify the trusted-origin method in the Go 1.25 `net/http` docs; not fetched here). Non-browser clients send no `Origin` and pass. Spec S1 says servers MUST validate `Origin` and return `403`. This is the same vulnerability class as GHSA-89xv-2j6f-qhc8 / CVE-2026-33252 (cross-site tool execution, fixed in v1.4.1 by adding Content-Type checking and a configurable origin check).
+  - DNS rebinding Host check: on by default. A request arriving on a loopback address with a non-loopback `Host` header gets `403` unless `DisableLocalhostProtection` is set. This is a Host check, not an Origin check; do not conflate the two.
+  - Content-Type: POST must be `application/json` (parameters tolerated) else `415`. Accept: POST must list both JSON and SSE else `400`.
+  - Body limit: `MaxRequestBodyBytes` default 4 MiB (`DefaultMaxRequestBodyBytes`), enforced with `http.MaxBytesReader`, `413` on overflow; negative disables (documented as unsafe for untrusted clients).
+  - `MCP-Protocol-Version` header: if present and unsupported, `400` listing supported versions. If absent, the SDK defaults to `2025-03-26` (legacy accept path). A 2026-07-28 body with `_meta` protocolVersion but no header is rejected with `400` and `-32020`. Spec S1 says a server that does not support pre-2025-06-18 clients MUST reject a header-less request; the SDK's default is the permissive MAY branch. Policy choice for the auditor.
+  - Header/body validation: `validateMcpHeaders` runs on single non-batch messages; mismatch returns HTTP `400` with JSON-RPC `-32020`, echoing the request id (matches S1 MUST).
+  - `JSONResponse: true` returns `Content-Type: application/json`; `subscriptions/listen` always forces SSE; notification-only POSTs return `202` with no body (matches S1).
+  - `PropagateRequestCancellation` defaults to false, so a tool handler keeps running after the client closes the connection. Spec S1 says the server SHOULD stop work as soon as practical. Recommend enabling for stateless 2026-07-28 servers.
+  - Rate limiting: nothing in the SDK. Spec S7 says servers MUST rate limit tool invocations; it has to be middleware.
+  - Error code: `CodeResourceNotFound` now equals `-32602`; the old `-32002` returns only with `MCPGODEBUG=customresnotfounderrcode=1` (spec S9 says implementations MUST NOT emit `-32002`).
+  - `auth.RequireBearerToken` (S19): parses `Authorization` with `strings.Fields`, requires exactly two fields with `bearer` (case-insensitive). Missing or malformed header: `401` "no bearer token". Verifier error unwrapping to `ErrInvalidToken`: `401`; `ErrOAuth`: `400`; anything else: `500`. Missing expiration (unless `AllowMissingExpiration`): `401`; expired beyond `ClockSkew`: `401`. Scope check runs before expiry: any required scope missing gives `403` "insufficient scope". `WWW-Authenticate: Bearer resource_metadata="...", scope="..."` is emitted on 401 and 403 only if `opts` has `ResourceMetadataURL` and/or `Scopes` set. There is no `error="insufficient_scope"` parameter and `scope=` lists all required scopes, not the missing ones. Spec S3 `#runtime-insufficient-scope-errors` is SHOULD-level, so this is a gap, not a violation. `TokenInfo` is available via `TokenInfoFromContext`.
+  - `auth.ProtectedResourceMetadataHandler` serves RFC 9728 JSON with `Access-Control-Allow-Origin: *`, no field validation.
+  - Things the release notes claim but that should be verified at runtime, not assumed: `ttlMs`/`cacheScope` are emitted on `tools/list` and `server/discover`; `structuredContent` is mirrored into a `TextContent` block; tool arguments are validated against `inputSchema` before the handler runs; `tools/list` ordering is deterministic; `ReadOnlyHint`/`IdempotentHint` are always serialized (v1.7.0 release note).
+- Advisories (S17): four published, all High, all before the window, all patched at or before v1.4.1:
+  - GHSA-wvj2-96wp-fq3f / CVE-2026-27896, 2026-02-25: case-insensitive `encoding/json` key matching (CWE-178/436), fixed 1.3.1. https://github.com/advisories/GHSA-wvj2-96wp-fq3f
+  - GHSA-89xv-2j6f-qhc8 / CVE-2026-33252, 2026-03-18: cross-site tool execution for HTTP servers without authorization (CWE-352, CVSS 7.1), affected <= 1.4.0, fixed 1.4.1. https://github.com/modelcontextprotocol/go-sdk/security/advisories/GHSA-89xv-2j6f-qhc8
+  - GHSA-q382-vc8q-7jhj (no CVE), 2026-03-18: null-Unicode key folding in `segmentio/encoding`, affected <= 1.4.0, fixed 1.4.1. https://github.com/modelcontextprotocol/go-sdk/security/advisories/GHSA-q382-vc8q-7jhj
+  - GHSA-xw59-hvm2-8pj6 / CVE-2026-34742, 2026-03-30: DNS rebinding protection disabled by default for localhost servers (CWE-1188), fixed 1.4.0. https://github.com/modelcontextprotocol/go-sdk/security/advisories/GHSA-xw59-hvm2-8pj6
+  - No go-sdk advisory has been published since 2026-06-09. v1.7.0 is not affected by any of the four. The v1.8.0-pre.1 hardening (JSON depth cap, size limits, DCR response bound) shipped without an advisory. Go vuln DB entry for the first: https://osv.dev/vulnerability/GO-2026-4569
+
+## 5. Consolidated audit checklist (each item cites its source)
+
+Transport
+- [ ] Single POST endpoint; GET/DELETE return 405 with `Allow: POST` (S1 `#earlier-streamable-http-revisions`; SDK does this in stateless mode, S18).
+- [ ] `Origin` header validated with 403 on invalid (S1 `#security--endpoint`). SDK default is NO check; wrap with `http.NewCrossOriginProtection` (S18).
+- [ ] Host-header DNS rebinding check left enabled (`DisableLocalhostProtection` false) (S18; GHSA-xw59-hvm2-8pj6).
+- [ ] Decide policy on absent `MCP-Protocol-Version`: SDK accepts as 2025-03-26; spec MUST reject if legacy clients are unsupported (S1 `#protocol-version-header`).
+- [ ] `Mcp-Method`/`Mcp-Name`/`Mcp-Param-*` header-body mismatch yields 400 / -32020 (S1 `#server-validation`; SDK does this, S18).
+- [ ] No sensitive parameter marked `x-mcp-header` (S7 `#x-mcp-header`).
+- [ ] Content-Type 415 and Accept 400 checks not disabled via MCPGODEBUG (S18).
+- [ ] `MaxRequestBodyBytes` left at default or explicitly set; never negative (S18).
+- [ ] `PropagateRequestCancellation: true` so handlers stop on disconnect (S1 `#cancellation`; S18).
+- [ ] No `Mcp-Session-Id` minted or echoed; `allowsessionsinstateless` not set (S1; S18).
+- [ ] TLS terminated somewhere in front; no plaintext HTTP outside loopback (S4 `#communication-security`; S26).
+- [ ] If bound to 0.0.0.0, that is deliberate and auth is enforced (S1 `#security--endpoint`).
+
+Authorization
+- [ ] Bearer token only in `Authorization` header; never in query string (S3 `#token-requirements`).
+- [ ] Token verified on every request; audience bound to this server; 401 on invalid/expired (S3 `#token-handling`; S4).
+- [ ] Token never forwarded upstream (S4 `#access-token-privilege-restriction`; S13 `#token-passthrough`).
+- [ ] 401 vs 403 vs 400 mapping correct (S3 `#error-handling`; SDK mapping in S19).
+- [ ] If OAuth framework adopted: RFC 9728 metadata served, `WWW-Authenticate` carries `resource_metadata` and `scope` (S3, S5). If static bearer: document that OAuth discovery is intentionally not implemented (S3 `#protocol-requirements`).
+- [ ] Tokens never logged; log redaction for `Authorization` and tool arguments (S4 `#token-theft`; S21; S26).
+- [ ] Missing-expiration and clock-skew options set deliberately (S19).
+
+Tools
+- [ ] `tools` capability declared; `tools/list` deterministic, static per token, never varies with call count or connection (S7 `#capabilities`; S22 rug-pull).
+- [ ] Every tool has non-null `inputSchema`; no-arg tools use `{"type":"object","additionalProperties":false}` (S7 `#tool`).
+- [ ] Inputs validated server-side against schema (types, ranges, formats); no shell or SQL concatenation (S7 `#security-considerations`; S25; S20).
+- [ ] `readOnlyHint`/`idempotentHint`/`destructiveHint`/`openWorldHint` reflect real behaviour; read-only tools carry no write capability (S7 `#tool`; S26; S28).
+- [ ] Descriptions factual, no instructions to the model, no embedded secrets (S25; S20; S22).
+- [ ] `structuredContent` conforms to `outputSchema` and is mirrored into a text block (S7 `#structured-content`).
+- [ ] Tool execution errors use `isError: true` with actionable text; protocol errors use JSON-RPC codes; internal details not leaked (S7 `#error-handling`; S28; S30).
+- [ ] Outputs sanitized: no config, env, tokens, or internal paths echoed (S7 `#security-considerations`; S23 CVE-2026-67357; S24).
+- [ ] Untrusted external content in outputs delimited and labelled as data (S25; S20).
+- [ ] Rate limiting on `tools/call` via middleware (S7 `#security-considerations`; S21; S26).
+- [ ] Any cross-call handle is random, opaque, bound to the verified user, expiring (S13 `#state-handle-hijacking`; S7 `#stateful-tools`).
+
+Pagination and caching
+- [ ] Cursors opaque, stable, integrity-checked, never a path or raw offset; invalid cursor returns -32602 (S8; S24).
+- [ ] `ttlMs >= 0` and `cacheScope` on `tools/list` and `server/discover`; `"private"` if the list varies by token (S11).
+
+Protocol hygiene
+- [ ] `server/discover` implemented and reachable (S10).
+- [ ] Missing `_meta` fields produce 400 / -32602; unsupported version produces 400 / -32022 with `supported` list (S9 `#_meta`; S6).
+- [ ] No emission of -32002 or -32042 (S9 `#error-codes`).
+- [ ] `serverInfo` in result `_meta` (S9; S10).
+- [ ] JSON Schema 2020-12 default; no network `$ref` dereference; schema complexity bounded (S9).
+
+Supply chain and ops
+- [ ] go-sdk >= v1.4.1 (all four GHSAs); on v1.7.0 now; track v1.8.0 for the removed MCPGODEBUG flags and `SupportedProtocolVersions` (S16, S17).
+- [ ] Dependency scanning and SBOM in CI (S29; S26).
+- [ ] Structured request logging with caller identity, tool name, outcome, duration; arguments redacted (S21; S25; S26).
+- [ ] Human-in-the-loop is a client obligation; server should not assume it and should keep read-only tools genuinely read-only (S7 `#user-interaction-model`).
+
+## 6. Caveats
+
+- Unofficial mirror: modelcontextprotocol.info (S30) is a third-party site, undated, references 2024-11-05 as "current", and contains no MCP-transport-specific guidance. Weighted low.
+- Unwatched video: S31 (youtu.be/BqRhBq-_kgE, Neon Postgres, 2026-09-08). Only page metadata and the description were fetched; the video content was not reviewed and nothing in this file is attributed to it beyond the description. Its topic (workflow-shaped tools, progressive discovery) is tool-design ergonomics, not security.
+- Normative standing of S13: the `specification/2026-07-28/basic/security_best_practices` URL serves the same document as the tutorial URL, and the authorization spec links to it under `/docs/.../tutorials/`. The binding auth security requirements are in `basic/authorization/security-considerations` (S4). Treat S13 MUSTs as guidance the spec incorporates by reference, not as an independent normative section.
+- URL resolution: `basic/lifecycle` resolves to "Versioning and Compatibility" (S6); `basic/transports` is only an overview, the Streamable HTTP requirements are on the sub-page (S1); pagination lives at `server/utilities/pagination` (S8).
+- Undated sources: only S30. S26 is dated but marked "draft". All spec pages carry the revision date, not a page date.
+- Out-of-window sources (S17 advisories, S26, S27, S28, S29, S30) are included because the task named them or because they remain the canonical reference; they are not presented as new. Few sources in the window are specifically about server best practice; the in-window material is the spec itself (S1..S13), the project blog (S14, S15), the go-sdk releases (S16), and vendor or incident posts (S20..S25).
+- Not fetched: the OWASP MCP guide PDF body (S27), the three August CVE records (data via S23), the SEP documents themselves (SEP-2575, 2567, 2243, 2549, 2322 are cited via the changelog S12 and blog S14, not read directly), the Go 1.25 `net/http` CrossOriginProtection docs, the Microsoft post body was obtained via a text-render proxy (r.jina.ai) after the direct fetch returned only a title.
+- Secondary WebFetch summarisation: spec text was extracted by a summarising fetch tool; quoted MUST/SHOULD wording was checked against the returned page text but anchors were inferred from headings and should be spot-checked when cited in the audit.

--- a/docs/site/src/content/docs/docs/mcp.mdx
+++ b/docs/site/src/content/docs/docs/mcp.mdx
@@ -301,7 +301,7 @@ hikyo sa credential revoke \
 The check proves unauthenticated discovery, the closed tool catalog, one
 authorized safe read, invalid-token denial, immediate revoked-token denial,
 and absence of an MCP session ID. Invalid and revoked credentials must return
-the same tenant-safe result.
+the same uniform `401`.
 
 ## Conformance, replicas, and shutdown
 
@@ -341,8 +341,8 @@ duration. Trace and log exporters must not capture request headers or bodies.
 | Symptom | Cause and fix |
 | --- | --- |
 | `404` at `/mcp` | `HIKYO_MCP_ENABLED` is false, or the proxy rewrote the path. Enable it and forward exact `POST /mcp`. |
-| `401` with `WWW-Authenticate: Bearer` | The tool call supplied no single bearer header. Repair the client's runtime secret channel. |
-| `Hikyo operation refused` | The token is invalid, expired, revoked, the wrong principal class, or lacks scope. Check credential metadata and grants without logging the bearer. |
+| `401` with `WWW-Authenticate: Bearer` | The tool call supplied no single bearer header, or the token is invalid, expired, or revoked. Repair the client's runtime secret channel or rotate the credential. |
+| `Hikyo operation refused` | The token is live but is the wrong principal class or lacks scope. Check credential metadata and grants without logging the bearer. |
 | `unsupported protocol version` | The client did not negotiate `2026-07-28`. Upgrade it to the pinned profile. |
 | `protocol mirror headers do not match request` | A proxy or client removed or changed the modern MCP mirror headers. Preserve all three headers. |
 

--- a/internal/isolation/mcp_e2e_test.go
+++ b/internal/isolation/mcp_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/mcpserver"
@@ -143,6 +144,29 @@ func mintMCPAutomation(t *testing.T, db *store.DB, auth *service.Auth, scope dom
 		}
 	}
 	minted, err := identities.MintCredential(t.Context(), service.LocalPrincipal(custodian), scope, sa.ID, service.MintRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return machineCredential{Principal: sa.Principal, AccountID: sa.ID, CredentialID: minted.Credential.ID, token: minted.Value}
+}
+
+// mintExpiredMCPAutomation mints a granted automation credential whose finite
+// lifetime already elapsed: the identities clock is moved into the past, so
+// the row is ordinary and live-shaped except for its expiry.
+func mintExpiredMCPAutomation(t *testing.T, db *store.DB, auth *service.Auth, scope domain.Scope, name string) machineCredential {
+	t.Helper()
+	identities := &service.Identities{DB: db, Auth: auth, Now: func() time.Time { return time.Now().UTC().Add(-2 * time.Hour) }}
+	sa, err := identities.CreateServiceAccount(t.Context(), service.LocalPrincipal(custodian), scope, name, domain.ClassAutomation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grants := &service.Grants{DB: db, Auth: auth}
+	if _, err := grants.Create(t.Context(), service.LocalPrincipal(domain.PrincipalID("usr_orgadmin")), service.GrantSpec{
+		Target: sa.Principal, Capability: domain.CapRead, Scope: scope,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	minted, err := identities.MintCredential(t.Context(), service.LocalPrincipal(custodian), scope, sa.ID, service.MintRequest{Lifetime: time.Hour})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,20 +349,28 @@ func TestMCPToolsEndToEndCanaryAndDenial(t *testing.T) {
 		// An invalid bearer is the silent, non-enumerating authentication failure:
 		// the REST disposition (uniform HTTP 401, no detail) and no audit row of
 		// any kind. It is byte-identical to a missing bearer.
+		expiredCredential := mintExpiredMCPAutomation(t, db, auth, domain.Scope{Org: "org_a", Project: "prj_a1"}, "mcp-expired")
 		beforeInvalid := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events`) + queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events`)
 		invalid := mcpCall(t, handler, "not-a-real-token", mcpserver.ToolInspectConfiguration,
 			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
 		missing := mcpCall(t, handler, "", mcpserver.ToolInspectConfiguration,
 			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
+		expired := mcpCall(t, handler, expiredCredential.token, mcpserver.ToolInspectConfiguration,
+			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
 		if invalid.Code != http.StatusUnauthorized || invalid.Header().Get("WWW-Authenticate") != "Bearer" ||
-			strings.Contains(invalid.Body.String(), "jsonrpc") ||
-			missing.Code != invalid.Code || missing.Body.String() != invalid.Body.String() {
-			t.Fatalf("invalid bearer = %d %q, missing bearer = %d %q: want identical uniform 401",
-				invalid.Code, invalid.Body.String(), missing.Code, missing.Body.String())
+			invalid.Body.String() != "Unauthorized\n" {
+			t.Fatalf("invalid bearer = %d %q: want the uniform 401", invalid.Code, invalid.Body.String())
+		}
+		for name, rec := range map[string]*httptest.ResponseRecorder{"missing": missing, "expired": expired} {
+			if rec.Code != invalid.Code || rec.Body.String() != invalid.Body.String() ||
+				rec.Header().Get("WWW-Authenticate") != invalid.Header().Get("WWW-Authenticate") {
+				t.Fatalf("%s bearer = %d %q, invalid bearer = %d %q: want identical uniform 401",
+					name, rec.Code, rec.Body.String(), invalid.Code, invalid.Body.String())
+			}
 		}
 		afterInvalid := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events`) + queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events`)
 		if afterInvalid != beforeInvalid {
-			t.Fatalf("invalid bearer wrote %d audit rows, want 0", afterInvalid-beforeInvalid)
+			t.Fatalf("invalid, missing, and expired bearers wrote %d audit rows, want 0", afterInvalid-beforeInvalid)
 		}
 		for _, table := range []string{"audit_tenant_events", "audit_instance_events"} {
 			if leaked := queryInt(t, db, `SELECT COUNT(*) FROM `+table+` WHERE CAST(payload AS TEXT) LIKE '%`+mcpCanaryPlaintext+`%'`); leaked != 0 {

--- a/internal/isolation/mcp_e2e_test.go
+++ b/internal/isolation/mcp_e2e_test.go
@@ -323,12 +323,18 @@ func TestMCPToolsEndToEndCanaryAndDenial(t *testing.T) {
 		}
 
 		// An invalid bearer is the silent, non-enumerating authentication failure:
-		// no audit row of any kind.
+		// the REST disposition (uniform HTTP 401, no detail) and no audit row of
+		// any kind. It is byte-identical to a missing bearer.
 		beforeInvalid := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events`) + queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events`)
 		invalid := mcpCall(t, handler, "not-a-real-token", mcpserver.ToolInspectConfiguration,
 			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
-		if !strings.Contains(invalid.Body.String(), mcpserver.SafeOperationError) {
-			t.Fatalf("invalid bearer call not the safe error: %q", invalid.Body.String())
+		missing := mcpCall(t, handler, "", mcpserver.ToolInspectConfiguration,
+			`{"org_id":"org_a","project_id":"prj_a1","environment_id":"env_a1"}`)
+		if invalid.Code != http.StatusUnauthorized || invalid.Header().Get("WWW-Authenticate") != "Bearer" ||
+			strings.Contains(invalid.Body.String(), "jsonrpc") ||
+			missing.Code != invalid.Code || missing.Body.String() != invalid.Body.String() {
+			t.Fatalf("invalid bearer = %d %q, missing bearer = %d %q: want identical uniform 401",
+				invalid.Code, invalid.Body.String(), missing.Code, missing.Body.String())
 		}
 		afterInvalid := queryInt(t, db, `SELECT COUNT(*) FROM audit_tenant_events`) + queryInt(t, db, `SELECT COUNT(*) FROM audit_instance_events`)
 		if afterInvalid != beforeInvalid {
@@ -429,8 +435,9 @@ func TestMCPToolsEndToEndCanaryAndDenial(t *testing.T) {
 			`{"org_id":"org_a","project_id":"prj_a1"}`)
 		invalidAfterRevoke := mcpCall(t, other, "not-a-real-token", mcpserver.ToolListDefinitions,
 			`{"org_id":"org_a","project_id":"prj_a1"}`)
-		if revoked.Code != http.StatusOK || revoked.Body.String() != invalidAfterRevoke.Body.String() ||
-			!strings.Contains(revoked.Body.String(), mcpserver.SafeOperationError) {
+		if revoked.Code != http.StatusUnauthorized || revoked.Code != invalidAfterRevoke.Code ||
+			revoked.Body.String() != invalidAfterRevoke.Body.String() ||
+			revoked.Header().Get("WWW-Authenticate") != "Bearer" {
 			t.Fatalf("revoked result differs from invalid-token result: revoked=%d %q invalid=%d %q",
 				revoked.Code, revoked.Body.String(), invalidAfterRevoke.Code, invalidAfterRevoke.Body.String())
 		}

--- a/internal/mcpserver/handler.go
+++ b/internal/mcpserver/handler.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -66,12 +67,25 @@ type bearerContextKey struct{}
 type callStateContextKey struct{}
 
 type callState struct {
-	rateLimited atomic.Bool
+	rateLimited     atomic.Bool
+	unauthenticated atomic.Bool
 }
 
 func markRateLimited(ctx context.Context) {
 	if state, ok := ctx.Value(callStateContextKey{}).(*callState); ok {
 		state.rateLimited.Store(true)
+	}
+}
+
+// markUnauthenticated records that the presented bearer is not a live
+// artifact. The transport then answers with the same uniform 401 a missing
+// bearer receives, which is the REST disposition for domain.ErrUnauthenticated
+// and lets an MCP client surface an authentication problem instead of handing
+// the model a retryable tool error. Authorization denial for a live artifact
+// is not routed here; it stays the indistinguishable safe tool error.
+func markUnauthenticated(ctx context.Context) {
+	if state, ok := ctx.Value(callStateContextKey{}).(*callState); ok {
+		state.unauthenticated.Store(true)
 	}
 }
 
@@ -178,10 +192,20 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	methodHeaders := r.Header.Values("Mcp-Method")
 	nameHeaders := r.Header.Values("Mcp-Name")
 	if len(methodHeaders) != 1 || methodHeaders[0] != envelope.Method ||
-		(envelope.Method == "tools/call" && (len(nameHeaders) != 1 || nameHeaders[0] != requestedName)) ||
+		(envelope.Method == "tools/call" && len(nameHeaders) != 1) ||
 		(envelope.Method != "tools/call" && len(nameHeaders) != 0) {
 		writeRPCError(w, http.StatusBadRequest, envelope.ID, -32020, "protocol mirror headers do not match request", nil)
 		return
+	}
+	if envelope.Method == "tools/call" {
+		decodedName, ok := decodeHeaderSentinel(nameHeaders[0])
+		if !ok || decodedName != requestedName {
+			writeRPCError(w, http.StatusBadRequest, envelope.ID, -32020, "protocol mirror headers do not match request", nil)
+			return
+		}
+		// The pinned SDK validator compares Mcp-Name without decoding, so it
+		// must see the decoded value this check accepted.
+		r.Header.Set("Mcp-Name", decodedName)
 	}
 	if requestedVersion == "" {
 		// Missing modern request metadata is an invalid-params error. The SDK
@@ -240,8 +264,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	bearer, ok := parseBearer(r.Header.Values("Authorization"))
 	if !ok {
-		w.Header().Set("WWW-Authenticate", "Bearer")
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		writeUnauthorized(w)
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, ToolExecutionTimeout)
@@ -304,6 +327,10 @@ func (h *handler) serveSDK(w http.ResponseWriter, r *http.Request, method string
 		http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 		return
 	}
+	if state != nil && state.unauthenticated.Load() {
+		writeUnauthorized(w)
+		return
+	}
 	body := capture.body.Bytes()
 	if len(body) > 0 && baseMediaType(capture.header.Get("Content-Type")) == "application/json" {
 		var response map[string]json.RawMessage
@@ -329,6 +356,38 @@ func (h *handler) serveSDK(w http.ResponseWriter, r *http.Request, method string
 	w.Header().Del("Content-Length")
 	w.WriteHeader(capture.status)
 	_, _ = w.Write(body)
+}
+
+// writeUnauthorized is the one authentication-failure response: a missing
+// bearer and a presented bearer that is not live are byte-identical.
+func writeUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}
+
+const (
+	headerSentinelPrefix = "=?base64?"
+	headerSentinelSuffix = "?="
+)
+
+// decodeHeaderSentinel applies the pinned protocol's Base64 sentinel rule to
+// one mirror header value: a value wrapped in =?base64?...?= is decoded with
+// strict standard Base64, and any other value is used as presented. A wrapped
+// value that does not decode is a mirror-header failure, never a match.
+func decodeHeaderSentinel(value string) (string, bool) {
+	encoded, ok := strings.CutPrefix(value, headerSentinelPrefix)
+	if !ok {
+		return value, true
+	}
+	encoded, ok = strings.CutSuffix(encoded, headerSentinelSuffix)
+	if !ok {
+		return "", false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", false
+	}
+	return string(decoded), true
 }
 
 func parseBearer(values []string) (string, bool) {

--- a/internal/mcpserver/handler.go
+++ b/internal/mcpserver/handler.go
@@ -203,8 +203,11 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeRPCError(w, http.StatusBadRequest, envelope.ID, -32020, "protocol mirror headers do not match request", nil)
 			return
 		}
-		// The pinned SDK validator compares Mcp-Name without decoding, so it
-		// must see the decoded value this check accepted.
+		// The pinned SDK v1.7.0 validator compares Mcp-Name without decoding
+		// (fixed upstream in go-sdk #1242, unreleased as of v1.8.0-pre.2), so
+		// it must see the decoded value this check accepted. The write-back
+		// stays correct once the SDK decodes too: a decoded tool name never
+		// carries the sentinel prefix.
 		r.Header.Set("Mcp-Name", decodedName)
 	}
 	if requestedVersion == "" {

--- a/internal/mcpserver/handler.go
+++ b/internal/mcpserver/handler.go
@@ -254,6 +254,14 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(envelope.ID) == 0 {
+		// tools/call is a request. As a notification it is malformed, and it
+		// is refused here, before the slot and the bearer, so a missing and a
+		// presented bearer receive the same response and no tool ever runs.
+		writeRPCError(w, http.StatusBadRequest, nil, -32600, "tools/call requires a request id", nil)
+		return
+	}
+
 	select {
 	case h.slots <- struct{}{}:
 		defer func() { <-h.slots }()

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/operation"
 )
 
@@ -630,6 +631,62 @@ func TestAuthenticatedRateLimitUsesUniformHTTPResponse(t *testing.T) {
 	if rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") != "60" ||
 		strings.Contains(rec.Body.String(), "CANARY-RATE-DETAIL") {
 		t.Fatalf("rate response = %d Retry-After %q body %q", rec.Code, rec.Header().Get("Retry-After"), rec.Body.String())
+	}
+}
+
+func TestUnauthenticatedBearerUsesUniformHTTP401(t *testing.T) {
+	registry := NewRegistry()
+	err := Register(registry, ToolSpec{
+		Name: "unauthenticated", Description: "Refuse an invalid bearer.", ServiceOperation: "service.Keys.List",
+		Contract: testContract(t, "unauthenticated"), AuditDisposition: AuditDispositionNone, SecretPolicy: SecretPolicyNoSecretMaterial,
+	}, func(context.Context, Bearer, echoInput) (echoOutput, error) {
+		return echoOutput{}, fmt.Errorf("CANARY-AUTH-DETAIL: %w", domain.ErrUnauthenticated)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := testHandler(t, registry)
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "unauthenticated", modernBody(1, "tools/call", "unauthenticated", `{"value":"x"}`))
+	req.Header.Set("Authorization", "Bearer not-a-live-token")
+	rec := serve(t, h, req)
+	// The presented artifact is not live. That is the REST disposition for
+	// domain.ErrUnauthenticated (HTTP 401, no detail), so an MCP client can
+	// surface an authentication problem instead of retrying a tool error.
+	if rec.Code != http.StatusUnauthorized || rec.Header().Get("WWW-Authenticate") != "Bearer" ||
+		strings.Contains(rec.Body.String(), "CANARY-AUTH-DETAIL") || strings.Contains(rec.Body.String(), "jsonrpc") {
+		t.Fatalf("unauthenticated response = %d WWW-Authenticate %q body %q", rec.Code, rec.Header().Get("WWW-Authenticate"), rec.Body.String())
+	}
+	missing := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "unauthenticated", modernBody(1, "tools/call", "unauthenticated", `{"value":"x"}`))
+	missingRec := serve(t, h, missing)
+	if missingRec.Code != rec.Code || missingRec.Body.String() != rec.Body.String() ||
+		missingRec.Header().Get("WWW-Authenticate") != rec.Header().Get("WWW-Authenticate") {
+		t.Fatalf("missing bearer = %d %q, invalid bearer = %d %q: must be identical", missingRec.Code, missingRec.Body.String(), rec.Code, rec.Body.String())
+	}
+}
+
+func TestBase64SentinelMcpNameIsDecodedBeforeComparison(t *testing.T) {
+	registry, seen := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	encoded := "=?base64?" + base64.StdEncoding.EncodeToString([]byte("echo")) + "?="
+	req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", encoded, modernBody(1, "tools/call", "echo", `{"value":"ok"}`))
+	req.Header.Set("Authorization", "Bearer token")
+	rec := serve(t, h, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"value":"ok"`) {
+		t.Fatalf("encoded Mcp-Name = %d %q", rec.Code, rec.Body.String())
+	}
+	<-seen
+
+	for _, bad := range []string{
+		"=?base64?" + base64.StdEncoding.EncodeToString([]byte("other")) + "?=",
+		"=?base64?not*base64?=",
+		"=?base64?" + base64.StdEncoding.EncodeToString([]byte("echo")),
+	} {
+		req := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", bad, modernBody(1, "tools/call", "echo", `{"value":"ok"}`))
+		req.Header.Set("Authorization", "Bearer token")
+		rec := serve(t, h, req)
+		if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), `"code":-32020`) {
+			t.Fatalf("Mcp-Name %q = %d %q, want 400 -32020", bad, rec.Code, rec.Body.String())
+		}
 	}
 }
 

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -664,6 +664,31 @@ func TestUnauthenticatedBearerUsesUniformHTTP401(t *testing.T) {
 	}
 }
 
+func TestToolCallNotificationIsRefusedBeforeBearerHandling(t *testing.T) {
+	registry, seen := testRegistry(t, "echo")
+	h := testHandler(t, registry)
+	body := bytes.Replace(modernBody(1, "tools/call", "echo", `{"value":"x"}`), []byte(`"id":1,`), nil, 1)
+
+	withBearer := request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "echo", body)
+	withBearer.Header.Set("Authorization", "Bearer not-a-live-token")
+	bearerRec := serve(t, h, withBearer)
+	missingRec := serve(t, h, request(http.MethodPost, "https://hikyo.example.com/mcp", "tools/call", "echo", body))
+	if bearerRec.Code != http.StatusBadRequest || !strings.Contains(bearerRec.Body.String(), `"code":-32600`) ||
+		!strings.Contains(bearerRec.Body.String(), `"id":null`) {
+		t.Fatalf("tools/call notification = %d %q, want 400 -32600", bearerRec.Code, bearerRec.Body.String())
+	}
+	if missingRec.Code != bearerRec.Code || missingRec.Body.String() != bearerRec.Body.String() ||
+		missingRec.Header().Get("WWW-Authenticate") != "" || bearerRec.Header().Get("WWW-Authenticate") != "" {
+		t.Fatalf("missing bearer = %d %q, presented bearer = %d %q: must be identical and pre-auth",
+			missingRec.Code, missingRec.Body.String(), bearerRec.Code, bearerRec.Body.String())
+	}
+	select {
+	case bearer := <-seen:
+		t.Fatalf("tool ran for a notification with bearer %q", bearer)
+	default:
+	}
+}
+
 func TestBase64SentinelMcpNameIsDecodedBeforeComparison(t *testing.T) {
 	registry, seen := testRegistry(t, "echo")
 	h := testHandler(t, registry)

--- a/internal/mcpserver/registry.go
+++ b/internal/mcpserver/registry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/Hikyo-Org/hikyo/internal/authz"
+	"github.com/Hikyo-Org/hikyo/internal/domain"
 	"github.com/Hikyo-Org/hikyo/internal/operation"
 )
 
@@ -197,6 +198,9 @@ func Register[In, Out any](registry *Registry, spec ToolSpec, handler func(conte
 					var zero Out
 					if errors.Is(err, ErrRateLimited) {
 						markRateLimited(ctx)
+					}
+					if errors.Is(err, domain.ErrUnauthenticated) {
+						markUnauthenticated(ctx)
 					}
 					// Named cursor, bound, and argument errors are tenant-safe,
 					// so their exact token crosses the transport; every other

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -339,14 +339,18 @@ func (m *Metrics) ObserveMCP(next http.Handler, log *slog.Logger, toolNames []st
 	m.initializeMCPMetrics(toolNames)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		method := mcpMetricMethod(r.Header.Get("Mcp-Method"))
-		tool := "none"
-		if method == "tools/call" {
+		// The tool label is read after the adapter has run: the adapter
+		// decodes a Base64-sentinel Mcp-Name in place once it has validated
+		// the mirror, so the label reflects the routed tool, not its encoding.
+		toolLabel := func() string {
+			if method != "tools/call" {
+				return "none"
+			}
 			candidate := r.Header.Get("Mcp-Name")
 			if _, ok := knownTools[candidate]; ok {
-				tool = candidate
-			} else {
-				tool = "other"
+				return candidate
 			}
+			return "other"
 		}
 		sw := newResponseWriter(w)
 		start := time.Now()
@@ -361,6 +365,7 @@ func (m *Metrics) ObserveMCP(next http.Handler, log *slog.Logger, toolNames []st
 			}
 			m.mcpInFlight.Dec()
 			duration := time.Since(start)
+			tool := toolLabel()
 			status := statusNames[bucketForStatus(sw.status)]
 			m.mcpRequests.WithLabelValues(method, tool, status).Inc()
 			m.mcpDurations.WithLabelValues(method, tool).Observe(duration.Seconds())

--- a/internal/server/metrics_scrape_test.go
+++ b/internal/server/metrics_scrape_test.go
@@ -157,7 +157,12 @@ func TestMCPMetricsAndAccessLogsUseOnlyClosedLabels(t *testing.T) {
 	metrics := server.NewMetrics(nil)
 	var logs bytes.Buffer
 	log := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	handler := metrics.ObserveMCP(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := metrics.ObserveMCP(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The adapter rewrites a validated Base64-sentinel Mcp-Name to its
+		// decoded value in place; the label must be read after that.
+		if r.Header.Get("Mcp-Name") == "=?base64?aGlreW9fbGlzdF9kZWZpbml0aW9ucw==?=" {
+			r.Header.Set("Mcp-Name", "hikyo_list_definitions")
+		}
 		w.WriteHeader(http.StatusOK)
 	}), log, []string{"hikyo_list_definitions"})
 
@@ -167,6 +172,7 @@ func TestMCPMetricsAndAccessLogsUseOnlyClosedLabels(t *testing.T) {
 	}{
 		{method: "server/discover"},
 		{method: "tools/call", tool: "hikyo_list_definitions"},
+		{method: "tools/call", tool: "=?base64?aGlreW9fbGlzdF9kZWZpbml0aW9ucw==?="},
 		{method: "tools/call", tool: "CANARY-SECRET-TOOL"},
 	} {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
@@ -187,7 +193,7 @@ func TestMCPMetricsAndAccessLogsUseOnlyClosedLabels(t *testing.T) {
 	mustContain(t, body, "# TYPE "+server.MetricMCPRequestsInFlight+" gauge")
 	mustContain(t, body, "# TYPE "+server.MetricMCPRequestDuration+" histogram")
 	mustContain(t, body, server.MetricMCPRequestsTotal+`{method="server/discover",status="2xx",tool="none"} 1`)
-	mustContain(t, body, server.MetricMCPRequestsTotal+`{method="tools/call",status="2xx",tool="hikyo_list_definitions"} 1`)
+	mustContain(t, body, server.MetricMCPRequestsTotal+`{method="tools/call",status="2xx",tool="hikyo_list_definitions"} 2`)
 	mustContain(t, body, server.MetricMCPRequestsTotal+`{method="tools/call",status="2xx",tool="other"} 1`)
 	if strings.Contains(body, "CANARY") || strings.Contains(logs.String(), "CANARY") {
 		t.Fatalf("MCP telemetry leaked request-controlled or bearer material\nmetrics:\n%s\nlogs:\n%s", body, logs.String())

--- a/scripts/mcp-public-smoke/main.go
+++ b/scripts/mcp-public-smoke/main.go
@@ -149,34 +149,38 @@ func run(opts options, client *http.Client) error {
 	if err != nil {
 		return err
 	}
-	invalid, sessionID, err := invoke(client, opts.endpoint, "tools/call", mcpserver.ToolListDefinitions, args, invalidToken)
+	invalid, err := invokeRaw(client, opts.endpoint, "tools/call", mcpserver.ToolListDefinitions, args, invalidToken)
 	if err != nil {
 		return fmt.Errorf("invalid-token probe: %w", err)
 	}
-	if err := requireStateless("invalid-token denial", sessionID); err != nil {
+	if err := requireStateless("invalid-token denial", invalid.sessionID); err != nil {
 		return err
 	}
-	invalidMessage := safeToolError(invalid.Result)
-	if invalidMessage != mcpserver.SafeOperationError {
-		return errors.New("invalid credential did not receive the exact tenant-safe denial")
+	if err := requireUnauthenticated("invalid credential", invalid); err != nil {
+		return err
 	}
 
 	deadline := time.Now().Add(opts.revocationTimeout)
 	for {
-		rotated, sessionID, err := invoke(client, opts.endpoint, "tools/call", mcpserver.ToolListDefinitions, args, rotating)
+		rotated, err := invokeRaw(client, opts.endpoint, "tools/call", mcpserver.ToolListDefinitions, args, rotating)
 		if err != nil {
 			return fmt.Errorf("revocation probe: %w", err)
 		}
-		if err := requireStateless("revoked-token denial", sessionID); err != nil {
+		if err := requireStateless("revoked-token denial", rotated.sessionID); err != nil {
 			return err
 		}
-		if safeToolError(rotated.Result) == invalidMessage {
-			if !bytes.Equal(bytes.TrimSpace(invalid.Result), bytes.TrimSpace(rotated.Result)) {
+		if rotated.status == http.StatusUnauthorized {
+			if err := requireUnauthenticated("revoked credential", rotated); err != nil {
+				return err
+			}
+			if !bytes.Equal(bytes.TrimSpace(invalid.body), bytes.TrimSpace(rotated.body)) ||
+				rotated.header.Get("WWW-Authenticate") != invalid.header.Get("WWW-Authenticate") {
 				return errors.New("revoked credential denial differed from the invalid-token denial")
 			}
 			return nil
 		}
-		if rotated.Error != nil || !successfulToolResult(rotated.Result, opts.orgID, opts.projectID) {
+		decoded, err := rotated.rpc()
+		if err != nil || decoded.Error != nil || !successfulToolResult(decoded.Result, opts.orgID, opts.projectID) {
 			return errors.New("rotating credential returned an unexpected response while waiting for revocation")
 		}
 		if !time.Now().Before(deadline) {
@@ -271,7 +275,47 @@ func validateOptions(opts options) error {
 	return nil
 }
 
+// rawResponse is one HTTP exchange before JSON-RPC decoding, so a probe can
+// assert a non-200 transport disposition (the uniform 401) as exactly as a
+// JSON-RPC result.
+type rawResponse struct {
+	status    int
+	header    http.Header
+	body      []byte
+	sessionID string
+}
+
+func (r rawResponse) rpc() (rpcResponse, error) {
+	if r.status != http.StatusOK {
+		return rpcResponse{}, fmt.Errorf("HTTP status %d", r.status)
+	}
+	return decodeRPCResponse(r.body)
+}
+
+// requireUnauthenticated asserts the one authentication-failure disposition:
+// HTTP 401 with a bare Bearer challenge and no JSON-RPC envelope, identical
+// for a missing, invalid, expired, or revoked bearer.
+func requireUnauthenticated(subject string, response rawResponse) error {
+	if response.status != http.StatusUnauthorized || response.header.Get("WWW-Authenticate") != "Bearer" ||
+		bytes.Contains(response.body, []byte("jsonrpc")) {
+		return fmt.Errorf("%s did not receive the exact uniform 401 denial", subject)
+	}
+	return nil
+}
+
 func invoke(client *http.Client, endpoint, method, tool string, arguments map[string]any, token string) (rpcResponse, string, error) {
+	raw, err := invokeRaw(client, endpoint, method, tool, arguments, token)
+	if err != nil {
+		return rpcResponse{}, "", err
+	}
+	decoded, err := raw.rpc()
+	if err != nil {
+		return rpcResponse{}, "", err
+	}
+	return decoded, raw.sessionID, nil
+}
+
+func invokeRaw(client *http.Client, endpoint, method, tool string, arguments map[string]any, token string) (rawResponse, error) {
 	meta := map[string]any{
 		"io.modelcontextprotocol/protocolVersion":    mcpserver.ProtocolVersion,
 		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
@@ -288,11 +332,11 @@ func invoke(client *http.Client, endpoint, method, tool string, arguments map[st
 		"jsonrpc": "2.0", "id": 1, "method": method, "params": params,
 	})
 	if err != nil {
-		return rpcResponse{}, "", err
+		return rawResponse{}, err
 	}
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return rpcResponse{}, "", err
+		return rawResponse{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
@@ -306,24 +350,20 @@ func invoke(client *http.Client, endpoint, method, tool string, arguments map[st
 	}
 	response, err := client.Do(req)
 	if err != nil {
-		return rpcResponse{}, "", err
+		return rawResponse{}, err
 	}
 	defer response.Body.Close()
 	encoded, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
 	if err != nil {
-		return rpcResponse{}, "", err
+		return rawResponse{}, err
 	}
 	if len(encoded) > maxResponseBytes {
-		return rpcResponse{}, "", errors.New("response exceeded smoke-test bound")
+		return rawResponse{}, errors.New("response exceeded smoke-test bound")
 	}
-	if response.StatusCode != http.StatusOK {
-		return rpcResponse{}, "", fmt.Errorf("HTTP status %d", response.StatusCode)
-	}
-	decoded, err := decodeRPCResponse(encoded)
-	if err != nil {
-		return rpcResponse{}, "", err
-	}
-	return decoded, response.Header.Get("Mcp-Session-Id"), nil
+	return rawResponse{
+		status: response.StatusCode, header: response.Header.Clone(), body: encoded,
+		sessionID: response.Header.Get("Mcp-Session-Id"),
+	}, nil
 }
 
 func decodeRPCResponse(encoded []byte) (rpcResponse, error) {
@@ -350,31 +390,6 @@ func decodeRPCResponse(encoded []byte) (rpcResponse, error) {
 		}
 	}
 	return decoded, nil
-}
-
-func safeToolError(result json.RawMessage) string {
-	fields, err := profileResultFields(result, false)
-	if err != nil || len(fields) != 2 || fields["isError"] == nil || fields["content"] == nil {
-		return ""
-	}
-	var toolResult struct {
-		IsError bool `json:"isError"`
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if json.Unmarshal(result, &toolResult) != nil || !toolResult.IsError || len(toolResult.Content) != 1 {
-		return ""
-	}
-	var contentFields map[string]json.RawMessage
-	var contentItems []json.RawMessage
-	if json.Unmarshal(fields["content"], &contentItems) != nil || len(contentItems) != 1 ||
-		json.Unmarshal(contentItems[0], &contentFields) != nil || len(contentFields) != 2 ||
-		contentFields["type"] == nil || contentFields["text"] == nil || toolResult.Content[0].Type != "text" {
-		return ""
-	}
-	return toolResult.Content[0].Text
 }
 
 func successfulToolResult(result json.RawMessage, orgID, projectID string) bool {

--- a/scripts/mcp-public-smoke/main.go
+++ b/scripts/mcp-public-smoke/main.go
@@ -159,6 +159,19 @@ func run(opts options, client *http.Client) error {
 	if err := requireUnauthenticated("invalid credential", invalid); err != nil {
 		return err
 	}
+	missing, err := invokeRaw(client, opts.endpoint, "tools/call", mcpserver.ToolListDefinitions, args, "")
+	if err != nil {
+		return fmt.Errorf("missing-token probe: %w", err)
+	}
+	if err := requireStateless("missing-token denial", missing.sessionID); err != nil {
+		return err
+	}
+	if err := requireUnauthenticated("missing credential", missing); err != nil {
+		return err
+	}
+	if err := requireSameDenial("missing credential", missing, invalid); err != nil {
+		return err
+	}
 
 	deadline := time.Now().Add(opts.revocationTimeout)
 	for {
@@ -173,11 +186,7 @@ func run(opts options, client *http.Client) error {
 			if err := requireUnauthenticated("revoked credential", rotated); err != nil {
 				return err
 			}
-			if !bytes.Equal(bytes.TrimSpace(invalid.body), bytes.TrimSpace(rotated.body)) ||
-				rotated.header.Get("WWW-Authenticate") != invalid.header.Get("WWW-Authenticate") {
-				return errors.New("revoked credential denial differed from the invalid-token denial")
-			}
-			return nil
+			return requireSameDenial("revoked credential", rotated, invalid)
 		}
 		decoded, err := rotated.rpc()
 		if err != nil || decoded.Error != nil || !successfulToolResult(decoded.Result, opts.orgID, opts.projectID) {
@@ -292,13 +301,28 @@ func (r rawResponse) rpc() (rpcResponse, error) {
 	return decodeRPCResponse(r.body)
 }
 
-// requireUnauthenticated asserts the one authentication-failure disposition:
-// HTTP 401 with a bare Bearer challenge and no JSON-RPC envelope, identical
-// for a missing, invalid, expired, or revoked bearer.
+// unauthorizedBody is the exact plain-text body of the uniform 401.
+const unauthorizedBody = "Unauthorized\n"
+
+// requireUnauthenticated asserts the one authentication-failure disposition
+// exactly: HTTP 401, exactly one bare Bearer challenge, and the fixed
+// plain-text body. It is the same bytes for a missing, invalid, expired, or
+// revoked bearer, and it is never a JSON-RPC envelope.
 func requireUnauthenticated(subject string, response rawResponse) error {
-	if response.status != http.StatusUnauthorized || response.header.Get("WWW-Authenticate") != "Bearer" ||
-		bytes.Contains(response.body, []byte("jsonrpc")) {
+	challenges := response.header.Values("WWW-Authenticate")
+	if response.status != http.StatusUnauthorized || len(challenges) != 1 || challenges[0] != "Bearer" ||
+		string(response.body) != unauthorizedBody {
 		return fmt.Errorf("%s did not receive the exact uniform 401 denial", subject)
+	}
+	return nil
+}
+
+// requireSameDenial asserts two authentication failures are byte-identical
+// on the wire: status, challenge, and untrimmed body.
+func requireSameDenial(subject string, a, b rawResponse) error {
+	if a.status != b.status || !bytes.Equal(a.body, b.body) ||
+		!slices.Equal(a.header.Values("WWW-Authenticate"), b.header.Values("WWW-Authenticate")) {
+		return fmt.Errorf("%s denial differed from the invalid-token denial", subject)
 	}
 	return nil
 }

--- a/scripts/mcp-public-smoke/main_test.go
+++ b/scripts/mcp-public-smoke/main_test.go
@@ -43,10 +43,9 @@ func TestRunProvesPublicProfileWithoutPersistingCredentials(t *testing.T) {
 			} else if r.Header.Get("Authorization") == "Bearer rot-token" && rotatingCalls.Add(1) == 1 {
 				result = successfulDefinitionsResult()
 			} else {
-				result = map[string]any{
-					"isError": true,
-					"content": []map[string]string{{"type": "text", "text": mcpserver.SafeOperationError}},
-				}
+				w.Header().Set("WWW-Authenticate", "Bearer")
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
 			}
 		default:
 			http.Error(w, "unknown method", http.StatusNotFound)
@@ -80,6 +79,54 @@ func successfulDefinitionsResult() map[string]any {
 
 func populatedDefinitionsResult() string {
 	return `{"content":[{"type":"text","text":"Hikyo returned structured data."}],"structuredContent":{"org_id":"org_test","project_id":"prj_test","schema_revision":1,"definitions":[{"name":"DATABASE_URL","description":"Database endpoint","classification":"secret","deprecated":false,"declaration":{"rule":{"type":"string"}},"presence":{"required_in":{"mode":"none"},"forbidden_in":{"mode":"none"}}}]}}`
+}
+
+func TestRunRefusesToolErrorAsAuthenticationDenial(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		method := r.Header.Get("Mcp-Method")
+		var result map[string]any
+		switch method {
+		case "server/discover":
+			result = map[string]any{
+				"supportedVersions": []string{mcpserver.ProtocolVersion},
+				"capabilities":      map[string]any{"tools": map[string]any{}},
+			}
+		case "tools/list":
+			tools := make([]map[string]string, 0, len(mcpserver.ProductionToolNames()))
+			for _, name := range mcpserver.ProductionToolNames() {
+				tools = append(tools, map[string]string{"name": name})
+			}
+			result = map[string]any{"tools": tools}
+		case "tools/call":
+			if r.Header.Get("Authorization") == "Bearer live-runtime-token" || r.Header.Get("Authorization") == "Bearer rot-token" {
+				result = successfulDefinitionsResult()
+			} else {
+				// The superseded disposition: a tool error instead of HTTP 401.
+				result = map[string]any{
+					"isError": true,
+					"content": []map[string]string{{"type": "text", "text": mcpserver.SafeOperationError}},
+				}
+			}
+		default:
+			http.Error(w, "unknown method", http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": modernResult(result, method != "tools/call")})
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("TEST_MCP_LIVE", "live-runtime-token")
+	t.Setenv("TEST_MCP_ROTATING", "rot-token")
+
+	err := run(options{
+		endpoint: server.URL + mcpserver.Path,
+		tokenEnv: "TEST_MCP_LIVE", rotatingTokenEnv: "TEST_MCP_ROTATING",
+		orgID: "org_test", projectID: "prj_test",
+		revocationTimeout: time.Second,
+	}, server.Client())
+	if err == nil || !strings.Contains(err.Error(), "invalid credential did not receive the exact uniform 401 denial") {
+		t.Fatalf("tool-error denial accepted: %v", err)
+	}
 }
 
 func TestRunRefusesRedirectBeforeBearerCanReachDowngradedTarget(t *testing.T) {


### PR DESCRIPTION
## Summary

Audit of the MCP adapter against the 2026-07-28 specification, the official security tutorial, and every best-practice source published in the last three months. Verdict: compliant and stronger than the SDK default on Origin, Host, cursors, rate limits, and output sanitisation. Two findings, both fixed here.

- **Uniform 401 for dead bearers.** A `tools/call` whose bearer is invalid, expired, or revoked now receives the same 401 with `WWW-Authenticate: Bearer` that a missing bearer receives (byte-identical, no audit row). Previously it was an HTTP 200 tool error, which MCP clients hand to the model as retryable. Live but refused artifacts (wrong class, no grant) keep the safe tool error. ADR amended by banner.
- **`Mcp-Name` base64 sentinel decoded** before the mirror comparison, as the transport spec requires; the pinned go-sdk v1.7.0 does not decode `Mcp-Name`, so the decoded value is written back before the SDK validator runs.
- A `tools/call` sent as a notification is refused with 400 before the bearer is read (Codex R1 finding).
- Public smoke probe asserts the exact 401 disposition, probes a missing bearer, and has a negative test against the old tool-error denial.
- E2E mints an actually expired credential and asserts it matches invalid and missing.

Docs: `docs/reports/mcp-best-practices-audit-2026-09-10.md` (practice table with evidence), `docs/research/mcp-best-practices-sources-2026-09-09.md` (31 sources), `docs/handoff/mcp-best-practices-audit.md`.

## Verification

- `go test` for `internal/mcpserver`, `internal/server`, `internal/service`, `scripts/mcp-public-smoke`, `internal/isolation -run MCP`: green
- `scripts/ci/check-mcp-conformance.sh` (upstream 2026-07-28 suite): baseline passed
- `go vet`, `go build ./...`, GOROOT `gofmt -l .`: clean
- Cross-model review: Codex gpt-5.6-sol high effort, R1 four findings (all fixed), R2 CLEAN

## Follow-ups

- `Mcp-Name` sentinel: already fixed upstream on go-sdk `main` (#1242, #1246, unreleased as of v1.8.0-pre.2). Nothing to file; the adapter keeps its own decode because its mirror check runs before the SDK validator.
- Re-run conformance and interop when go-sdk v1.8.0 goes stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

