### PR TITLE
fix(upgrade): prevent nightly downgrades to their stable base

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           COMMIT: ${{ steps.source.outputs.commit }}
         run: ./scripts/release/require-green-main.sh "$REPOSITORY" "$COMMIT"
-      - name: Resolve next-minor nightly identity
+      - name: Resolve stable-base nightly identity
         id: identity
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/adr/signed-upgrade-compatibility.md
+++ b/docs/adr/signed-upgrade-compatibility.md
@@ -93,6 +93,11 @@ verification tools; no new cryptographic verifier. Unsigned current nightlies
 cannot claim this profile. The gated server refuses an unsigned nightly upgrade
 of a populated database until a valid profile and bridge exist.
 
+Nightly-to-stable transitions require a stable version strictly greater than the
+nightly's major/minor/patch base, even when the target release sequence is newer.
+For example, `1.1.0-nightly...` cannot transition to `1.1.0`; `1.1.1` or higher
+is eligible only with the normal forward compatibility and bridge proofs.
+
 Nightly never authorizes a stable edge or stable identity. Nightly application
 is explicit CLI only; no nightly WebUI apply. A trust-profile transition or exit
 from a revoked stable source requires two proofs: a recovery-root-signed bridge

--- a/docs/handoff/nightly-stable-base-transition.md
+++ b/docs/handoff/nightly-stable-base-transition.md
@@ -1,0 +1,37 @@
+# Nightly base versions and stable transition eligibility
+
+Nightlies now retain the latest stable major/minor/patch version instead of
+incrementing its minor version. A nightly may contain migrations added after
+that base. Consequently, `1.1.0-nightly...` must never update to stable `1.1.0`;
+stable `1.1.1` or higher is eligible only with the existing compatibility proofs.
+
+`releaseidentity.CompareUpdateVersions` supplies shared update ordering for
+release selection and binary installation. Within a matching version core, an
+explicit nightly sorts after stable. The binary installer checks the installed
+and selected versions again before downloading, rather than trusting the
+availability flag. Recovery bridge verification independently rejects a stable
+target at or below the nightly base even if its signed sequence increases.
+
+Existing published next-minor nightly identities remain unchanged and receive
+the same conservative eligibility rule. This can delay their next update until
+a release exceeds that historical base; no identity or migration history is
+rewritten. Initial pre-stable nightlies retain their existing `0.0.1` base.
+
+The automatic server upgrade command still supports only nightly targets.
+This change does not add stable server automation or relax authenticated routes,
+operator attestation, migration sequence checks, or backup/restore proof.
+
+Regression coverage includes both channels, same-base and older stable refusals,
+build metadata, higher patch/minor/major stable eligibility, nightly selection
+after its stable base, installer refusal before network/file access, and signed
+bridge refusal despite increasing release sequence. The release shell fixture
+checks stable-base naming including nonzero patch versions.
+
+Validation passed: Go tests for `releaseidentity`, `updatecheck`, `selfupdate`,
+`releasetrust`, `upgradecompat`, `upgradebundle`, `cli`, `app`, `store/upgrade`,
+`upgradegate`, `scripts/release/nightly`, and `scripts/release/assemble-upgrade`;
+Go vet for the four changed production packages; nightly release shell fixtures;
+ShellCheck; nightly workflow actionlint; docs site check; and diff whitespace.
+
+Cross-provider review was skipped at the user's request. The user subsequently
+authorized signed commit, push, PR creation, and merge after green CI.

--- a/docs/site/src/content/docs/docs/upgrades.mdx
+++ b/docs/site/src/content/docs/docs/upgrades.mdx
@@ -118,9 +118,17 @@ manually during an unfinished upgrade.
 
 `stable` follows signed production releases. `nightly` follows signed GitHub
 prereleases built from the newest green, changed `main` commit. A stable
-`1.0.0` makes the nightly line `1.1.0-nightly.<date>.<run>.g<sha>`; after stable
-`1.1.0`, it advances to `1.2.0-nightly...`. Nightlies use the distinct
+`1.0.0` makes the nightly line `1.0.0-nightly.<date>.<run>.g<sha>`; after stable
+`1.1.0`, it advances to `1.1.0-nightly...`. Nightlies use the distinct
 recovery-authorized `nightly/v1` keyless signing policy. They remain prereleases.
+
+Nightlies may contain migrations added after their stable base. Update ordering
+therefore treats a nightly as newer than that base, unlike ordinary SemVer
+prerelease ordering. `1.1.0-nightly...` cannot update to stable `1.1.0`; only
+`1.1.1` or higher is eligible. Server transitions still require an authenticated
+forward migration route, a recovery-authorized bridge and backup/restore proof.
+Older nightlies published with next-minor names keep their original identities;
+the same conservative base-version rule applies to them.
 
 Before any stable release exists, the first line is
 `0.0.1-nightly.<date>.<run>.g<sha>`. Release discovery is paginated; a long

--- a/internal/releaseidentity/version.go
+++ b/internal/releaseidentity/version.go
@@ -1,0 +1,25 @@
+package releaseidentity
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// CompareUpdateVersions orders nightlies after their stable base and its other
+// prereleases: they may
+// contain migrations added after that stable release. All other comparisons
+// retain SemVer ordering. This is eligibility, not migration authorization.
+func CompareUpdateVersions(a, b *semver.Version) int {
+	if a.Major() == b.Major() && a.Minor() == b.Minor() && a.Patch() == b.Patch() {
+		aNightly := strings.HasPrefix(a.Prerelease(), "nightly.")
+		bNightly := strings.HasPrefix(b.Prerelease(), "nightly.")
+		if aNightly && !bNightly {
+			return 1
+		}
+		if !aNightly && bNightly {
+			return -1
+		}
+	}
+	return a.Compare(b)
+}

--- a/internal/releasetrust/bridge.go
+++ b/internal/releasetrust/bridge.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Masterminds/semver/v3"
 )
 
 type BridgeStatement struct {
@@ -83,6 +84,13 @@ func VerifyBridge(snapshot Snapshot, material BridgeMaterial) (VerifiedBridge, e
 	case "hikyo.dev/recovery-bridge/v1":
 		if statement.SourceGenesis != "" || statement.Source.Validate() != nil || statement.Target.Sequence <= statement.Source.Sequence || statement.SourcePolicySHA256.Validate() != nil {
 			return VerifiedBridge{}, errors.New("invalid recovery bridge source")
+		}
+		if statement.Source.Profile == releaseidentity.NightlyV1 && statement.Target.Profile == releaseidentity.StableV1 {
+			source, _ := semver.StrictNewVersion(statement.Source.Version) // identities validated above
+			target, _ := semver.StrictNewVersion(statement.Target.Version)
+			if releaseidentity.CompareUpdateVersions(target, source) <= 0 {
+				return VerifiedBridge{}, errors.New("stable target must be newer than the nightly base version")
+			}
 		}
 	case "hikyo.dev/legacy-nightly-bridge/v1":
 		if statement.SourceGenesis != releaseidentity.LegacyGenesisV1 || statement.Source != (releaseidentity.Identity{}) || statement.SourcePolicySHA256 != "" || statement.Target.Profile != releaseidentity.NightlyV1 || len(statement.SourceMigrations.Entries) == 0 {

--- a/internal/releasetrust/bridge_version_test.go
+++ b/internal/releasetrust/bridge_version_test.go
@@ -1,0 +1,45 @@
+package releasetrust_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust"
+	"github.com/Hikyo-Org/hikyo/internal/releasetrust/testfixture"
+)
+
+func TestSignedBridgeCannotReturnNightlyToItsStableBase(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		allowed bool
+	}{
+		{"1.0.9", false}, {"1.1.0", false}, {"1.1.0+rebuilt", false}, {"1.1.0-rc.1", false},
+		{"1.1.1", true}, {"1.2.0", true},
+	} {
+		t.Run(tc.version, func(t *testing.T) {
+			f := testfixture.New(t)
+			digest := releaseidentity.Hash([]byte("fixture"))
+			source := releaseidentity.Identity{
+				Profile: releaseidentity.NightlyV1, Version: "1.1.0-nightly.20260911.1.gaaaaaaaa",
+				Sequence: 10, Commit: strings.Repeat("a", 40), CompatibilitySHA256: digest, ManifestSHA256: digest,
+			}
+			target := source
+			target.Profile, target.Version, target.Sequence = releaseidentity.StableV1, tc.version, 11
+			migrations := releaseidentity.MigrationManifest{Engine: releaseidentity.SQLite, Entries: []releaseidentity.Migration{}}
+			material := f.AddBridge(t, releasetrust.BridgeStatement{
+				Schema: "hikyo.dev/recovery-bridge/v1", Source: source, Target: target,
+				SourcePolicySHA256: digest, TargetPolicySHA256: digest,
+				SourceMigrations: migrations, TargetMigrations: migrations,
+				SourceSchemaSHA256: digest, TargetSchemaSHA256: digest, Mode: "maintenance",
+			})
+			_, err := releasetrust.VerifyBridge(f.Snapshot(t), material)
+			if (err == nil) != tc.allowed {
+				t.Fatalf("VerifyBridge = %v; want allowed=%v", err, tc.allowed)
+			}
+			if !tc.allowed && !strings.Contains(err.Error(), "stable target must be newer") {
+				t.Fatalf("unexpected refusal: %v", err)
+			}
+		})
+	}
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Hikyo-Org/hikyo/internal/diagnostics"
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Hikyo-Org/hikyo/internal/updatecheck"
 	"github.com/Masterminds/semver/v3"
 )
@@ -91,6 +92,13 @@ func (i *Installer) Apply(ctx context.Context, status updatecheck.Status) error 
 	}
 	if status.Channel == updatecheck.ChannelStable && isPrerelease {
 		return errors.New("selfupdate: stable channel cannot install a prerelease")
+	}
+	installed, err := semver.StrictNewVersion(status.CurrentVersion)
+	if err != nil {
+		return fmt.Errorf("selfupdate: installed version is not SemVer: %w", err)
+	}
+	if releaseidentity.CompareUpdateVersions(selectedVersion, installed) <= 0 {
+		return errors.New("selfupdate: selected release is not newer than the installed version")
 	}
 
 	archiveFile, err := archiveName(status.LatestVersion, runtime.GOOS, runtime.GOARCH)

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -30,6 +30,27 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 const nightlyTestVersion = "1.0.1-nightly.20260824.1.gaaaaaaaa"
 
+func TestApplyRefusesStableAtOrBelowNightlyBaseBeforeDownload(t *testing.T) {
+	for _, version := range []string{"1.0.9", "1.1.0", "1.1.0+rebuilt"} {
+		t.Run(version, func(t *testing.T) {
+			installer := newInstaller(&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("refused transition attempted a download")
+				return nil, nil
+			})}, func() (string, error) {
+				t.Fatal("refused transition accessed executable")
+				return "", nil
+			})
+			err := installer.Apply(t.Context(), updatecheck.Status{
+				Available: true, Channel: updatecheck.ChannelStable,
+				CurrentVersion: "1.1.0-nightly.20260911.1.gaaaaaaaa", LatestVersion: version,
+			})
+			if err == nil || !strings.Contains(err.Error(), "not newer") {
+				t.Fatalf("Apply = %v; want downgrade refusal", err)
+			}
+		})
+	}
+}
+
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return fn(request)
 }

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Hikyo-Org/hikyo/internal/releaseidentity"
 	"github.com/Masterminds/semver/v3"
 )
 
@@ -87,7 +88,7 @@ func Select(current string, channel Channel, releases []Release) (Status, error)
 		if err != nil || !admitted(channel, release, candidate) {
 			continue
 		}
-		if latest == nil || candidate.GreaterThan(latest) {
+		if latest == nil || releaseidentity.CompareUpdateVersions(candidate, latest) > 0 {
 			latest = candidate
 			selected = release
 		}
@@ -102,7 +103,7 @@ func Select(current string, channel Channel, releases []Release) (Status, error)
 	status.Immutable = selected.Immutable
 	status.PublishedAt = selected.PublishedAt
 	status.Assets = selected.Assets
-	status.Available = latest.GreaterThan(installed)
+	status.Available = releaseidentity.CompareUpdateVersions(latest, installed) > 0
 	return status, nil
 }
 

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -29,7 +29,7 @@ func TestSelectSeparatesStableAndNightlyChannels(t *testing.T) {
 	}
 }
 
-func TestSelectNightlyChannelAcceptsNewStableBetweenNightlies(t *testing.T) {
+func TestSelectNightlyChannelPreservesNightlyOverSameBaseStable(t *testing.T) {
 	releases := []Release{
 		{Version: "1.1.0"},
 		{Version: "1.1.0-nightly.20260824.42.gbbbbbbbb", Prerelease: true},
@@ -39,8 +39,37 @@ func TestSelectNightlyChannelAcceptsNewStableBetweenNightlies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !status.Available || status.LatestVersion != "1.1.0" || status.Prerelease {
-		t.Fatalf("nightly status = %+v, want promoted stable 1.1.0", status)
+	if status.Available || status.LatestVersion != "1.1.0-nightly.20260824.42.gbbbbbbbb" || !status.Prerelease {
+		t.Fatalf("nightly status = %+v, want installed nightly retained", status)
+	}
+}
+
+func TestSelectStableMustExceedNightlyBase(t *testing.T) {
+	for _, channel := range []Channel{ChannelStable, ChannelNightly} {
+		for _, tc := range []struct {
+			version   string
+			available bool
+		}{
+			{"1.0.9", false}, {"1.1.0", false}, {"1.1.0+rebuilt", false},
+			{"1.1.1", true}, {"1.2.0", true}, {"2.0.0", true},
+		} {
+			t.Run(string(channel)+"/"+tc.version, func(t *testing.T) {
+				status, err := Select("1.1.0-nightly.20260911.1.gaaaaaaaa", channel, []Release{{Version: tc.version}})
+				if err != nil || status.Available != tc.available {
+					t.Fatalf("Select = %+v, %v; want available=%v", status, err, tc.available)
+				}
+			})
+		}
+	}
+}
+
+func TestSelectNightlyAfterStableBase(t *testing.T) {
+	status, err := Select("1.1.0", ChannelNightly, []Release{
+		{Version: "1.1.0-nightly.20260911.1.gaaaaaaaa", Prerelease: true},
+		{Version: "1.1.0"},
+	})
+	if err != nil || !status.Available || !status.Prerelease {
+		t.Fatalf("Select = %+v, %v; want newer nightly", status, err)
 	}
 }
 

--- a/scripts/release/next-nightly-version.sh
+++ b/scripts/release/next-nightly-version.sh
@@ -19,9 +19,5 @@ if ! is_semver "$stable" || [ "${stable%%[-+]*}" != "$stable" ]; then
 	printf 'next nightly version: %s is not a stable SemVer version\n' "$1" >&2
 	exit 2
 fi
-major=${stable%%.*}
-remainder=${stable#*.}
-minor=${remainder%%.*}
-next_minor=$((minor + 1))
 exec "$script_dir/nightly-version.sh" \
-	"$major.$next_minor.0" "$date" "$run" "$commit"
+	"$stable" "$date" "$run" "$commit"

--- a/scripts/release/next-nightly-version_test.sh
+++ b/scripts/release/next-nightly-version_test.sh
@@ -8,11 +8,11 @@ commit=176e6e67379d0675e6211f0491dc965cee4f1c5c
 [ "$("$nightly_script" 0.0.1 20260824 1 "$commit")" = \
 	'0.0.1-nightly.20260824.1.g176e6e67' ]
 [ "$("$script" 1.0.0 20260824 42 "$commit")" = \
-	'1.1.0-nightly.20260824.42.g176e6e67' ]
+	'1.0.0-nightly.20260824.42.g176e6e67' ]
 [ "$("$script" v1.0.9 20261231 7 "$commit")" = \
-	'1.1.0-nightly.20261231.7.g176e6e67' ]
+	'1.0.9-nightly.20261231.7.g176e6e67' ]
 [ "$("$script" 2.14.3 20260824 1001 "$commit")" = \
-	'2.15.0-nightly.20260824.1001.g176e6e67' ]
+	'2.14.3-nightly.20260824.1001.g176e6e67' ]
 
 expect_reject() {
 	label=$1
@@ -33,4 +33,4 @@ if "$nightly_script" 0.0.1-rc.1 20260824 1 "$commit" >/dev/null 2>&1; then
 	exit 1
 fi
 
-printf 'next nightly version fixture: initial and stable next-minor tags are deterministic\n'
+printf 'next nightly version fixture: initial and stable-base tags are deterministic\n'


### PR DESCRIPTION
Nightly builds can contain migrations added after their stable base. Previously SemVer ordering offered `1.1.0` to an installation running `1.1.0-nightly...`. This change refuses that transition and requires `1.1.1` or higher, while preserving authenticated forward migration and backup/restore requirements.

- Use shared nightly-aware ordering for update selection and recheck eligibility before binary downloads. Reject recovery-signed nightly-to-stable bridges at or below the nightly base, even with an increasing release sequence.
- Generate new nightly identities from the latest stable major/minor/patch version. Existing published identities stay unchanged and receive the conservative version guard.
- Update the upgrade guide and ADR. Stable server automation remains outside this change.

Validation: 12 Go packages passed, including CLI, server, upgrade gate, signed bridge, and bundle assembly integration tests; scoped Go vet; nightly release fixtures; ShellCheck; actionlint; docs check; and diff whitespace checks. Commits are cryptographically signed and DCO signed-off. Cross-provider review skipped at the user's explicit request.

Handoff: [nightly stable transitions](docs/handoff/nightly-stable-base-transition.md).
