### PR TITLE
docs: clarify hikyo.app policy pages from reviewer feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contributing to Hikyo
 
 Open an issue and get maintainer agreement before starting a large change.
+Security vulnerabilities are the exception: never open them as public issues.
+Report them privately through the [security policy](./SECURITY.md).
 
 ## Developer Certificate of Origin
 
 Every commit in a pull request must carry a Developer Certificate of Origin
-sign-off. Add it with:
+(DCO) sign-off. Add it with:
 
 ```sh
 git commit -s
@@ -13,8 +15,8 @@ git commit -s
 
 The sign-off certifies the [Developer Certificate of Origin 1.1](https://developercertificate.org/).
 CI checks the pull request's commit history; a sign-off added only to a squash
-message does not satisfy the gate. Hikyo uses DCO, never a CLA, so contributors
-retain their copyright.
+message does not satisfy the gate. Hikyo uses the DCO, never a Contributor
+License Agreement (CLA), so contributors retain their copyright.
 
 ## Security-sensitive contributions
 
@@ -23,8 +25,8 @@ delivery paths require maintainer security review. Maintainer-authored changes
 use adversarial cross-model review until a second maintainer exists; this is a
 compensating check, not independent human review.
 
-Do not report vulnerabilities in public issues. Use the private channels in
-[SECURITY.md](./SECURITY.md).
+Do not report vulnerabilities in public issues. Use the private channels in the
+[security policy](./SECURITY.md).
 
 ## Design decisions
 
@@ -32,23 +34,54 @@ The locked architecture decision records live in [`docs/adr/`](./docs/adr/README
 and the build-ready specification set in [`docs/spec/`](./docs/spec/README.md).
 Code comments cite them by file stem ("the encryption-model ADR" is
 `docs/adr/encryption-model.md`); `docs/adr/README.md` maps every short name to
-its file. A change that contradicts a locked ADR reopens the ADR (amendment
-banner) rather than silently diverging — see
-[`oss-mechanics.md`](./docs/adr/oss-mechanics.md) § Governance.
+its file. A change that contradicts a locked ADR reopens it under the
+[amendment procedure](./GOVERNANCE.md#amendment-procedure) rather than silently
+diverging. See the [OSS mechanics ADR](./docs/adr/oss-mechanics.md), section
+Governance, for the full mechanism.
 
 ## Local verification
 
-Run the checks relevant to the changed package and the full test suite before
-requesting review. CI is the source of truth for the complete release gates.
-CI also runs the race detector over every package except `./internal/isolation/`
-(which runs race-instrumented on the weekly `race-isolation` workflow), a bounded
-fuzz pass over every `Fuzz*` target, and `govulncheck`. To fuzz one target
-locally: `go test -run='^$' -fuzz='^FuzzParseHeader$' -fuzztime=30s ./internal/crypto/`.
+Before you request review, run the checks for what you touched:
 
-When fuzzing finds a failure, CI retains the minimized corpus file for 30 days
-and replays it against the pull request's trusted base. A finding that does not
-reproduce on the base is added to the pull request with its replay command; a
-finding that also fails on the base creates or updates a standalone bug issue.
-Either result leaves `fuzz` and the aggregate `ci-required` gate red until fixed.
-Commit the minimized corpus file with the fix so `go test ./...` keeps it as a
-regression case.
+- Go changes: `go test ./<changed-package>/...`, plus `go test ./...` for
+  anything cross-cutting. Add or update tests for the behaviour you change.
+  There is no numeric coverage gate, so reviewers, not an automated threshold,
+  judge whether the tests cover the change.
+- `web/` changes: `node --run typecheck` and `node --run test` in `web/`.
+- Run the formatter and linters so the `lint` gate does not bounce the pull
+  request.
+
+You do not need to reproduce the full release gate locally; CI is the source of
+truth for that.
+
+## Continuous integration
+
+Every pull request runs the complete gate. The aggregate `ci-required` check
+stays red, and blocks merge, until all of these pass:
+
+- `lint`, `test`, and the sharded isolation suites;
+- `race`, the race detector over every package except `./internal/isolation/`
+  (that suite runs race-instrumented on the weekly `race-isolation` workflow);
+- `fuzz` (see below);
+- `govulncheck` for known vulnerabilities, plus the supply-chain, web, compose,
+  and Kubernetes end-to-end checks.
+
+You do not run these by hand as a rule; open the pull request and let CI report.
+
+### Fuzzing
+
+Fuzzing feeds a function randomised inputs to surface crashes and panics that
+example-based tests miss. CI runs a bounded fuzz pass over every `Fuzz*` target
+on every pull request, so you never have to fuzz manually. To reproduce or
+extend one target locally:
+
+```sh
+go test -run='^$' -fuzz='^FuzzParseHeader$' -fuzztime=30s ./internal/crypto/
+```
+
+When fuzzing finds a failure, CI keeps the minimised input for 30 days and
+replays it against the pull request's trusted base. A finding that does not
+reproduce on the base is added to the pull request with its replay command; one
+that also fails on the base opens or updates a standalone bug issue. Either way,
+`fuzz` and `ci-required` stay red until it is fixed. Commit the minimised input
+with the fix so `go test ./...` keeps it as a regression case.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Hikyo governance
 
-Hikyo uses an honest BDFL model. The current maintainer set has one member,
-Marc Went, who is the benevolent dictator for life (BDFL). If the maintainer
+Hikyo uses an honest benevolent dictator for life (BDFL) model. The current
+maintainer set has one member, Marc Went, who is that BDFL. If the maintainer
 set grows, the BDFL retains final decision authority.
 
 ## Roles and powers
@@ -11,7 +11,7 @@ security-response authority, and authority to amend this document. Release
 authority and signing-key custody are one responsibility and are never split.
 
 Maintainers are invited after sustained, high-quality contributions. Acceptance
-includes organization 2FA and the review duties in `CONTRIBUTING.md`. A
+includes organization 2FA and the review duties in [`CONTRIBUTING.md`](./CONTRIBUTING.md). A
 maintainer may leave voluntarily or be removed by the BDFL for cause, including
 security negligence or a breach of project trust.
 
@@ -39,7 +39,8 @@ recusal quorum; disclosure in the permanent record is the control.
 
 ## Amendment procedure
 
-A locked ADR, including the OSS mechanics decision that governs this document,
+A locked architecture decision record (ADR), including the OSS mechanics
+decision that governs this document,
 may be amended only by reopening its originating ticket, running the same
 adversarial cross-model review that locked it, and recording the amendment in
 the ADR itself. Amendments to this governance document follow that procedure.
@@ -47,13 +48,14 @@ the ADR itself. Amendments to this governance document follow that procedure.
 Repository branch and tag protections are enforced and auditable. Organization-wide
 2FA enforcement and repository ownership are operational controls whose current
 verification lives under `OBL-REPOSITORY-TRANSFER` in the machine-checked
-[implementation-status ledger](./docs/status/README.md). The immutable transfer
+[implementation-status ledger](./docs/status/README.md#obl-repository-transfer). The immutable transfer
 record remains in the [historical handoff](./docs/handoff/github-org-transfer.md).
 
 ## Fully-open pledge
 
 Every capability required to run Hikyo in production is and will remain open
-source; there is no `/ee` directory and there will never be one.
+source; there is no enterprise-edition (`/ee`) directory and there will never be
+one.
 
 This includes every functional and administrative outcome: running,
 configuring, backing up, restoring, upgrading, and operating Hikyo, including

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,15 @@
 
 Do not report vulnerabilities in public issues. Use GitHub Private Vulnerability
 Reporting or, when GitHub is unavailable or inaccessible, the independently
-hosted fallback address below.
+hosted fallback address below. The repository's New Issue page links straight to
+private reporting, so this is the default path.
+
+If a vulnerability is nonetheless filed as a public issue, the maintainer locks
+the issue and redacts the exploitation details, then opens a private advisory to
+coordinate the fix. Because the report is already public, the disclosure is
+treated as public: mitigation guidance, the fix, and the advisory are
+fast-tracked ahead of any milestone, exactly as for active exploitation. The
+reporter is still credited unless they opt out.
 
 ## Reporting a vulnerability
 
@@ -49,6 +57,13 @@ guidance, the fix, and the advisory are fast-tracked ahead of any milestone when
 exploitation is active.
 
 ## Advisories and CVEs
+
+A security advisory is the record of a vulnerability: what was affected, the
+impact, and the fixed version. It starts as a private draft used to coordinate
+the fix and becomes the public record once the patched release ships. GitHub
+assigns each advisory a GHSA (GitHub Security Advisory) identifier; a CVE (Common
+Vulnerabilities and Exposures) is the cross-industry identifier for the same
+issue.
 
 A CVE is requested through the private GitHub advisory before publication. CVE
 assignment is never release-blocking: an urgent fix may ship under its GHSA,

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -15,4 +15,5 @@ name or confusingly similar branding. Forks remain free to thrive under a
 different name.
 
 Questions and permission requests may be opened as a public repository issue.
-Security reports must instead use the private channels in `SECURITY.md`.
+Security reports must instead use the private channels in the
+[security policy](./SECURITY.md).

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -2,11 +2,11 @@
 dist/
 node_modules/
 public/upgrade-nightly.sh
-src/content/docs/security.md
-src/content/docs/support.md
-src/content/docs/governance.md
-src/content/docs/implementation-status.md
-src/content/docs/trademark.md
-src/content/docs/contributing.md
+src/content/docs/security.mdx
+src/content/docs/support.mdx
+src/content/docs/governance.mdx
+src/content/docs/implementation-status.mdx
+src/content/docs/trademark.mdx
+src/content/docs/contributing.mdx
 src/content/docs/license.md
 src/content/docs/release/

--- a/docs/site/scripts/prepare-content.mjs
+++ b/docs/site/scripts/prepare-content.mjs
@@ -89,7 +89,19 @@ for (const page of pages) {
   }
   // MDX parses HTML comments as JSX and chokes on them; the generated status
   // page carries a "do not edit" note that is only meaningful on the repo source.
-  body = body.replace(/<!--[\s\S]*?-->\n?/g, '');
+  // Strip to a fixpoint: a single pass can leave a fresh `<!-- -->` behind when
+  // comment markers overlap, which CodeQL flags as incomplete multi-character
+  // sanitization.
+  let beforeStrip;
+  do {
+    beforeStrip = body;
+    body = body.replace(/<!--[\s\S]*?-->\n?/g, '');
+  } while (body !== beforeStrip);
+  // A leftover `<!--` is an unterminated/malformed comment the loop cannot
+  // remove; fail loud rather than ship MDX the build would choke on later.
+  if (body.includes('<!--')) {
+    throw new Error(`${page.source}: unterminated HTML comment (<!--) after stripping`);
+  }
   // Fail the build if any repo-relative Markdown link survived the rewrite above.
   // siteLinks is hand-maintained; without this guard a new relative link ships
   // as a 404 on the site (as ./docs/adr/oss-mechanics.md once did). Flag every

--- a/docs/site/scripts/prepare-content.mjs
+++ b/docs/site/scripts/prepare-content.mjs
@@ -14,30 +14,35 @@ await writeFile(
   await readFile(resolve(repositoryRoot, 'install/upgrade-nightly.sh')),
 );
 
+// Targets are .mdx, not .md: Astro only applies the Fumadocs `components`
+// override (the overflow-scrolling table wrapper and the anchor-linked headings)
+// when the page is MDX. A plain .md page renders bare `<table>`/`<h2 id>`, which
+// is what broke horizontal table scrolling and copyable heading links on these
+// generated policy pages.
 const pages = [
-  { source: 'SECURITY.md', target: 'security.md', title: 'Security policy' },
-  { source: 'SUPPORT.md', target: 'support.md', title: 'Support policy' },
-  { source: 'GOVERNANCE.md', target: 'governance.md', title: 'Governance' },
+  { source: 'SECURITY.md', target: 'security.mdx', title: 'Security policy' },
+  { source: 'SUPPORT.md', target: 'support.mdx', title: 'Support policy' },
+  { source: 'GOVERNANCE.md', target: 'governance.mdx', title: 'Governance' },
   {
     source: 'docs/status/README.md',
-    target: 'implementation-status.md',
+    target: 'implementation-status.mdx',
     title: 'Implementation status',
   },
-  { source: 'TRADEMARK.md', target: 'trademark.md', title: 'Trademark policy' },
-  { source: 'CONTRIBUTING.md', target: 'contributing.md', title: 'Contributing' },
+  { source: 'TRADEMARK.md', target: 'trademark.mdx', title: 'Trademark policy' },
+  { source: 'CONTRIBUTING.md', target: 'contributing.mdx', title: 'Contributing' },
   {
     source: 'docs/release/signing.md',
-    target: 'release/signing.md',
+    target: 'release/signing.mdx',
     title: 'Release signing ceremony',
   },
   {
     source: 'docs/release/online-signing.md',
-    target: 'release/online-signing.md',
+    target: 'release/online-signing.mdx',
     title: 'Online stable release guide',
   },
   {
     source: 'docs/release/legacy-offline-signing.md',
-    target: 'release/legacy-offline-signing.md',
+    target: 'release/legacy-offline-signing.mdx',
     title: 'Legacy offline release reference',
   },
 ];
@@ -51,7 +56,12 @@ const siteLinks = new Map([
   ['../research/release-signing-ceremonies.md', 'https://github.com/Hikyo-Org/Hikyo/blob/main/docs/research/release-signing-ceremonies.md'],
   ['./CONTRIBUTING.md', '/contributing/'],
   ['./GOVERNANCE.md', '/governance/'],
+  ['./GOVERNANCE.md#amendment-procedure', '/governance/#amendment-procedure'],
   ['./docs/status/README.md', '/implementation-status/'],
+  ['./docs/status/README.md#obl-repository-transfer', '/implementation-status/#obl-repository-transfer'],
+  ['./docs/adr/README.md', 'https://github.com/Hikyo-Org/Hikyo/blob/main/docs/adr/README.md'],
+  ['./docs/spec/README.md', 'https://github.com/Hikyo-Org/Hikyo/blob/main/docs/spec/README.md'],
+  ['./docs/adr/oss-mechanics.md', 'https://github.com/Hikyo-Org/Hikyo/blob/main/docs/adr/oss-mechanics.md'],
   [
     './docs/handoff/github-org-transfer.md',
     'https://github.com/Hikyo-Org/Hikyo/blob/main/docs/handoff/github-org-transfer.md',
@@ -63,6 +73,9 @@ const siteLinks = new Map([
 
 for (const page of pages) {
   await rm(resolve(docsRoot, page.target), { force: true });
+  // Remove the pre-.mdx artifact too so a stale local .md never collides with
+  // the .mdx page for the same slug.
+  await rm(resolve(docsRoot, page.target.replace(/\.mdx$/, '.md')), { force: true });
 }
 await rm(resolve(docsRoot, 'policies'), { recursive: true, force: true });
 await rm(resolve(docsRoot, 'license.md'), { force: true });
@@ -73,6 +86,22 @@ for (const page of pages) {
   let body = source.replace(/^# .+\n+/, '');
   for (const [repositoryLink, siteLink] of siteLinks) {
     body = body.replaceAll(`(${repositoryLink})`, `(${siteLink})`);
+  }
+  // MDX parses HTML comments as JSX and chokes on them; the generated status
+  // page carries a "do not edit" note that is only meaningful on the repo source.
+  body = body.replace(/<!--[\s\S]*?-->\n?/g, '');
+  // Fail the build if any repo-relative Markdown link survived the rewrite above.
+  // siteLinks is hand-maintained; without this guard a new relative link ships
+  // as a 404 on the site (as ./docs/adr/oss-mechanics.md once did). Flag every
+  // inline-link destination that is not absolute: this catches bare-relative
+  // links like `online-signing.md` too, not only `./`/`../` forms.
+  const unrewritten = [...body.matchAll(/\]\(([^)]+)\)/g)]
+    .map((match) => match[1])
+    .filter((destination) => !/^(?:https?:|mailto:|#|\/)/.test(destination));
+  if (unrewritten.length > 0) {
+    throw new Error(
+      `${page.source}: relative links have no site mapping in prepare-content.mjs: ${unrewritten.join(', ')}`,
+    );
   }
   const destination = resolve(docsRoot, page.target);
   await mkdir(dirname(destination), { recursive: true });

--- a/docs/site/src/styles/docs.css
+++ b/docs/site/src/styles/docs.css
@@ -65,6 +65,22 @@ pre {
   padding-block-start: 1.25rem;
 }
 
+/* Sidebar section labels ("Project policy", "Release trust"). Fumadocs renders
+   these separators as bare <p> at the same size, weight and colour as the
+   clickable page links, so they read as tappable links. Style them as clear
+   labels instead: smaller, uppercase, muted. Page links render as <a>, so the
+   only <p> in the sidebar are separators; `inline-flex` is their marker (the
+   spacing utility `mt-6` is deliberately not matched, since `first:mt-0` strips
+   it from a first-in-tree separator). If Fumadocs ever drops these utility
+   classes, eject the sidebar component and add a semantic marker instead. */
+:is(#nd-sidebar, #nd-sidebar-mobile) p[class~='inline-flex'] {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground);
+}
+
 button,
 a {
   border-radius: 0.25rem;


### PR DESCRIPTION
Adapts the hikyo.app policy pages to reviewer feedback across `/security/`, `/implementation-status/`, `/contributing/`, and `/governance/`.

## Root cause
Astro applies the Fumadocs `components` override (table overflow wrapper + anchored copyable headings) only to `.mdx`, not `.md`. Emitting the generated policy pages as `.mdx` fixes **both** the Android table-horizontal-scroll bug **and** the copyable-heading-anchor bug with one change.

## Changes (7 source files; generated `.mdx` are gitignored)
- **`prepare-content.mjs`** — emit `.mdx`; add missing `siteLinks` mappings (incl. the oss-mechanics 404); strip MDX-breaking HTML comments; **build guard** now fails on any non-absolute inline link with no site mapping (catches bare-relative like `online-signing.md`, not only `./`/`../`), so a relative link can never ship as a 404 again.
- **`docs.css`** — sidebar separators ("Project policy" / "Release trust") styled as uppercase muted labels via `#nd-sidebar p[class~='inline-flex']` (all sidebar `<p>` are separators; page links are `<a>`).
- **`SECURITY.md`** — advisory/GHSA/CVE definitions with the private-draft → public-record lifecycle; what happens if a vuln is filed publicly (lock + redact, private advisory, treat as public disclosure, still credit reporter).
- **`CONTRIBUTING.md`** — reconcile "open an issue" with private reporting; DCO shorthand; spell out CLA; consistent security-policy links; amendment link; local-verification / CI / fuzzing split.
- **`GOVERNANCE.md`** — BDFL full-form-before-shorthand (locked phrase kept); ADR spelled out; `/ee` enterprise-edition; linked CONTRIBUTING + ledger.
- **`TRADEMARK.md`** — route security reports to private channels.

## Verification
- `pnpm run test` exit 0: OSS-policy gate, docs PWA, PostHog, CSP (47 governed pages), PWA offline.
- Android table scroll confirmed on pixel-7 (412px): wrapper scrollWidth 641 > clientWidth 380.
- Sidebar labels confirmed live: 11px / 600 / uppercase / muted.
- Build guard exercised; no false positive on release-docs code blocks.
- Locked phrases exact; no em-dash.

## Cross-model review
Blocking native Codex (gpt-5.6-sol, high effort), 2 rounds: R1 five findings (security-prose accuracy + lifecycle, coverage-overpromise wording, link-guard completeness, CSS selector fragility) → all fixed → R2 **CLEAN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)