### PR TITLE
fix(upgrade): download only native nightly payloads

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,7 +163,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ALLOW_MISSING_PREDECESSOR: ${{ inputs.allow_missing_predecessor == true }}
-          PREDECESSOR_EDGES: 3
+          PREDECESSOR_EDGES: 8
         run: |
           set -o pipefail
           # Up to PREDECESSOR_EDGES signed predecessors, newest first, each

--- a/cmd/hikyo/main.go
+++ b/cmd/hikyo/main.go
@@ -32,6 +32,7 @@ import (
 	binaryupdate "github.com/Hikyo-Org/hikyo/internal/selfupdate"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
 	"github.com/Hikyo-Org/hikyo/internal/updater"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
 )
 
 // Set by GoReleaser. Development builds deliberately identify themselves as
@@ -107,6 +108,10 @@ func run() int {
 	}
 
 	switch {
+	case cmd == "--upgrade-bundle-formats":
+		fmt.Fprintln(os.Stdout, upgradebundle.IndexFormat)
+		fmt.Fprintln(os.Stdout, upgradebundle.PlatformIndexFormat)
+		return 0
 	case cmd == "--version":
 		writeMachineVersion(os.Stdout)
 		return 0

--- a/cmd/hikyo/verbosity_test.go
+++ b/cmd/hikyo/verbosity_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
 )
 
 func TestGlobalVerbosityKeepsVersionAndHelpContracts(t *testing.T) {
@@ -15,6 +17,7 @@ func TestGlobalVerbosityKeepsVersionAndHelpContracts(t *testing.T) {
 		stderr string
 	}{
 		{"machine version", []string{"-vvv", "--version"}, 0, version + "\n", ""},
+		{"bundle formats", []string{"--upgrade-bundle-formats"}, 0, upgradebundle.IndexFormat + "\n" + upgradebundle.PlatformIndexFormat + "\n", ""},
 		{"overview", []string{"-v", "--verbose", "--help"}, 0, "global diagnostics (stderr only):", ""},
 		{"missing command", []string{"-vvv"}, 2, "", ""},
 		{"server help", []string{"-vvv", "server", "--help"}, 0, "", "Usage of server:"},

--- a/docs/adr/signed-upgrade-compatibility.md
+++ b/docs/adr/signed-upgrade-compatibility.md
@@ -1,5 +1,12 @@
 # Signed upgrade compatibility and platform orchestration
 
+> **Platform-download amendment (2026-09-11, owner requested):** Automatic
+> upgrades fetch only the native OS/architecture binary archive and required
+> metadata. The complete signed manifest remains unchanged; v2 runtime bundles
+> verify a closed platform selection. Complete v1 offline bundles remain
+> supported. Historical intermediate executables without v2 support are refused
+> before service fencing or migration. See [artifact verification](../operations/upgrade-artifacts.md#nightly-profile).
+
 > **Declared stable-signing amendment (2026-09-08):** The owner selected online keyless stable signing with reviewed draft publication. [Stable workflow signing](stable-workflow-signing.md) supersedes the historical offline stable ceremony after implementation merge and explicit recovery-signed policy activation. The existing root remains; activation and 1.0 publication are pending.
 
 Status: locked upon merge of the #638 governance and legacy-retirement PR, 2026-09-05.

--- a/docs/operations/signed-nightlies.md
+++ b/docs/operations/signed-nightlies.md
@@ -82,7 +82,7 @@ bundle and boots/restarts the packaged Linux binary in production mode on both
 engines. After the first signed nightly, it also runs the previous published
 binary, populates an encrypted secret, exports and drills a backup, signs local
 operator evidence, upgrades with the candidate binary, and checks readiness,
-secret readability and restart. Each nightly declares up to three signed
+secret readability and restart. Each nightly declares up to eight signed
 predecessors as exact-schema upgrade sources, newest first, and the populated
 upgrade proof runs from both the newest and the oldest of them, so a route can
 skip one revoked or missing release without a bridge ceremony as long as an

--- a/docs/operations/upgrade-artifacts.md
+++ b/docs/operations/upgrade-artifacts.md
@@ -122,16 +122,40 @@ index, tree size, pinned log and checkpoint origin. Local wall time never
 substitutes for signed-time evidence. TSA-only Rekor v2 evidence does not satisfy
 this profile's signed integrated-time contract.
 
-The closed inventory contains every payload asset, including executables with
-exact platforms, compatibility, provenance, checksums, other metadata and
-applicable exact OCI references/digests. Only the fixed enclosing
-`release-manifest.json` and `release-manifest.sigstore.json` pair is outside its
-own inventory. All actual inventory readers are hashed before a nightly release
-is returned. Extra, missing, duplicate, unknown or substituted assets refuse.
-Verified staging bytes must remain immutable until execution. Current unsigned
-nightlies remain unsupported; no fallback constructs a stable identity.
-The [signed-nightly runbook](signed-nightlies.md) covers automated publication,
-offline public trust authorization and complete-payload bundle assembly.
+The signed manifest contains the complete release inventory, including exact
+platforms and artifact digests. Its signature and identity are never rewritten
+for a particular host. Only the fixed enclosing `release-manifest.json` and
+`release-manifest.sigstore.json` pair is outside that inventory.
+
+The automatic binary updater authenticates this manifest before downloading
+payloads. It selects exactly one archive for the host OS and architecture, plus
+shared or matching compatibility, policy, trust-root, provenance, checksum,
+release-note and SBOM metadata. Linux amd64 LXC installations therefore fetch the
+Linux amd64 archive, without Windows, macOS, ARM or OS-package downloads. Debian,
+RPM, APK and Arch packages are not used by the binary updater.
+
+`VerifyNightlyManifest` authenticates release identity and inventory without
+claiming payload verification. `VerifyNightly` then requires and hashes exactly
+the chosen inventory. Missing native archives, ambiguous native archives, extra
+payloads and substituted bytes fail. An empty platform retains complete-release
+verification for offline publication tooling.
+
+Platform bundles use `hikyo.dev/offline-upgrade-bundle/v2` and an explicit
+`nightly_platform` in `index.json`. The loader still supports complete v1 bundles;
+v2 requires a supported platform and its exact signed selection. Private cache
+and bundle payloads share storage on the same filesystem, remain immutable, and
+are independently reverified. Cache removal does not invalidate a linked bundle.
+
+Historical binaries only understand complete v1 bundles. Before stopping the
+service or migrating, the coordinator probes every staged route executable with
+`--upgrade-bundle-formats`. A required intermediate release without v2 support
+fails with an explicit compatibility error, without downloading foreign payloads.
+The initial invocation from an older installed updater still follows that older
+binary's download behavior until it hands off to the new release.
+
+Current unsigned nightlies remain unsupported; no fallback constructs a stable
+identity. The [signed-nightly runbook](signed-nightlies.md) covers automated
+publication, offline public trust authorization and complete-payload assembly.
 
 ## Planner and recovery edges
 

--- a/internal/app/automatic_bundle_format.go
+++ b/internal/app/automatic_bundle_format.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+)
+
+// Probe only a staged, authenticated executable, before service fencing or
+// migration. Historical runtimes require all platforms' payloads and cannot
+// consume v2. Never silently redownload foreign payloads to accommodate them.
+func checkAutomaticBundleFormat(ctx context.Context, executable string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, executable, "--upgrade-bundle-formats").Output()
+	if err != nil || !slices.Contains(strings.Fields(string(output)), upgradebundle.PlatformIndexFormat) {
+		return errors.New("release lacks platform-specific bundle support; select a compatible upgrade route")
+	}
+	return nil
+}

--- a/internal/app/automatic_bundle_format_test.go
+++ b/internal/app/automatic_bundle_format_test.go
@@ -1,0 +1,33 @@
+//go:build darwin || linux
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+)
+
+func TestAutomaticBundleFormatRejectsHistoricalCandidateBeforeApplication(t *testing.T) {
+	for _, tc := range []struct {
+		name, output string
+		accepted     bool
+	}{
+		{"platform-aware", upgradebundle.IndexFormat + "\\n" + upgradebundle.PlatformIndexFormat, true},
+		{"historical", upgradebundle.IndexFormat, false},
+		{"unknown-command", "unknown command", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			binary := filepath.Join(t.TempDir(), "candidate")
+			script := "#!/bin/sh\n[ \"$1\" = --upgrade-bundle-formats ] || exit 2\nprintf '" + tc.output + "\\n'\n"
+			if err := os.WriteFile(binary, []byte(script), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := checkAutomaticBundleFormat(t.Context(), binary); (err == nil) != tc.accepted {
+				t.Fatalf("accepted=%t, err=%v", tc.accepted, err)
+			}
+		})
+	}
+}

--- a/internal/app/automatic_upgrade.go
+++ b/internal/app/automatic_upgrade.go
@@ -270,6 +270,9 @@ func RunAutomaticUpgrade(ctx context.Context, args []string, out io.Writer, read
 		if err != nil {
 			return err
 		}
+		if err := checkAutomaticBundleFormat(ctx, staged[step.Target]); err != nil {
+			return fmt.Errorf("nightly %s cannot use the platform bundle: %w", step.Target.Version, err)
+		}
 	}
 	resume := previous != nil && previous.Phase != "complete" && previous.Phase != "preparing"
 	journal := previous

--- a/internal/releasetrust/nightly.go
+++ b/internal/releasetrust/nightly.go
@@ -47,16 +47,19 @@ type NightlyManifest struct {
 	Artifacts       []Artifact              `json:"artifacts"`
 }
 
-// Artifacts is the actual closed payload inventory, excluding only the fixed
-// release-manifest.json and release-manifest.sigstore.json envelope pair.
-// Every reader is consumed and checked. The caller must enumerate the actual
-// asset directory and keep verified staging bytes immutable until use.
+// Artifacts is the actual closed payload inventory, excluding the fixed
+// manifest/signature pair. Platform selects the native subset; empty means the
+// complete release. VerifyNightly consumes every reader. The caller enumerates
+// the actual directory and keeps verified staging bytes immutable until use.
 type NightlyMaterial struct {
 	Policy, TrustedRoot, Manifest, Bundle, Compatibility []byte
 	Artifacts                                            map[string]io.Reader
+	Platform                                             string
 }
 
-func VerifyNightly(snapshot Snapshot, material NightlyMaterial) (VerifiedRelease, error) {
+// VerifyNightlyManifest authenticates identity and signed inventory without
+// fetching payloads. Each selected artifact must still be verified before use.
+func VerifyNightlyManifest(snapshot Snapshot, material NightlyMaterial) (VerifiedRelease, error) {
 	if !snapshot.Valid() {
 		return VerifiedRelease{}, errors.New("unverified trust snapshot")
 	}
@@ -102,9 +105,6 @@ func VerifyNightly(snapshot Snapshot, material NightlyMaterial) (VerifiedRelease
 	}
 	identity := releaseidentity.Identity{Profile: manifest.Profile, Version: manifest.Version, Sequence: manifest.ReleaseSequence, Commit: manifest.SourceCommit, ManifestSHA256: manifestDigest, CompatibilitySHA256: releaseidentity.Hash(material.Compatibility)}
 	release := VerifiedRelease{state: &verifiedReleaseState{identity: identity, snapshot: snapshot.Digest(), policy: policyDigest, artifacts: slices.Clone(manifest.Artifacts)}}
-	if len(material.Artifacts) != len(manifest.Artifacts) {
-		return VerifiedRelease{}, errors.New("nightly payload inventory is incomplete or has extra assets")
-	}
 	kinds := map[string]bool{}
 	for _, artifact := range manifest.Artifacts {
 		if artifact.Name == "release-manifest.json" || artifact.Name == "release-manifest.sigstore.json" {
@@ -114,18 +114,85 @@ func VerifyNightly(snapshot Snapshot, material NightlyMaterial) (VerifiedRelease
 			return VerifiedRelease{}, errors.New("nightly executable lacks exact platform")
 		}
 		kinds[artifact.Kind] = true
-		reader, ok := material.Artifacts[artifact.Name]
-		if !ok {
-			return VerifiedRelease{}, errors.New("nightly payload missing")
-		}
-		if err := release.VerifyArtifact(artifact.Name, reader); err != nil {
-			return VerifiedRelease{}, fmt.Errorf("nightly asset %s: %w", artifact.Name, err)
-		}
 	}
 	if !kinds["binary"] || !kinds["binary-provenance"] || !kinds["checksum"] {
 		return VerifiedRelease{}, errors.New("nightly binary/provenance/checksum inventory is incomplete")
 	}
+	// These documents grant authority before any payload is downloaded.
+	for name, raw := range map[string][]byte{"nightly-policy.json": material.Policy, "sigstore-trusted-root.json": material.TrustedRoot, CompatibilityArtifact: material.Compatibility} {
+		if err := release.VerifyArtifact(name, bytes.NewReader(raw)); err != nil {
+			return VerifiedRelease{}, fmt.Errorf("nightly document %s: %w", name, err)
+		}
+	}
 	return release, nil
+}
+
+// VerifyNightly verifies the complete inventory by default. Platform requests
+// require exactly the authenticated platform selection, including its metadata.
+func VerifyNightly(snapshot Snapshot, material NightlyMaterial) (VerifiedRelease, error) {
+	release, err := VerifyNightlyManifest(snapshot, material)
+	if err != nil {
+		return VerifiedRelease{}, err
+	}
+	artifacts, err := release.NightlyArtifacts(material.Platform)
+	if err != nil {
+		return VerifiedRelease{}, err
+	}
+	if len(material.Artifacts) != len(artifacts) {
+		return VerifiedRelease{}, errors.New("nightly payload inventory is incomplete or has extra assets")
+	}
+	for _, artifact := range artifacts {
+		if err := release.VerifyArtifact(artifact.Name, material.Artifacts[artifact.Name]); err != nil {
+			return VerifiedRelease{}, fmt.Errorf("nightly asset %s: %w", artifact.Name, err)
+		}
+	}
+	return release, nil
+}
+
+// ValidNightlyPlatform recognizes the release platforms supported by the updater.
+func ValidNightlyPlatform(platform string) bool {
+	return slices.Contains([]string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"}, platform)
+}
+
+// NightlyArtifacts selects one native binary archive and shared or matching
+// platform metadata. OS packages are not used by the binary self-updater.
+// An empty platform preserves complete offline release verification.
+func (r VerifiedRelease) NightlyArtifacts(platform string) ([]Artifact, error) {
+	if !r.Valid() || r.Identity().Profile != releaseidentity.NightlyV1 {
+		return nil, errors.New("verified nightly required for platform selection")
+	}
+	if platform == "" {
+		return r.Artifacts(), nil
+	}
+	if !ValidNightlyPlatform(platform) {
+		return nil, errors.New("unsupported nightly platform")
+	}
+	var selected []Artifact
+	binaries := 0
+	metadata := map[string]bool{}
+	for _, artifact := range r.Artifacts() {
+		if artifact.Platform != "" && artifact.Platform != platform {
+			continue
+		}
+		switch artifact.Kind {
+		case "binary":
+			binaries++
+		case "nightly-policy", "sigstore-trusted-root", "upgrade-compatibility", "binary-provenance", "checksum", "release-notes", "sbom":
+			metadata[artifact.Kind] = true
+		default:
+			continue
+		}
+		selected = append(selected, artifact)
+	}
+	if binaries != 1 {
+		return nil, errors.New("nightly requires one exact platform binary")
+	}
+	for _, kind := range []string{"nightly-policy", "sigstore-trusted-root", "upgrade-compatibility", "binary-provenance", "checksum"} {
+		if !metadata[kind] {
+			return nil, errors.New("nightly platform metadata is incomplete")
+		}
+	}
+	return selected, nil
 }
 
 func (p NightlyPolicy) Validate() error {

--- a/internal/releasetrust/nightly_platform_test.go
+++ b/internal/releasetrust/nightly_platform_test.go
@@ -1,0 +1,84 @@
+package releasetrust_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
+)
+
+func TestNightlyPlatformSelectionVerifiesExactNativeInventory(t *testing.T) {
+	platforms := []string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"}
+	for _, platform := range platforms {
+		for _, mutation := range []string{"none", "missing binary", "missing metadata", "tampered", "extra binary", "extra package", "invalid signature", "unsupported", "ambiguous"} {
+			t.Run(platform+"/"+mutation, func(t *testing.T) {
+				compatibility := []byte("signed compatibility fixture")
+				payloads := map[string][]byte{"upgrade-compatibility.json": compatibility, "binary-provenance.json": []byte("{}"), "checksums.txt": []byte("checksums")}
+				artifacts := []releasetrust.Artifact{{Name: "upgrade-compatibility.json", Kind: "upgrade-compatibility"}, {Name: "binary-provenance.json", Kind: "binary-provenance"}, {Name: "checksums.txt", Kind: "checksum"}}
+				for _, target := range platforms {
+					name := strings.ReplaceAll(target, "/", "-") + ".archive"
+					payloads[name] = []byte(target)
+					artifacts = append(artifacts, releasetrust.Artifact{Name: name, Kind: "binary", Platform: target})
+				}
+				payloads["linux.deb"] = []byte("package")
+				artifacts = append(artifacts, releasetrust.Artifact{Name: "linux.deb", Kind: "package", Platform: "linux/amd64", Format: "deb", Arch: "amd64"})
+				if mutation == "ambiguous" {
+					payloads["duplicate.archive"] = []byte("duplicate")
+					artifacts = append(artifacts, releasetrust.Artifact{Name: "duplicate.archive", Kind: "binary", Platform: platform})
+				}
+				fixture, material, _ := testfixture.NightlyWithPayloads(t, compatibility, false, payloads, artifacts)
+				snapshot := fixture.Snapshot(t)
+				release, err := releasetrust.VerifyNightlyManifest(snapshot, material)
+				if err != nil {
+					t.Fatal(err)
+				}
+				selected, err := release.NightlyArtifacts(platform)
+				if mutation == "ambiguous" {
+					if err == nil {
+						t.Fatal("ambiguous native archive accepted")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				keep := map[string]bool{}
+				for _, artifact := range selected {
+					keep[artifact.Name] = true
+				}
+				for name := range material.Artifacts {
+					if !keep[name] {
+						delete(material.Artifacts, name)
+					}
+				}
+				material.Platform = platform
+				native := strings.ReplaceAll(platform, "/", "-") + ".archive"
+				switch mutation {
+				case "missing binary":
+					delete(material.Artifacts, native)
+				case "missing metadata":
+					delete(material.Artifacts, "checksums.txt")
+				case "tampered":
+					material.Artifacts[native] = strings.NewReader("tampered")
+				case "extra binary":
+					material.Artifacts["foreign.archive"] = strings.NewReader("foreign")
+				case "extra package":
+					material.Artifacts["linux.deb"] = bytes.NewReader(payloads["linux.deb"])
+				case "invalid signature":
+					material.Bundle = []byte("{}")
+				case "unsupported":
+					material.Platform = "linux/386"
+				}
+				_, err = releasetrust.VerifyNightly(snapshot, material)
+				if mutation == "none" && err != nil {
+					t.Fatal(err)
+				}
+				if mutation != "none" && err == nil {
+					t.Fatal("invalid platform evidence accepted")
+				}
+			})
+		}
+	}
+}

--- a/internal/releasetrust/testfixture/nightly.go
+++ b/internal/releasetrust/testfixture/nightly.go
@@ -210,6 +210,10 @@ func NightlyWithPayloads(t testing.TB, compatibility []byte, wrongCommit bool, p
 		}
 		return releasetrust.NightlyMaterial{Policy: policyRaw, TrustedRoot: rootRaw, Manifest: manifest, Bundle: bundleRaw, Compatibility: payloads[releasetrust.CompatibilityArtifact], Artifacts: readers}, pb
 	}
+	f.SignNightlyWithPayloads = func(compatibility []byte, version string, sequence uint64, payloads map[string][]byte, artifacts []releasetrust.Artifact) releasetrust.NightlyMaterial {
+		material, _ := sign(compatibility, version, sequence, payloads, artifacts)
+		return material
+	}
 	f.SignNightly = func(compatibility []byte, version string, sequence uint64) releasetrust.NightlyMaterial {
 		material, _ := sign(compatibility, version, sequence, nil, nil)
 		return material

--- a/internal/releasetrust/testfixture/stable.go
+++ b/internal/releasetrust/testfixture/stable.go
@@ -23,10 +23,11 @@ import (
 // and demonstrate that the real verifier refuses it.
 type Fixture struct {
 	// SignNightly reuses the same test-local OIDC policy for subsequent releases.
-	SignNightly func([]byte, string, uint64) releasetrust.NightlyMaterial
-	Pinned      releasetrust.PinnedTrust
-	Metadata    releasetrust.Metadata
-	Catalog     releasetrust.Catalog
+	SignNightly             func([]byte, string, uint64) releasetrust.NightlyMaterial
+	SignNightlyWithPayloads func([]byte, string, uint64, map[string][]byte, []releasetrust.Artifact) releasetrust.NightlyMaterial
+	Pinned                  releasetrust.PinnedTrust
+	Metadata                releasetrust.Metadata
+	Catalog                 releasetrust.Catalog
 	// NightlyPolicy is the currently published nightly policy served from the
 	// trust tree; nil for stable-only fixtures.
 	NightlyPolicy  []byte

--- a/internal/selfupdate/nightly.go
+++ b/internal/selfupdate/nightly.go
@@ -102,7 +102,7 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 	}
 	cachedDirectory := ""
 	if cacheIdentity.Validate() == nil && cacheIdentity.Version == status.LatestVersion {
-		candidate := filepath.Join(i.config.StateDir, "nightly-"+string(cacheIdentity.ManifestSHA256))
+		candidate := filepath.Join(i.config.StateDir, nightlyCacheDirectory(cacheIdentity))
 		if err := realNightlyDirectory(candidate); err == nil {
 			cachedDirectory = candidate
 		} else if !errors.Is(err, os.ErrNotExist) {
@@ -119,57 +119,9 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 		}
 		defer func() { err = errors.Join(err, os.RemoveAll(stage)) }()
 	}
-	var total int64
-	for _, candidate := range status.Assets {
-		total += candidate.Size
-	}
-	if cachedDirectory == "" {
-		diagnostics.Printf(ctx, 1, "  Downloading nightly %s: %d assets, %s.", status.LatestVersion, len(status.Assets), mebibytes(total))
-	} else {
-		diagnostics.Printf(ctx, 1, "  Reusing cached nightly %s; re-verifying %d assets.", status.LatestVersion, len(status.Assets))
-	}
-	total = 0
-	for _, candidate := range status.Assets {
-		if !releaseidentity.SafeName(candidate.Name) {
-			return errors.New("selfupdate: unsafe nightly payload name")
-		}
-		asset, err := exactAsset(status.LatestVersion, candidate.Name, status.Assets)
-		if err != nil {
-			return err
-		}
-		total += asset.Size
-		if asset.Size > maxArchiveBytes || total > 8<<30 {
-			return errors.New("selfupdate: nightly payload inventory exceeds byte bound")
-		}
-		var raw []byte
-		if cachedDirectory == "" {
-			diagnostics.Printf(ctx, 2, "    %s (%s)", asset.Name, mebibytes(asset.Size))
-			raw, err = i.download(ctx, asset, maxArchiveBytes)
-		} else {
-			raw, err = readNightlyFile(filepath.Join(cachedDirectory, asset.Name), maxArchiveBytes)
-			if err == nil && (int64(len(raw)) != asset.Size || "sha256:"+string(releaseidentity.Hash(raw)) != asset.Digest) {
-				err = errors.New("selfupdate: cached nightly differs from immutable release asset inventory")
-			}
-		}
-		if err != nil {
-			return err
-		}
-		if cachedDirectory != "" {
-			continue
-		}
-		file, err := os.OpenFile(filepath.Join(stage, asset.Name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-		if err != nil {
-			return err
-		}
-		_, err = file.Write(raw)
-		if err := errors.Join(err, file.Sync(), file.Close()); err != nil {
-			return err
-		}
-	}
-	diagnostics.Printf(ctx, 1, "  Verifying nightly %s signatures.", status.LatestVersion)
-	release, err := upgradebundle.VerifyNightlyDirectory(ctx, stage, snapshot)
+	release, err := i.downloadNightlyPlatform(ctx, status, stage, cachedDirectory != "", snapshot)
 	if err != nil {
-		return fmt.Errorf("selfupdate: authenticate complete nightly: %w", err)
+		return err
 	}
 	identity := release.Identity()
 	if identity.Version != status.LatestVersion {
@@ -184,12 +136,12 @@ func (i *Installer) prepareNightly(ctx context.Context, status updatecheck.Statu
 	if err := filedurability.SyncDirectory(stage); err != nil {
 		return err
 	}
-	destination := filepath.Join(i.config.StateDir, "nightly-"+string(identity.ManifestSHA256))
+	destination := filepath.Join(i.config.StateDir, nightlyCacheDirectory(identity))
 	if _, statErr := os.Lstat(destination); statErr == nil {
 		if err := realNightlyDirectory(destination); err != nil {
 			return err
 		}
-		verified, err := upgradebundle.VerifyNightlyDirectory(ctx, destination, snapshot)
+		verified, err := upgradebundle.VerifyNightlyPlatformDirectory(ctx, destination, snapshot, nightlyPlatform())
 		if err != nil || verified.Identity() != identity {
 			return errors.New("selfupdate: existing nightly staging differs from verified release")
 		}

--- a/internal/selfupdate/nightly_bundle.go
+++ b/internal/selfupdate/nightly_bundle.go
@@ -40,7 +40,7 @@ func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []Prep
 		if err := realNightlyDirectory(item.Directory); err != nil {
 			return "", err
 		}
-		verified, err := upgradebundle.VerifyNightlyDirectory(ctx, item.Directory, snapshot)
+		verified, err := upgradebundle.VerifyNightlyPlatformDirectory(ctx, item.Directory, snapshot, nightlyPlatform())
 		if err != nil {
 			return "", err
 		}
@@ -50,7 +50,7 @@ func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []Prep
 		identities = append(identities, string(item.Identity.ManifestSHA256))
 	}
 	slices.Sort(identities)
-	routeDigest := releaseidentity.Hash([]byte(strings.Join(identities, "\n")))
+	routeDigest := releaseidentity.Hash([]byte(nightlyPlatform() + "\n" + strings.Join(identities, "\n")))
 	destination := filepath.Join(i.config.StateDir, "bundle-"+string(routeDigest)+"-"+string(snapshot.Digest()))
 	if _, err := os.Lstat(destination); err == nil {
 		if err := realNightlyDirectory(destination); err != nil {
@@ -108,7 +108,7 @@ func (i *Installer) assembleNightlyEvidence(ctx context.Context, evidence []Prep
 			return "", err
 		}
 	}
-	options := upgradeassembly.Options{Pinned: pinned, Floor: snapshot.Floor(), SnapshotDirectory: filepath.Join(stage, "snapshot"), KeysDirectory: filepath.Join(stage, "keys"), OutputDirectory: destination, NightlyPolicy: material.NightlyPolicy}
+	options := upgradeassembly.Options{Pinned: pinned, Floor: snapshot.Floor(), SnapshotDirectory: filepath.Join(stage, "snapshot"), KeysDirectory: filepath.Join(stage, "keys"), OutputDirectory: destination, NightlyPolicy: material.NightlyPolicy, NightlyPlatform: nightlyPlatform()}
 	for _, item := range evidence {
 		options.Nightlies = append(options.Nightlies, item.Directory)
 	}

--- a/internal/selfupdate/nightly_download.go
+++ b/internal/selfupdate/nightly_download.go
@@ -1,0 +1,97 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+)
+
+func nightlyPlatform() string { return runtime.GOOS + "/" + runtime.GOARCH }
+
+func nightlyCacheDirectory(identity releaseidentity.Identity) string {
+	return "nightly-" + string(identity.ManifestSHA256) + "-" + runtime.GOOS + "-" + runtime.GOARCH
+}
+
+// Authenticate metadata before selecting any executable payload. Discovery
+// must match the entire signed inventory, but only native bytes are fetched.
+func (i *Installer) downloadNightlyPlatform(ctx context.Context, status updatecheck.Status, stage string, cached bool, snapshot releasetrust.Snapshot) (releasetrust.VerifiedRelease, error) {
+	documents := map[string][]byte{}
+	var total int64
+	read := func(name string, limit int64) ([]byte, error) {
+		asset, err := exactAsset(status.LatestVersion, name, status.Assets)
+		if err != nil {
+			return nil, err
+		}
+		total += asset.Size
+		if asset.Size > limit || total > 8<<30 {
+			return nil, errors.New("selfupdate: nightly payload inventory exceeds byte bound")
+		}
+		if cached {
+			raw, err := readNightlyFile(filepath.Join(stage, name), limit)
+			if err == nil && (int64(len(raw)) != asset.Size || "sha256:"+string(releaseidentity.Hash(raw)) != asset.Digest) {
+				err = errors.New("selfupdate: cached nightly differs from immutable release asset inventory")
+			}
+			return raw, err
+		}
+		diagnostics.Printf(ctx, 2, "    %s (%s)", name, mebibytes(asset.Size))
+		raw, err := i.download(ctx, asset, limit)
+		if err != nil {
+			return nil, err
+		}
+		file, err := os.OpenFile(filepath.Join(stage, name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		if err != nil {
+			return nil, err
+		}
+		_, err = file.Write(raw)
+		return raw, errors.Join(err, file.Sync(), file.Close())
+	}
+	for _, name := range []string{"release-manifest.json", "release-manifest.sigstore.json", "nightly-policy.json", "sigstore-trusted-root.json", "upgrade-compatibility.json"} {
+		raw, err := read(name, releasetrust.MaxDocumentBytes)
+		if err != nil {
+			return releasetrust.VerifiedRelease{}, err
+		}
+		documents[name] = raw
+	}
+	release, err := releasetrust.VerifyNightlyManifest(snapshot, releasetrust.NightlyMaterial{
+		Manifest: documents["release-manifest.json"], Bundle: documents["release-manifest.sigstore.json"],
+		Policy: documents["nightly-policy.json"], TrustedRoot: documents["sigstore-trusted-root.json"], Compatibility: documents["upgrade-compatibility.json"],
+	})
+	if err != nil {
+		return releasetrust.VerifiedRelease{}, fmt.Errorf("selfupdate: authenticate nightly manifest: %w", err)
+	}
+	if release.Identity().Version != status.LatestVersion || len(status.Assets) != len(release.Artifacts())+2 {
+		return releasetrust.VerifiedRelease{}, errors.New("selfupdate: discovery differs from signed nightly inventory")
+	}
+	for _, artifact := range release.Artifacts() {
+		asset, err := exactAsset(status.LatestVersion, artifact.Name, status.Assets)
+		if err != nil {
+			return releasetrust.VerifiedRelease{}, err
+		}
+		if asset.Digest != "sha256:"+artifact.SHA256 {
+			return releasetrust.VerifiedRelease{}, errors.New("selfupdate: discovery digest differs from signed nightly inventory")
+		}
+	}
+	selected, err := release.NightlyArtifacts(nightlyPlatform())
+	if err != nil {
+		return releasetrust.VerifiedRelease{}, err
+	}
+	diagnostics.Printf(ctx, 1, "  Preparing nightly %s for %s: %d selected assets.", status.LatestVersion, nightlyPlatform(), len(selected)+2)
+	for _, artifact := range selected {
+		if _, have := documents[artifact.Name]; have {
+			continue
+		}
+		if _, err := read(artifact.Name, maxArchiveBytes); err != nil {
+			return releasetrust.VerifiedRelease{}, err
+		}
+	}
+	return upgradebundle.VerifyNightlyPlatformDirectory(ctx, stage, snapshot, nightlyPlatform())
+}

--- a/internal/selfupdate/nightly_download_test.go
+++ b/internal/selfupdate/nightly_download_test.go
@@ -1,0 +1,118 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/upgradebundle"
+)
+
+func TestNightlyDownloadsOnlyNativeArchiveAndMetadata(t *testing.T) {
+	installer, status, _, _, _, _ := preparedNightlyFixture(t, nil)
+	native := mustArchiveName(t, status.LatestVersion)
+	transport := installer.client.Transport
+	requests := map[string]int{}
+	installer.client.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if strings.Contains(request.URL.Path, "/releases/download/") {
+			name := filepath.Base(request.URL.Path)
+			requests[name]++
+			if (strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".zip") || strings.HasSuffix(name, ".deb")) && name != native {
+				t.Errorf("downloaded irrelevant payload %s on %s", name, nightlyPlatform())
+			}
+		}
+		return transport.RoundTrip(request)
+	})
+	prepared, err := installer.PrepareNightly(t.Context(), status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests[native] != 1 || len(requests) != 8 {
+		t.Fatalf("expected native archive and seven metadata files: %v", requests)
+	}
+	entries, err := os.ReadDir(prepared.Directory)
+	if err != nil || len(entries) != len(requests) {
+		t.Fatalf("cache differs from selected download inventory: %v %v", entries, err)
+	}
+	for _, entry := range entries {
+		if requests[entry.Name()] != 1 {
+			t.Fatalf("unexpected cached artifact: %s", entry.Name())
+		}
+	}
+	if _, err := installer.PrepareNightly(t.Context(), status); err != nil {
+		t.Fatal(err)
+	}
+	if requests[native] != 1 {
+		t.Fatal("handoff downloaded the native archive again")
+	}
+}
+
+func TestPlatformBundleRejectsInventoryModeSubstitution(t *testing.T) {
+	installer, status, _, trust, _, _ := preparedNightlyFixture(t, nil)
+	prepared, err := installer.PrepareNightly(t.Context(), status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(prepared.BundleDirectory, "index.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mutation := range []string{"missing platform", "unsupported platform", "other platform", "downgrade"} {
+		t.Run(mutation, func(t *testing.T) {
+			var index upgradebundle.Index
+			if err := json.Unmarshal(raw, &index); err != nil {
+				t.Fatal(err)
+			}
+			switch mutation {
+			case "missing platform":
+				index.NightlyPlatform = ""
+			case "unsupported platform":
+				index.NightlyPlatform = "linux/386"
+			case "other platform":
+				index.NightlyPlatform = "windows/amd64"
+				if nightlyPlatform() == index.NightlyPlatform {
+					index.NightlyPlatform = "linux/amd64"
+				}
+			case "downgrade":
+				index.Format, index.NightlyPlatform = upgradebundle.IndexFormat, ""
+			}
+			changed, err := json.Marshal(index)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, changed, 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := upgradebundle.Load(t.Context(), prepared.BundleDirectory, trust.Pinned, releaseidentity.SnapshotFloor{}); err == nil {
+				t.Fatal("substituted platform inventory accepted")
+			}
+		})
+	}
+}
+
+func TestNightlyRejectsSignatureBeforeDownloadingExecutable(t *testing.T) {
+	installer, status, _, _, _, responses := preparedNightlyFixture(t, nil)
+	for index := range status.Assets {
+		asset := &status.Assets[index]
+		if asset.Name == "release-manifest.sigstore.json" {
+			raw := []byte("{}")
+			responses[asset.URL] = raw
+			asset.Size, asset.Digest = int64(len(raw)), "sha256:"+string(releaseidentity.Hash(raw))
+		}
+	}
+	transport := installer.client.Transport
+	installer.client.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(request.URL.Path, ".tar.gz") || strings.HasSuffix(request.URL.Path, ".zip") || strings.HasSuffix(request.URL.Path, ".deb") {
+			t.Error("downloaded executable before authenticating manifest")
+		}
+		return transport.RoundTrip(request)
+	})
+	if _, err := installer.PrepareNightly(t.Context(), status); err == nil {
+		t.Fatal("invalid manifest signature accepted")
+	}
+}

--- a/internal/selfupdate/nightly_prepare_test.go
+++ b/internal/selfupdate/nightly_prepare_test.go
@@ -44,6 +44,23 @@ func preparedNightlyFixture(t *testing.T, archive []byte) (*Installer, updateche
 	}
 	payloads := map[string][]byte{name: archive, "checksums.txt": responses[base+"checksums.txt"], "binary-provenance.json": []byte("{}"), "upgrade-compatibility.json": claim}
 	artifacts := []releasetrust.Artifact{{Name: name, Kind: "binary", Platform: runtime.GOOS + "/" + runtime.GOARCH}, {Name: "checksums.txt", Kind: "checksum"}, {Name: "binary-provenance.json", Kind: "binary-provenance"}, {Name: "upgrade-compatibility.json", Kind: "upgrade-compatibility"}}
+	for _, platform := range []string{"linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm64"} {
+		if platform == nightlyPlatform() {
+			continue
+		}
+		parts := strings.Split(platform, "/")
+		foreign, err := archiveName(version, parts[0], parts[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		payloads[foreign] = []byte("foreign platform payload")
+		artifacts = append(artifacts, releasetrust.Artifact{Name: foreign, Kind: "binary", Platform: platform})
+	}
+	for _, arch := range []string{"amd64", "arm64"} {
+		name := "hikyo_" + arch + ".deb"
+		payloads[name] = []byte("unused package")
+		artifacts = append(artifacts, releasetrust.Artifact{Name: name, Kind: "package", Platform: "linux/" + arch, Format: "deb", Arch: arch})
+	}
 	trust, material, _ := testfixture.NightlyWithPayloads(t, claim, false, payloads, artifacts)
 	installer.config.TrustRootBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.Root)
 	installer.config.RecoveryKeyBase64 = base64.StdEncoding.EncodeToString(trust.Pinned.RecoveryPublicKey)
@@ -173,7 +190,9 @@ func TestNightlyRouteReauthenticatesAllExactEvidence(t *testing.T) {
 			}
 			declaration.Profile, declaration.Version, declaration.Sequence, declaration.Commit = releaseidentity.NightlyV1, "1.0.0-nightly.1", 1, strings.Repeat("a", 40)
 			claim := testfixture.JSON(t, declaration)
-			material := trust.SignNightly(claim, declaration.Version, declaration.Sequence)
+			material := trust.SignNightlyWithPayloads(claim, declaration.Version, declaration.Sequence,
+				map[string][]byte{"upgrade-compatibility.json": claim, "source.tar.gz": []byte("source binary"), "binary-provenance.json": []byte("{}"), "checksums.txt": []byte("checksums")},
+				[]releasetrust.Artifact{{Name: "upgrade-compatibility.json", Kind: "upgrade-compatibility"}, {Name: "source.tar.gz", Kind: "binary", Platform: nightlyPlatform()}, {Name: "binary-provenance.json", Kind: "binary-provenance"}, {Name: "checksums.txt", Kind: "checksum"}})
 			source := PreparedNightly{Directory: t.TempDir(), Identity: releaseidentity.Identity{Profile: declaration.Profile, Version: declaration.Version, Sequence: declaration.Sequence, Commit: declaration.Commit, CompatibilitySHA256: releaseidentity.Hash(claim), ManifestSHA256: releaseidentity.Hash(material.Manifest)}}
 			for name, reader := range material.Artifacts {
 				raw, err := io.ReadAll(reader)

--- a/internal/selfupdate/nightly_prune.go
+++ b/internal/selfupdate/nightly_prune.go
@@ -65,6 +65,7 @@ func (i *Installer) pruneNightlyCache(ctx context.Context, scratchOnly bool, kee
 			return errors.New("selfupdate: retained nightly identity is invalid")
 		}
 		retained["nightly-"+string(identity.ManifestSHA256)] = true
+		retained[nightlyCacheDirectory(identity)] = true
 		retained["executable-"+string(identity.ManifestSHA256)+"-"] = true
 	}
 	return i.pruneNightlyEntries(ctx, func(name string) bool {
@@ -75,7 +76,7 @@ func (i *Installer) pruneNightlyCache(ctx context.Context, scratchOnly bool, kee
 	})
 }
 
-var nightlyCacheName = regexp.MustCompile(`^(nightly-[0-9a-f]{64}|bundle-[0-9a-f]{64}-[0-9a-f]{64}|executable-[0-9a-f]{64}-[a-z0-9]+-[a-z0-9]+)$`)
+var nightlyCacheName = regexp.MustCompile(`^(nightly-[0-9a-f]{64}(-[a-z0-9]+-[a-z0-9]+)?|bundle-[0-9a-f]{64}-[0-9a-f]{64}|executable-[0-9a-f]{64}-[a-z0-9]+-[a-z0-9]+)$`)
 
 func generatedNightlyEntry(name string) bool {
 	if nightlyCacheName.MatchString(name) {

--- a/internal/selfupdate/nightly_prune_test.go
+++ b/internal/selfupdate/nightly_prune_test.go
@@ -17,7 +17,7 @@ func TestPruneNightlyCacheKeepsRetainedIdentityAndTrustState(t *testing.T) {
 	state := t.TempDir()
 	keep := releaseidentity.Identity{Profile: releaseidentity.NightlyV1, Version: "1.1.0-nightly.3", Sequence: 3, Commit: strings.Repeat("b", 40), CompatibilitySHA256: releaseidentity.Hash([]byte("claim")), ManifestSHA256: releaseidentity.Hash([]byte("keep"))}
 	stale := releaseidentity.Hash([]byte("stale"))
-	for _, dir := range []string{"nightly-" + string(keep.ManifestSHA256), "nightly-" + string(stale), "bundle-" + strings.Repeat("a", 64) + "-" + strings.Repeat("b", 64), ".nightly-download-abandoned", ".nightly-bundle-inputs-abandoned"} {
+	for _, dir := range []string{nightlyCacheDirectory(keep), "nightly-" + string(stale) + "-linux-amd64", "nightly-" + string(keep.ManifestSHA256), "nightly-" + string(stale), "bundle-" + strings.Repeat("a", 64) + "-" + strings.Repeat("b", 64), ".nightly-download-abandoned", ".nightly-bundle-inputs-abandoned"} {
 		if err := os.MkdirAll(filepath.Join(state, dir, "inner"), 0700); err != nil {
 			t.Fatal(err)
 		}
@@ -41,12 +41,12 @@ func TestPruneNightlyCacheKeepsRetainedIdentityAndTrustState(t *testing.T) {
 	for _, entry := range entries {
 		names = append(names, entry.Name())
 	}
-	want := []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "nightly-" + string(keep.ManifestSHA256), "nightly-trust.lock", "unrelated"}
+	want := []string{"executable-" + string(keep.ManifestSHA256) + "-linux-amd64", "nightly-" + string(keep.ManifestSHA256), nightlyCacheDirectory(keep), "nightly-trust.lock", "unrelated"}
 	slices.Sort(want)
 	if !slices.Equal(names, want) {
 		t.Fatalf("after prune: %v, want %v", names, want)
 	}
-	if !strings.Contains(progress.String(), "Removed 5 cached nightly artifacts") {
+	if !strings.Contains(progress.String(), "Removed 6 cached nightly artifacts") {
 		t.Fatalf("progress: %q", progress.String())
 	}
 	if err := installer.PruneNightlyCache(t.Context(), releaseidentity.Identity{}); err == nil {

--- a/internal/upgradeassembly/assembly.go
+++ b/internal/upgradeassembly/assembly.go
@@ -37,6 +37,9 @@ type Options struct {
 	// NightlyPolicy is the currently published nightly policy when the caller
 	// obtained one online; its revocations then apply to every nightly input.
 	NightlyPolicy []byte
+	// NightlyPlatform selects native binary and metadata inputs for a v2 bundle.
+	// Empty preserves complete v1 offline release assembly.
+	NightlyPlatform string
 }
 
 // Assemble verifies all input evidence before atomically publishing a new
@@ -47,6 +50,9 @@ func Assemble(ctx context.Context, o Options) error {
 	}
 	if o.SnapshotDirectory == "" || o.KeysDirectory == "" || o.OutputDirectory == "" || len(o.Releases)+len(o.Nightlies) == 0 || len(o.Releases)+len(o.Nightlies) > upgradecompat.MaxReleases || len(o.Bridges) > upgradecompat.MaxEdges {
 		return errors.New("require snapshot, keys, output and releases with bounded inventories")
+	}
+	if o.NightlyPlatform != "" && !releasetrust.ValidNightlyPlatform(o.NightlyPlatform) {
+		return errors.New("unsupported nightly platform")
 	}
 	pinned, floor := o.Pinned, o.Floor
 	snapshotNames := []string{"metadata.json", "metadata.sigstore.json", "catalog.json", "catalog.sigstore.json"}
@@ -68,6 +74,9 @@ func Assemble(ctx context.Context, o Options) error {
 	}
 	names := []string{}
 	index := upgradebundle.Index{Format: upgradebundle.IndexFormat, PrimaryKeyIDs: []string{}, Releases: []upgradebundle.ReleaseEntry{}, Bridges: []releaseidentity.Digest{}}
+	if o.NightlyPlatform != "" {
+		index.Format, index.NightlyPlatform = upgradebundle.PlatformIndexFormat, o.NightlyPlatform
+	}
 	idPattern := regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 	for _, key := range metadata.PrimaryKeys {
 		if !releaseidentity.SafeName(key.PublicKey) || !idPattern.MatchString(key.ID) {
@@ -143,7 +152,7 @@ func Assemble(ctx context.Context, o Options) error {
 		}
 	}
 	for _, directory := range o.Nightlies {
-		release, err := upgradebundle.CopyNightlyRelease(ctx, directory, filepath.Join(stage, "releases"), snapshot)
+		release, err := upgradebundle.CopyNightlyPlatformRelease(ctx, directory, filepath.Join(stage, "releases"), snapshot, o.NightlyPlatform)
 		if err != nil {
 			return err
 		}

--- a/internal/upgradebundle/bundle.go
+++ b/internal/upgradebundle/bundle.go
@@ -20,6 +20,8 @@ import (
 )
 
 const IndexFormat = "hikyo.dev/offline-upgrade-bundle/v1"
+const PlatformIndexFormat = "hikyo.dev/offline-upgrade-bundle/v2"
+
 const maxBundleDocuments = 64 << 20
 
 var keyIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
@@ -30,10 +32,11 @@ type ReleaseEntry struct {
 }
 
 type Index struct {
-	Format        string                   `json:"format"`
-	PrimaryKeyIDs []string                 `json:"primary_key_ids"`
-	Releases      []ReleaseEntry           `json:"releases"`
-	Bridges       []releaseidentity.Digest `json:"bridges"`
+	Format          string                   `json:"format"`
+	NightlyPlatform string                   `json:"nightly_platform,omitempty"`
+	PrimaryKeyIDs   []string                 `json:"primary_key_ids"`
+	Releases        []ReleaseEntry           `json:"releases"`
+	Bridges         []releaseidentity.Digest `json:"bridges"`
 }
 
 // Bundle holds immutable authenticated documents, not mutable downloaded
@@ -101,9 +104,10 @@ func Load(ctx context.Context, directory string, pinned releasetrust.PinnedTrust
 		return Bundle{}, err
 	}
 	var index Index
-	if definitions.DecodeStrict(raw, &index) != nil || index.Format != IndexFormat || index.PrimaryKeyIDs == nil || len(index.PrimaryKeyIDs) > 256 || index.Releases == nil || len(index.Releases) == 0 || len(index.Releases) > upgradecompat.MaxReleases || index.Bridges == nil || len(index.Bridges) > upgradecompat.MaxEdges {
+	if definitions.DecodeStrict(raw, &index) != nil || !validIndexPlatform(index) || index.PrimaryKeyIDs == nil || len(index.PrimaryKeyIDs) > 256 || index.Releases == nil || len(index.Releases) == 0 || len(index.Releases) > upgradecompat.MaxReleases || index.Bridges == nil || len(index.Bridges) > upgradecompat.MaxEdges {
 		return Bundle{}, errors.New("invalid bounded offline bundle index")
 	}
+	reader.nightlyPlatform = index.NightlyPlatform
 	keys := map[string][]byte{}
 	for _, id := range index.PrimaryKeyIDs {
 		if !keyIDPattern.MatchString(id) || id == "." || id == ".." || keys[id] != nil {
@@ -199,12 +203,17 @@ func Load(ctx context.Context, directory string, pinned releasetrust.PinnedTrust
 	return bundle, nil
 }
 
+func validIndexPlatform(index Index) bool {
+	return (index.Format == IndexFormat && index.NightlyPlatform == "") || (index.Format == PlatformIndexFormat && releasetrust.ValidNightlyPlatform(index.NightlyPlatform))
+}
+
 type documentReader struct {
-	ctx          context.Context
-	root         *os.Root
-	bytes        int
-	payloadBytes int64
-	documents    map[string]releaseidentity.Digest
+	nightlyPlatform string
+	ctx             context.Context
+	root            *os.Root
+	bytes           int
+	payloadBytes    int64
+	documents       map[string]releaseidentity.Digest
 }
 
 func (r *documentReader) read(name string) ([]byte, error) {

--- a/internal/upgradebundle/nightly_directory.go
+++ b/internal/upgradebundle/nightly_directory.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
 )
@@ -15,17 +16,22 @@ import (
 // Policy and Sigstore roots are payloads too; the recovery-signed snapshot must
 // independently authorize their exact policy digest.
 func VerifyNightlyDirectory(ctx context.Context, directory string, snapshot releasetrust.Snapshot) (releasetrust.VerifiedRelease, error) {
+	return VerifyNightlyPlatformDirectory(ctx, directory, snapshot, "")
+}
+
+// VerifyNightlyPlatformDirectory verifies the closed selection for one platform.
+func VerifyNightlyPlatformDirectory(ctx context.Context, directory string, snapshot releasetrust.Snapshot, platform string) (releasetrust.VerifiedRelease, error) {
 	root, err := os.OpenRoot(directory)
 	if err != nil {
 		return releasetrust.VerifiedRelease{}, err
 	}
 	defer root.Close()
 	r := documentReader{ctx: ctx, root: root}
-	release, _, err := r.flatNightly(snapshot)
+	release, _, err := r.flatNightly(snapshot, platform)
 	return release, err
 }
 
-func (r *documentReader) flatNightly(snapshot releasetrust.Snapshot) (releasetrust.VerifiedRelease, map[string][]byte, error) {
+func (r *documentReader) flatNightly(snapshot releasetrust.Snapshot, platform string) (releasetrust.VerifiedRelease, map[string][]byte, error) {
 	documents := map[string][]byte{}
 	for _, name := range []string{"release-manifest.json", "release-manifest.sigstore.json", "nightly-policy.json", "sigstore-trusted-root.json", "upgrade-compatibility.json"} {
 		raw, err := r.read(name)
@@ -48,22 +54,29 @@ func (r *documentReader) flatNightly(snapshot releasetrust.Snapshot) (releasetru
 	release, err := releasetrust.VerifyNightly(snapshot, releasetrust.NightlyMaterial{
 		Manifest: documents["release-manifest.json"], Bundle: documents["release-manifest.sigstore.json"],
 		Policy: documents["nightly-policy.json"], TrustedRoot: documents["sigstore-trusted-root.json"],
-		Compatibility: documents["upgrade-compatibility.json"], Artifacts: assets,
+		Compatibility: documents["upgrade-compatibility.json"], Artifacts: assets, Platform: platform,
 	})
 	return release, documents, err
 }
 
 // CopyNightlyRelease writes beneath a private assembler staging directory.
-// Each copied payload is rehashed through the verified envelope. The caller
+// Payloads on the same filesystem share storage with the download cache. They
+// must be treated as immutable; removing either directory keeps the other valid.
+// Each payload is rehashed through the verified envelope. The caller
 // authenticates the complete staged bundle before atomic public publication.
 func CopyNightlyRelease(ctx context.Context, directory, releasesDirectory string, snapshot releasetrust.Snapshot) (releasetrust.VerifiedRelease, error) {
+	return CopyNightlyPlatformRelease(ctx, directory, releasesDirectory, snapshot, "")
+}
+
+// CopyNightlyPlatformRelease retains only the verified platform selection.
+func CopyNightlyPlatformRelease(ctx context.Context, directory, releasesDirectory string, snapshot releasetrust.Snapshot, platform string) (releasetrust.VerifiedRelease, error) {
 	root, err := os.OpenRoot(directory)
 	if err != nil {
 		return releasetrust.VerifiedRelease{}, err
 	}
 	defer root.Close()
 	r := documentReader{ctx: ctx, root: root}
-	release, documents, err := r.flatNightly(snapshot)
+	release, documents, err := r.flatNightly(snapshot, platform)
 	if err != nil {
 		return releasetrust.VerifiedRelease{}, err
 	}
@@ -90,10 +103,40 @@ func CopyNightlyRelease(ctx context.Context, directory, releasesDirectory string
 	if err := os.Mkdir(filepath.Join(destination, "payloads"), 0700); err != nil {
 		return releasetrust.VerifiedRelease{}, err
 	}
+	payloadRoot, err := os.OpenRoot(filepath.Join(destination, "payloads"))
+	if err != nil {
+		return releasetrust.VerifiedRelease{}, err
+	}
+	defer payloadRoot.Close()
 	var copied int64
-	for _, artifact := range release.Artifacts() {
+	artifacts, err := release.NightlyArtifacts(platform)
+	if err != nil {
+		return releasetrust.VerifiedRelease{}, err
+	}
+	for _, artifact := range artifacts {
+		// Link rather than duplicate the complete multi-platform inventory for
+		// every route assembly. Load reopens and authenticates the staged files,
+		// including rejecting symlinks or bytes changed since verification.
+		target := filepath.Join(destination, "payloads", artifact.Name)
+		if err := os.Link(filepath.Join(directory, artifact.Name), target); err == nil {
+			input := &payloadReader{ctx: ctx, root: payloadRoot, name: artifact.Name, aggregate: &copied}
+			if err := errors.Join(release.VerifyArtifact(artifact.Name, input), input.Close()); err != nil {
+				return releasetrust.VerifiedRelease{}, err
+			}
+			file, err := openDocument(payloadRoot, artifact.Name)
+			if err != nil {
+				return releasetrust.VerifiedRelease{}, err
+			}
+			if err := errors.Join(file.Sync(), file.Close()); err != nil {
+				return releasetrust.VerifiedRelease{}, err
+			}
+			continue
+		} else if !errors.Is(err, syscall.EXDEV) {
+			return releasetrust.VerifiedRelease{}, err
+		}
+		// Standalone offline assembly may use inputs on another filesystem.
 		input := &payloadReader{ctx: ctx, root: root, name: artifact.Name, aggregate: &copied}
-		output, err := os.OpenFile(filepath.Join(destination, "payloads", artifact.Name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		output, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 		if err != nil {
 			return releasetrust.VerifiedRelease{}, err
 		}

--- a/internal/upgradebundle/nightly_test.go
+++ b/internal/upgradebundle/nightly_test.go
@@ -3,6 +3,8 @@ package upgradebundle
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -38,6 +40,45 @@ func TestNightlyOfflineBundleAuthenticatesActualClosedPayloadDirectory(t *testin
 					t.Fatal(err)
 				}
 				writeFixture(t, directory, releaseDir+"payloads/"+name, raw)
+			}
+			if mutation != "wrong commit" {
+				// Assemble from a flat download on the same filesystem. Verify
+				// physical storage reuse and that cache pruning leaves a complete
+				// independently loadable bundle.
+				flat := t.TempDir()
+				for name, raw := range map[string][]byte{"release-manifest.json": nightly.Manifest, "release-manifest.sigstore.json": nightly.Bundle} {
+					writeFixture(t, flat, name, raw)
+				}
+				for name := range nightly.Artifacts {
+					raw, err := os.ReadFile(filepath.Join(directory, releaseDir, "payloads", name))
+					if err != nil {
+						t.Fatal(err)
+					}
+					writeFixture(t, flat, name, raw)
+				}
+				snapshot, err := releasetrust.VerifySnapshot(fixture.Pinned, material, releaseidentity.SnapshotFloor{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.RemoveAll(filepath.Join(directory, "releases")); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := CopyNightlyRelease(t.Context(), flat, filepath.Join(directory, "releases"), snapshot); err != nil {
+					t.Fatal(err)
+				}
+				for name := range nightly.Artifacts {
+					source, err := os.Stat(filepath.Join(flat, name))
+					if err != nil {
+						t.Fatal(err)
+					}
+					target, err := os.Stat(filepath.Join(directory, releaseDir, "payloads", name))
+					if err != nil || !os.SameFile(source, target) {
+						t.Fatalf("payload storage duplicated for %s: %v", name, err)
+					}
+				}
+				if err := os.RemoveAll(flat); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if mutation == "extra" {
 				writeFixture(t, directory, releaseDir+"payloads/unsigned-extra.txt", []byte("extra"))

--- a/internal/upgradebundle/release.go
+++ b/internal/upgradebundle/release.go
@@ -75,7 +75,7 @@ func (r *documentReader) release(snapshot releasetrust.Snapshot, entry ReleaseEn
 				closer.Close()
 			}
 		}()
-		release, err = releasetrust.VerifyNightly(snapshot, releasetrust.NightlyMaterial{Manifest: manifest, Bundle: signature, Policy: policy, TrustedRoot: trustedRoot, Compatibility: compatibility, Artifacts: assets})
+		release, err = releasetrust.VerifyNightly(snapshot, releasetrust.NightlyMaterial{Manifest: manifest, Bundle: signature, Policy: policy, TrustedRoot: trustedRoot, Compatibility: compatibility, Artifacts: assets, Platform: r.nightlyPlatform})
 		if err != nil {
 			return releasetrust.VerifiedRelease{}, nil, fmt.Errorf("authenticate offline nightly release: %w", err)
 		}


### PR DESCRIPTION
The nightly upgrader downloaded every OS and architecture package, then duplicated the complete inventory for each route bundle. On small system disks this exhausted space during assembly.

Authenticate the full signed manifest first, download only the native archive and required metadata, and verify a closed platform-specific v2 bundle. Share private payload storage between cache and assembly, preserve complete v1 offline verification, and reject incompatible historical route executables before stopping the service. Expand the existing signed predecessor window to eight so the first v2 release can directly upgrade the deployed nightly 27 without running a v1-only intermediate binary.

Validation: tests passed for releasetrust, upgradebundle, upgradeassembly, selfupdate, hostupgrade, upgradegate, cmd/hikyo and internal/app. Regression coverage checks all six platforms, actual HTTP requests, signature-before-download ordering, tampering, cache retention, bundle mode substitution and historical executable refusal. Cross-provider review was skipped at the owner's request.
