### PR TITLE
fix(web): answer the system scope honestly and name the grants it lacks

### DIFF
--- a/docs/handoff/system-scope-refusals.md
+++ b/docs/handoff/system-scope-refusals.md
@@ -1,5 +1,7 @@
 # Handoff: system-scope refusals and the first administrator's missing grants
 
+PR: https://github.com/Hikyo-Org/Hikyo/pull/728
+
 Origin: six screenshots from a nightly 35 instance (2026-09-11), every one a
 permission-shaped refusal for the first administrator inside the `Hikyo`
 organisation and its `Hikyo <instance id>` project.

--- a/docs/handoff/system-scope-refusals.md
+++ b/docs/handoff/system-scope-refusals.md
@@ -1,0 +1,62 @@
+# Handoff: system-scope refusals and the first administrator's missing grants
+
+Origin: six screenshots from a nightly 35 instance (2026-09-11), every one a
+permission-shaped refusal for the first administrator inside the `Hikyo`
+organisation and its `Hikyo <instance id>` project.
+
+## Diagnosis (reproduced on a fresh HEAD build, MFA session)
+
+Not a nightly 35 regression: no authz or service change since nightly 30.
+Three separate causes.
+
+1. **System scope refuses machine consumers, adapters and SCIM by design.**
+   The `Hikyo` organisation and project are the self-configuration hierarchy
+   (#686). `internal/authz/self_config.go` applies a closed operation
+   allowlist there; service-account, dynamic-provider, lease, adapter and
+   SCIM-binding operations are not on it, so they answer 404 whatever the
+   caller holds (permission-model ADR, 2026-09-06 amendment). The same calls
+   answer 200 in an ordinary organisation. The web app did not know this: it
+   offered the pages in the sidebar and rendered denial copy.
+2. **Two grants no template seeds.** `audit-read` is outside `admin`
+   (audit-model ADR); `instance-directory` is outside `operator`
+   (`internal/domain/permission.go`). Granting them through the ordinary
+   grant API resolves Audit, Project audit and Remotes. Each grant ends the
+   session.
+3. **Copy that lied.** Machine access said "needs manage-identities" on any
+   query error, to a holder of that capability.
+
+## What this change does
+
+- `web/src/api/selfConfig.ts`: `useSystemScope(enabled)` reads the binding
+  from the shared self-config query (one-minute staleness, no polling).
+  Enabled only for the session's `instance_operator` hint
+  (`useInstanceOperator` in `AuthProvider.tsx`): the status read needs
+  `instance-config` and records its denial, and the protected hierarchy is
+  hidden from everyone else. Outside a provider (page-level tests) the hint
+  reads false; a provider still waiting on whoami reads null, which the gate
+  treats as pending.
+- `web/src/routes/sidebar-model.ts`: omits `machine-access`, `adapters` and
+  `scim` in the system organisation/project (`SYSTEM_SCOPE_REFUSES`).
+- `web/src/routes/SystemScope.tsx`: `gateSystemScope` wraps Machine access,
+  Deployment adapters and SCIM provisioning so a deep link renders the reason
+  instead of the page. Renders nothing until the binding read settles.
+- `web/src/routes/Projects.tsx`: no "New project" form in the system
+  organisation (the profile refuses extra projects).
+- Audit and Remotes refusal copy names the exact grant, its scope and where to
+  make it. Machine access copy no longer asserts a cause it cannot know.
+- Docs: getting-started § 4 documents the two grants and the system scope;
+  browser-operations notes the refused pages.
+
+## Deliberately not changed
+
+- Templates and the allowlist: locked ADR decisions. Seeding `audit-read` or
+  `instance-directory` at bootstrap is a separate decision.
+- Change approvals stays in the system project: policy reads and votes are
+  on the allowlist; policy writes are not, and will refuse there.
+
+## Verification
+
+- `pnpm --dir web exec tsc --noEmit`, `pnpm --dir web exec vitest run` green.
+- `pnpm --dir docs/site run check` green.
+- Manual: fresh `server --dev`, bootstrap admin, TOTP enrolled, the six
+  pages walked before and after the two grants.

--- a/docs/site/src/content/docs/docs/browser-operations.mdx
+++ b/docs/site/src/content/docs/docs/browser-operations.mdx
@@ -111,3 +111,8 @@ after reauthentication. [Manage Hikyo with Hikyo](/docs/managed-configuration/)
 covers adoption, per-node convergence, independent remote projects and
 rollback; settings that need a restart go through
 [configuration rollouts](/docs/configuration-rollouts/).
+
+The protected organisation and project refuse machine access, deployment
+adapters, SCIM provisioning and additional projects by design, so the browser
+does not offer them there; a deep link to one of those pages says so. Use an
+organisation of your own for that work.

--- a/docs/site/src/content/docs/docs/getting-started.mdx
+++ b/docs/site/src/content/docs/docs/getting-started.mdx
@@ -91,6 +91,35 @@ or a pipe. Delete `hikyo-admin-authority` after the command succeeds, then open
   Hikyo beyond loopback.
 </Callout>
 
+## 4. What the first administrator does not hold yet
+
+The first administrator holds the `operator` template at instance scope and,
+once the instance has adopted its own configuration, the `admin` template on
+the `Hikyo` organisation it creates. Two capabilities are deliberately outside
+every template and must be granted explicitly, to yourself or anyone else:
+
+| Capability | Where | Unlocks |
+|---|---|---|
+| `audit-read` | an organisation, project or environment | that scope's audit trail (Audit, Project audit) |
+| `instance-directory` | the instance | Remotes: the directory of connected instances |
+
+Grant them in the browser under Members (organisation scope) and Instance
+members (instance scope), or from the CLI after `hikyo login`:
+
+```bash
+hikyo access grant add --principal <your principal id> --capability audit-read --org <org id>
+hikyo access grant add --principal <your principal id> --capability instance-directory --instance-scope
+```
+
+Every grant to yourself ends your current session. Sign in again and present
+your second factor before continuing.
+
+The `Hikyo` organisation and its `Hikyo <instance id>` project are the
+instance's own configuration. They refuse machine access, deployment adapters,
+SCIM provisioning and additional projects by design, so those pages are absent
+there. Create an organisation of your own for your projects, as
+[your first project](/docs/first-project/) does.
+
 ## Next steps
 
 - Complete [your first project](/docs/first-project/) to create environments and a validated value.

--- a/web/src/api/selfConfig.ts
+++ b/web/src/api/selfConfig.ts
@@ -17,6 +17,15 @@ const configKey = ['self-config'];
 /** The Hikyo system organisation and project ids, from the self-configuration binding. */
 export type SystemScope = { readonly org: string; readonly project: string };
 
+/**
+ * The surfaces the protected system profile refuses outright (permission-model
+ * ADR, 2026-09-06 amendment: machine consumers, adapters, SCIM). The sidebar
+ * omits them in the system scope and their routes answer a deep link with the
+ * reason; both read this one list.
+ */
+export const SYSTEM_SCOPE_REFUSED_SURFACES = ['machine-access', 'adapters', 'scim'] as const;
+export type SystemScopeSurface = (typeof SYSTEM_SCOPE_REFUSED_SURFACES)[number];
+
 export function useSelfConfig(enabled = true) {
   const transport = useTransport();
   return useQuery({ queryKey: configKey, queryFn: () => parsed(getInstanceConfigOp, { ...transport }), enabled, refetchInterval: (query) => query.state.status === 'error' ? false : 2000, retry: false });

--- a/web/src/api/selfConfig.ts
+++ b/web/src/api/selfConfig.ts
@@ -14,9 +14,28 @@ export type SelfConfigStatus = z.infer<typeof zInstanceConfigStatus>;
 export type SelfConfigIntent = z.infer<typeof zSelfConfigReauthIntent>;
 const configKey = ['self-config'];
 
+/** The Hikyo system organisation and project ids, from the self-configuration binding. */
+export type SystemScope = { readonly org: string; readonly project: string };
+
 export function useSelfConfig(enabled = true) {
   const transport = useTransport();
   return useQuery({ queryKey: configKey, queryFn: () => parsed(getInstanceConfigOp, { ...transport }), enabled, refetchInterval: (query) => query.state.status === 'error' ? false : 2000, retry: false });
+}
+
+/**
+ * The Hikyo system organisation and project, or null while the binding is
+ * unknown (not adopted, not disclosed to this session, or not yet read).
+ * Shares the self-config query so a page that polls it keeps this fresh; on
+ * its own it re-reads once a minute rather than every two seconds. Disabled
+ * for anyone but an instance operator: the status read needs
+ * `instance-config` and records its denial, and the protected hierarchy is
+ * hidden from everyone else anyway.
+ */
+export function useSystemScope(enabled: boolean): { readonly pending: boolean; readonly scope: SystemScope | null } {
+  const transport = useTransport();
+  const query = useQuery({ queryKey: configKey, queryFn: () => parsed(getInstanceConfigOp, { ...transport }), enabled, staleTime: 60_000, retry: false });
+  const binding = query.data?.binding;
+  return { pending: enabled && query.isPending, scope: binding === undefined || binding === null ? null : { org: binding.org_id, project: binding.project_id } };
 }
 
 export function useSelfConfigActions() {

--- a/web/src/api/sensitiveInventory.json
+++ b/web/src/api/sensitiveInventory.json
@@ -18,7 +18,7 @@
     "api/revisionDiff.ts": "5dca7d0ddb63c8832d7507eb62ecc1ea7b49080a72a329ad38043e342017d21f",
     "api/samlProviders.ts": "d0079f3a6e1b85a6fa36b78c433ec2e8307bf9bade861eb2df20b9b202e860ac",
     "api/scim.ts": "b4858db3cae9c346b56372862801e87aaaea33c9fd93b741ed02a512f0c33248",
-    "api/selfConfig.ts": "2bedf96c857e37ea5975e624a0e44d100a39d5c7c576e497625cff90a8f4c046",
+    "api/selfConfig.ts": "e07d422a5cf9cc174f06c9b5b8af21b4c9a2e5914d1cd02a4066d386a3263e6a",
     "api/sensitiveMutation.ts": "5a585ae0e42073f165a4356e329dc84336c0bc5115d681e7e6154f3091fe983c",
     "api/session.ts": "76a8a2dc57ae817feb5cfdccfcc3d86f3b13fb785d2b3b28d3bbbf27fe5e55c5",
     "api/settings.ts": "8db8611b316f062b29a4fe61103ec25ce703455bc966079a9e78db8fa96fa61e",

--- a/web/src/api/sensitiveInventory.json
+++ b/web/src/api/sensitiveInventory.json
@@ -18,7 +18,7 @@
     "api/revisionDiff.ts": "5dca7d0ddb63c8832d7507eb62ecc1ea7b49080a72a329ad38043e342017d21f",
     "api/samlProviders.ts": "d0079f3a6e1b85a6fa36b78c433ec2e8307bf9bade861eb2df20b9b202e860ac",
     "api/scim.ts": "b4858db3cae9c346b56372862801e87aaaea33c9fd93b741ed02a512f0c33248",
-    "api/selfConfig.ts": "e07d422a5cf9cc174f06c9b5b8af21b4c9a2e5914d1cd02a4066d386a3263e6a",
+    "api/selfConfig.ts": "db82504969754873dcab67552459f37ab07ff8f3dcbd96702c3dd880aa751c40",
     "api/sensitiveMutation.ts": "5a585ae0e42073f165a4356e329dc84336c0bc5115d681e7e6154f3091fe983c",
     "api/session.ts": "76a8a2dc57ae817feb5cfdccfcc3d86f3b13fb785d2b3b28d3bbbf27fe5e55c5",
     "api/settings.ts": "8db8611b316f062b29a4fe61103ec25ce703455bc966079a9e78db8fa96fa61e",

--- a/web/src/app/AuthProvider.tsx
+++ b/web/src/app/AuthProvider.tsx
@@ -638,3 +638,16 @@ export function useAuth(): AuthContextValue {
   }
   return value;
 }
+
+/**
+ * The disclosure-safe operator hint from the live session: null while the
+ * provider has not yet resolved a session, so a caller can wait rather than
+ * act on a guess; false outside any provider. For reads that only an
+ * instance operator may make, so a non-operator's chrome never provokes an
+ * audited denial on every mount.
+ */
+export function useInstanceOperator(): boolean | null {
+  const value = useContext(AuthContext);
+  if (value === null) return false;
+  return value.identity?.capabilities.instance_operator ?? null;
+}

--- a/web/src/routes/Adapters.tsx
+++ b/web/src/routes/Adapters.tsx
@@ -49,6 +49,7 @@ import {
   runAdapterTOTPCeremony,
 } from '../api/values.ts';
 import { useFeedback, useModalDialog } from './useModalDialog.ts';
+import { gateSystemScope } from './SystemScope.tsx';
 
 /**
  * Deployment adapters (#157): the multi-target synchronization surface.
@@ -116,7 +117,10 @@ function projectRef(org: string | undefined, project: string | undefined): Proje
   return { org, project };
 }
 
-export function Adapters() {
+/** Deep links into the Hikyo system project answer with the profile refusal. */
+export const Adapters = gateSystemScope('adapters', AdaptersPage);
+
+function AdaptersPage() {
   const params = useParams();
   const ref = useMemo(() => projectRef(params.org, params.project), [params.org, params.project]);
   const [search, setSearch] = useSearchParams();

--- a/web/src/routes/Audit.test.tsx
+++ b/web/src/routes/Audit.test.tsx
@@ -90,3 +90,23 @@ it('shows the actor name in the row while retaining its ID in event details', as
     expect(container.querySelector('#audit-detail')?.textContent).toContain('Principal IDprn_dana');
   } finally { await unmount(); }
 });
+
+it.each([
+  ['/orgs/acme/audit', '/orgs/:org/audit', 'this organisation'],
+  ['/orgs/acme/projects/app/audit', '/orgs/:org/projects/:project/audit', 'this project'],
+])('names the audit-read grant and its scope when %s refuses', async (path, pattern, where) => {
+  vi.stubGlobal('fetch', async () =>
+    Response.json({ error: { code: 'not_found', message: 'not found' } }, { status: 404 }),
+  );
+  const rendered = await renderForm(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes><Route path={pattern} element={<Audit />} /></Routes>
+    </MemoryRouter>,
+  );
+  await settleTask();
+  const alert = rendered.container.querySelector('[role="alert"]')?.textContent ?? '';
+  expect(alert).toContain('This trail is not available, or you may not read it.');
+  expect(alert).toContain(`audit-read grant on ${where}`);
+  expect(alert).toContain('No role template includes audit-read');
+  await rendered.unmount();
+});

--- a/web/src/routes/Audit.tsx
+++ b/web/src/routes/Audit.tsx
@@ -45,10 +45,20 @@ function when(value: string): string {
   return Number.isNaN(at.getTime()) ? value : at.toLocaleString();
 }
 
-function refusalText(error: unknown): string {
+function refusalText(error: unknown, scope: AuditScope): string {
   if (error instanceof ApiError) {
     if (error.status === 404 || error.status === 403) {
-      return 'This trail is not available, or you may not read it.';
+      // `audit-read` is its own grant (audit-model ADR): no template seeds
+      // it, the organisation `admin` template included. Name the exact grant
+      // and where it is made, so the holder of everything else is not left
+      // guessing which capability this is.
+      const where =
+        scope.project === undefined
+          ? 'this organisation'
+          : scope.environment === ''
+            ? 'this project'
+            : 'this environment';
+      return `This trail is not available, or you may not read it. Reading it needs the audit-read grant on ${where} with a second factor in this session. No role template includes audit-read; a member manager grants it under Members.`;
     }
     if (error.status === 400) {
       return error.detail ?? 'The filter is not valid.';
@@ -238,7 +248,7 @@ function AuditTrail({ org, project }: { readonly org: string; readonly project: 
           {trail.isPending ? <p role="status">Loading events…</p> : null}
           {trail.isError ? (
             <p className="audit__empty alert" role="alert">
-              {refusalText(trail.error)}
+              {refusalText(trail.error, scope)}
             </p>
           ) : emptyResult ? (
             <div className="audit__empty" role="status">

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -199,13 +199,13 @@ export function nextTab<T>(tabs: readonly T[], current: T, key: string): T | nul
 
 /**
  * accountsRefusalText names the listing failure without inventing a cause.
- * A 404 is the uniform "not available or not yours" answer: the capability
- * may be missing, or the project may be one where machine access is refused
- * by profile. Anything else is not a permission question at all.
+ * A 403 or 404 is the permission answer (the system scope never reaches
+ * here: gateSystemScope answers it first). Anything else is not a
+ * permission question at all, so it does not name a capability.
  */
 export function accountsRefusalText(error: unknown): string {
   if (error instanceof ApiError && (error.status === 403 || error.status === 404)) {
-    return 'The service accounts could not be listed. Listing them needs manage-identities on this project, and a project where machine access is available.';
+    return 'The service accounts could not be listed. Listing them needs manage-identities on this project.';
   }
   return 'The service accounts could not be listed. Reload to try again.';
 }

--- a/web/src/routes/MachineAccess.tsx
+++ b/web/src/routes/MachineAccess.tsx
@@ -58,6 +58,7 @@ import {
 } from '../api/identities.ts';
 import { TypedNameConfirm } from './Sections.tsx';
 import { ApiError } from '../api/client.ts';
+import { gateSystemScope } from './SystemScope.tsx';
 import {
   createDynamicProvider,
   createProviderRefusalText,
@@ -196,7 +197,23 @@ export function nextTab<T>(tabs: readonly T[], current: T, key: string): T | nul
   }
 }
 
-export function MachineAccess() {
+/**
+ * accountsRefusalText names the listing failure without inventing a cause.
+ * A 404 is the uniform "not available or not yours" answer: the capability
+ * may be missing, or the project may be one where machine access is refused
+ * by profile. Anything else is not a permission question at all.
+ */
+export function accountsRefusalText(error: unknown): string {
+  if (error instanceof ApiError && (error.status === 403 || error.status === 404)) {
+    return 'The service accounts could not be listed. Listing them needs manage-identities on this project, and a project where machine access is available.';
+  }
+  return 'The service accounts could not be listed. Reload to try again.';
+}
+
+/** Deep links into the Hikyo system project answer with the profile refusal. */
+export const MachineAccess = gateSystemScope('machine-access', MachineAccessPage);
+
+function MachineAccessPage() {
   const params = useParams();
   const project: ProjectRef = {
     org: params['org'] ?? '',
@@ -394,10 +411,7 @@ export function MachineAccess() {
           <span className="alert__glyph" aria-hidden="true">
             !
           </span>
-          <span>
-            The service accounts could not be listed. Listing them needs manage-identities on this
-            project.
-          </span>
+          <span>{accountsRefusalText(accountsQuery.error)}</span>
         </p>
       ) : null}
 

--- a/web/src/routes/Projects.test.tsx
+++ b/web/src/routes/Projects.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router';
 
+import { AuthProvider } from '../app/AuthProvider.tsx';
+import { authenticatedIdentity } from '../testkit/identity.ts';
 import { created, renderForm, settle, settleTask, typeInto } from '../testkit/renderForm.tsx';
 import { Overview } from './Placeholder.tsx';
 import { NewProjectForm, Projects } from './Projects.tsx';
@@ -108,6 +110,37 @@ describe('Projects', () => {
     expect(empty?.compareDocumentPosition(form ?? empty) ?? 0).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+    await unmount();
+  });
+
+  it('offers no project form in the Hikyo system organisation and says why', async () => {
+    const binding = { org_id: 'org_1', project_id: 'prj_system', environment_id: 'env_system', schema_version: 1 };
+    const status = { owner_instance_id: 'instance_local', managed: true, binding, generation: 1, desired_revision: 1, latest_revision: 1, state: 'active', nodes: [], job: null };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const path = new URL(request.url).pathname;
+        const body =
+          path === '/api/v1/instance/config'
+            ? status
+            : path === '/api/v1/auth/whoami'
+              ? authenticatedIdentity
+              : { items: [project], count: 1 };
+        return Promise.resolve(Response.json(body));
+      }),
+    );
+    const { container, unmount } = await renderForm(
+      <AuthProvider>{inShell(<Projects />, 'org_1', '/projects')}</AuthProvider>,
+    );
+    await settleTask();
+    await settle();
+
+    expect(container.querySelector('#projects-new')).toBeNull();
+    expect(container.querySelector('form')).toBeNull();
+    expect([...container.querySelectorAll('.jump__link')].map((a) => a.textContent)).toEqual(['All projects']);
+    const statuses = [...container.querySelectorAll('[role="status"]')].map((s) => s.textContent ?? '');
+    expect(statuses.some((text) => text.includes('Hikyo system organisation'))).toBe(true);
     await unmount();
   });
 

--- a/web/src/routes/Projects.tsx
+++ b/web/src/routes/Projects.tsx
@@ -14,7 +14,11 @@ export function Projects() {
   // The system organisation holds exactly one project, the instance's own
   // configuration; the protected profile refuses another (permission-model
   // ADR, 2026-09-06 amendment), so the form is absent rather than refused.
-  const systemOrg = useInSystemScope(activeOrgId, null) === 'system';
+  // While the answer is pending the form waits too: showing it and then
+  // taking it away would lose whatever was typed in between.
+  const scope = useInSystemScope(activeOrgId, null);
+  const systemOrg = scope === 'system';
+  const formReady = scope === 'ordinary';
 
   return (
     <div className="page page--chrome projects">
@@ -36,7 +40,7 @@ export function Projects() {
           <JumpIndex
             sections={[
               { id: 'projects-list', label: 'All projects' },
-              ...(systemOrg ? [] : [{ id: 'projects-new', label: 'New project' }]),
+              ...(formReady ? [{ id: 'projects-new', label: 'New project' }] : []),
             ]}
           />
           <Panel id="projects-list" title="Projects">
@@ -55,9 +59,9 @@ export function Projects() {
               and no other project. Create an organisation of your own under Instance settings
               for your projects.
             </p>
-          ) : (
+          ) : formReady ? (
             <NewProjectForm org={activeOrgId} />
-          )}
+          ) : null}
         </>
       )}
     </div>

--- a/web/src/routes/Projects.tsx
+++ b/web/src/routes/Projects.tsx
@@ -4,12 +4,17 @@ import { generatePath, Link, useOutletContext } from 'react-router';
 import { createProjectRefusalText, useCreateProject, useProjects } from '../api/settings.ts';
 import { surfaceById } from '../app/navigation.ts';
 import { Alert, JumpIndex, Panel } from './Sections.tsx';
+import { useInSystemScope } from './SystemScope.tsx';
 
 /** Projects is a real data surface; keeping it out of Placeholder preserves the chrome skeleton seam. */
 export function Projects() {
   const { activeOrgId } = useOutletContext<{ readonly activeOrgId: string }>();
   const projects = useProjects(activeOrgId);
   const items = projects.data?.items ?? [];
+  // The system organisation holds exactly one project, the instance's own
+  // configuration; the protected profile refuses another (permission-model
+  // ADR, 2026-09-06 amendment), so the form is absent rather than refused.
+  const systemOrg = useInSystemScope(activeOrgId, null) === 'system';
 
   return (
     <div className="page page--chrome projects">
@@ -31,7 +36,7 @@ export function Projects() {
           <JumpIndex
             sections={[
               { id: 'projects-list', label: 'All projects' },
-              { id: 'projects-new', label: 'New project' },
+              ...(systemOrg ? [] : [{ id: 'projects-new', label: 'New project' }]),
             ]}
           />
           <Panel id="projects-list" title="Projects">
@@ -44,7 +49,15 @@ export function Projects() {
             ) : null}
             {items.length === 0 ? null : <ProjectList org={activeOrgId} items={items} />}
           </Panel>
-          <NewProjectForm org={activeOrgId} />
+          {systemOrg ? (
+            <p className="hint-wrap" role="status">
+              This is the Hikyo system organisation: it holds this instance's own configuration
+              and no other project. Create an organisation of your own under Instance settings
+              for your projects.
+            </p>
+          ) : (
+            <NewProjectForm org={activeOrgId} />
+          )}
         </>
       )}
     </div>

--- a/web/src/routes/Remotes.tsx
+++ b/web/src/routes/Remotes.tsx
@@ -94,7 +94,9 @@ export function Remotes() {
             </span>
             <span>
               The remote directory could not be read. You may not hold{' '}
-              <span className="mono">instance-directory</span> on this instance.
+              <span className="mono">instance-directory</span> on this instance. The operator
+              template does not include it; an instance member manager grants it under Instance
+              members, and the grant ends the current session.
             </span>
           </p>
         ) : null}
@@ -138,7 +140,7 @@ export function ThisInstance() {
         <p className="alert" role="alert">
           <span className="alert__glyph" aria-hidden="true">!</span>
           <span>{directory.error instanceof ApiError && directory.error.status === 403
-            ? 'You do not hold instance-directory on this instance. Its directory is not available to you.'
+            ? 'You do not hold instance-directory on this instance. Its directory is not available to you. The operator template does not include it; an instance member manager grants it under Instance members, and the grant ends the current session.'
             : "This instance's directory could not be read. Reload to try again."}</span>
         </p>
       ) : directory.data === undefined ? null : (

--- a/web/src/routes/ScimProvisioning.secret-lifetime.test.tsx
+++ b/web/src/routes/ScimProvisioning.secret-lifetime.test.tsx
@@ -19,6 +19,12 @@ vi.mock('../api/scim.ts', async (importActual) => ({
   useScimDirectoryGroups: () => ({ data: { items: [] }, isSuccess: true }),
   useScimDirectoryUsers: () => ({ data: { items: [] }, isSuccess: true }),
 }));
+// The system-scope gate reads the self-config binding; this test stubs no
+// fetch, so answer it directly as an ordinary organisation.
+vi.mock('../api/selfConfig.ts', async (importActual) => ({
+  ...(await importActual<typeof import('../api/selfConfig.ts')>()),
+  useSystemScope: () => ({ pending: false, scope: null }),
+}));
 vi.mock('../api/settings.ts', async (importActual) => ({
   ...(await importActual<typeof import('../api/settings.ts')>()),
   useOrg: () => ({ data: { id: 'org', name: 'fixture' }, isSuccess: true }),

--- a/web/src/routes/ScimProvisioning.tsx
+++ b/web/src/routes/ScimProvisioning.tsx
@@ -42,6 +42,7 @@ import { writeClipboard } from '../app/clipboard.ts';
 import { Alert, Done, Explain, JumpIndex, Panel, TypedNameConfirm } from './Sections.tsx';
 import { useFeedback, useModalDialog } from './useModalDialog.ts';
 import { useNavigationGuard } from './MachineAccess.tsx';
+import { gateSystemScope } from './SystemScope.tsx';
 
 /**
  * SCIM provisioning administration (registry surface `scim`, #501; #73,
@@ -60,7 +61,10 @@ import { useNavigationGuard } from './MachineAccess.tsx';
  * its own, the binding teardown, the revocation bite, is factual and drawn
  * from the contract, never a guess about scope reach.
  */
-export function ScimProvisioning() {
+/** Deep links into the Hikyo system organisation answer with the profile refusal. */
+export const ScimProvisioning = gateSystemScope('scim', ScimProvisioningPage);
+
+function ScimProvisioningPage() {
   const params = useParams();
   const org = params['org'] ?? '';
   const [search, setSearch] = useSearchParams();

--- a/web/src/routes/Shell.tsx
+++ b/web/src/routes/Shell.tsx
@@ -98,7 +98,6 @@ export function Shell({ session }: { session: WhoAmI }) {
   // only be refused with a 403). The reads still swallow a 403 as belt-and-
   // suspenders; this just stops us provoking it.
   const isInstanceOperator = session.capabilities.instance_operator;
-  const systemScope = useSystemScope(isInstanceOperator).scope;
   const retentionHealth = useRetentionHealth(isInstanceOperator);
   const updateStatus = useUpdateStatus(isInstanceOperator);
   const serverVersion = useServerVersion();
@@ -130,6 +129,10 @@ export function Shell({ session }: { session: WhoAmI }) {
   const membersProjectId = here?.surface.id === 'members' ? search.get('project') ?? '' : '';
   const routeProjectId = pathProjectId === '' ? membersProjectId : pathProjectId;
   const remote = search.get('remote') ?? '';
+  // The system scope is this instance's; a remote workspace's config read
+  // would be an audited denial on the remote, and its project links are
+  // disabled here anyway.
+  const systemScope = useSystemScope(isInstanceOperator && remote === '').scope;
 
   // A deep link is a selection too. Persist it only after the organisation
   // listing confirms the id, then unscoped destinations keep the same tenant.

--- a/web/src/routes/Shell.tsx
+++ b/web/src/routes/Shell.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-router';
 
 import { useLogout, useOrgs, type WhoAmI } from '../api/session.ts';
+import { useSystemScope } from '../api/selfConfig.ts';
 import { useProjects } from '../api/settings.ts';
 import { retentionBanner, storageBanner, useRetentionHealth } from '../api/retention.ts';
 import {
@@ -97,6 +98,7 @@ export function Shell({ session }: { session: WhoAmI }) {
   // only be refused with a 403). The reads still swallow a 403 as belt-and-
   // suspenders; this just stops us provoking it.
   const isInstanceOperator = session.capabilities.instance_operator;
+  const systemScope = useSystemScope(isInstanceOperator).scope;
   const retentionHealth = useRetentionHealth(isInstanceOperator);
   const updateStatus = useUpdateStatus(isInstanceOperator);
   const serverVersion = useServerVersion();
@@ -309,6 +311,7 @@ export function Shell({ session }: { session: WhoAmI }) {
     routeProjectId: routeProjectId === '' ? '' : activeProjectId,
     remote,
     isInstanceOperator,
+    systemScope,
   });
 
   return (

--- a/web/src/routes/SystemScope.test.tsx
+++ b/web/src/routes/SystemScope.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthProvider } from '../app/AuthProvider.tsx';
+import { authenticatedIdentity } from '../testkit/identity.ts';
+import { renderForm, settle, settleTask } from '../testkit/renderForm.tsx';
+import { Adapters } from './Adapters.tsx';
+import { MachineAccess } from './MachineAccess.tsx';
+import { ScimProvisioning } from './ScimProvisioning.tsx';
+
+const binding = { org_id: 'org_system', project_id: 'prj_system', environment_id: 'env_system', schema_version: 1 };
+const status = { owner_instance_id: 'instance_local', managed: true, binding, generation: 1, desired_revision: 1, latest_revision: 1, state: 'active', nodes: [], job: null };
+const json = (value: object, stat = 200) => new Response(JSON.stringify(value), { status: stat, headers: { 'Content-Type': 'application/json' } });
+
+/** Stubs fetch so the self-config read answers and every tenant read is recorded. */
+function stub(config: object | null) {
+  const paths: string[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const path = new URL(request.url).pathname;
+    paths.push(path);
+    if (path === '/api/v1/auth/whoami') return json(authenticatedIdentity);
+    if (path === '/api/v1/instance/config') return config === null ? json({ error: { code: 'not_found', message: 'not found' } }, 404) : json(config);
+    return json({ error: { code: 'not_found', message: 'not found' } }, 404);
+  }));
+  return paths;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+async function mount(path: string, pattern: string, element: React.ReactElement) {
+  return renderForm(
+    <AuthProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path={pattern} element={element} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+describe('the system scope gate', () => {
+  it.each([
+    ['machine access', '/orgs/org_system/projects/prj_system/machine-access', '/orgs/:org/projects/:project/machine-access', <MachineAccess />, 'Machine access', 'service-accounts'],
+    ['adapters', '/orgs/org_system/projects/prj_system/adapters', '/orgs/:org/projects/:project/adapters', <Adapters />, 'Deployment adapters', '/adapters'],
+    ['scim', '/orgs/org_system/scim', '/orgs/:org/scim', <ScimProvisioning />, 'SCIM provisioning', 'scim-bindings'],
+  ])('answers a deep link into the system scope for %s with the reason, not a denial', async (_name, path, pattern, element, heading, tenantRead) => {
+    const paths = stub(status);
+    const { container, unmount } = await mount(path, pattern, element);
+    await settleTask();
+    await settle();
+    expect(container.querySelector('h1')?.textContent).toBe(heading);
+    const alert = container.querySelector('[role="alert"]')?.textContent ?? '';
+    expect(alert).toContain('Hikyo system configuration');
+    expect(alert).toContain('not available here');
+    expect(alert).toContain('Create an organisation of your own for this under Instance settings');
+    // No tenant read was attempted after the binding resolved: the page did
+    // not render and then fail, it never asked.
+    expect(paths.filter((p) => p.includes(tenantRead))).toEqual([]);
+    await unmount();
+  });
+
+  it('renders the ordinary page for any other project', async () => {
+    const paths = stub(status);
+    const { container, unmount } = await mount('/orgs/org_acme/projects/prj_app/adapters', '/orgs/:org/projects/:project/adapters', <Adapters />);
+    await settleTask();
+    await settle();
+    expect(container.textContent).not.toContain('Hikyo system configuration');
+    expect(paths.some((p) => p === '/api/v1/orgs/org_acme/projects/prj_app/adapters')).toBe(true);
+    await unmount();
+  });
+
+  it('renders the ordinary page while the binding is not disclosed', async () => {
+    const paths = stub(null);
+    const { container, unmount } = await mount('/orgs/org_system/projects/prj_system/adapters', '/orgs/:org/projects/:project/adapters', <Adapters />);
+    await settleTask();
+    await settle();
+    expect(container.textContent).not.toContain('Hikyo system configuration');
+    expect(paths.some((p) => p === '/api/v1/orgs/org_system/projects/prj_system/adapters')).toBe(true);
+    await unmount();
+  });
+});

--- a/web/src/routes/SystemScope.tsx
+++ b/web/src/routes/SystemScope.tsx
@@ -1,21 +1,20 @@
 import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router';
 
-import { useSystemScope } from '../api/selfConfig.ts';
+import { useSystemScope, type SystemScopeSurface } from '../api/selfConfig.ts';
+import { useWorkspaceContext } from '../api/transport.tsx';
 import { useInstanceOperator } from '../app/AuthProvider.tsx';
 import { surfaceById } from '../app/navigation.ts';
 import { Alert } from './Sections.tsx';
 
 /**
- * Which surfaces the protected system profile refuses. The Hikyo system
- * organisation and project carry the instance's own configuration; the
- * permission-model ADR (2026-09-06 amendment) refuses machine consumers,
- * adapters and SCIM there outright, whatever the caller holds. The sidebar
- * omits these entries in that scope (sidebar-model.ts); this gate answers a
- * deep link with the reason instead of a refusal dressed as a denial.
+ * The Hikyo system organisation and project carry the instance's own
+ * configuration; the permission-model ADR (2026-09-06 amendment) refuses
+ * machine consumers, adapters and SCIM there outright, whatever the caller
+ * holds. The sidebar omits these entries in that scope (sidebar-model.ts);
+ * this gate answers a deep link with the reason instead of a refusal dressed
+ * as a denial.
  */
-export type SystemScopeSurface = 'machine-access' | 'adapters' | 'scim';
-
 const REASON: Record<SystemScopeSurface, string> = {
   'machine-access':
     'Machine access is not available here: the system configuration project has no machine consumers, service accounts or dynamic providers.',
@@ -33,7 +32,12 @@ const REASON: Record<SystemScopeSurface, string> = {
  */
 export function useInSystemScope(org: string, project: string | null): 'pending' | 'system' | 'ordinary' {
   const operator = useInstanceOperator();
-  const { pending, scope } = useSystemScope(operator === true);
+  // A remote workspace is the viewing side: the operator hint is this
+  // instance's, the transport is the remote's, and its system scope is the
+  // remote's own concern (and an audited denial there). Never read it.
+  const local = useWorkspaceContext() === null;
+  const { pending, scope } = useSystemScope(local && operator === true);
+  if (!local) return 'ordinary';
   if (operator === null || pending) return 'pending';
   if (scope === null || scope.org !== org) return 'ordinary';
   return project === null || scope.project === project ? 'system' : 'ordinary';

--- a/web/src/routes/SystemScope.tsx
+++ b/web/src/routes/SystemScope.tsx
@@ -1,0 +1,72 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router';
+
+import { useSystemScope } from '../api/selfConfig.ts';
+import { useInstanceOperator } from '../app/AuthProvider.tsx';
+import { surfaceById } from '../app/navigation.ts';
+import { Alert } from './Sections.tsx';
+
+/**
+ * Which surfaces the protected system profile refuses. The Hikyo system
+ * organisation and project carry the instance's own configuration; the
+ * permission-model ADR (2026-09-06 amendment) refuses machine consumers,
+ * adapters and SCIM there outright, whatever the caller holds. The sidebar
+ * omits these entries in that scope (sidebar-model.ts); this gate answers a
+ * deep link with the reason instead of a refusal dressed as a denial.
+ */
+export type SystemScopeSurface = 'machine-access' | 'adapters' | 'scim';
+
+const REASON: Record<SystemScopeSurface, string> = {
+  'machine-access':
+    'Machine access is not available here: the system configuration project has no machine consumers, service accounts or dynamic providers.',
+  adapters:
+    'Deployment adapters are not available here: the system configuration project is applied to this instance, never pushed to a CI provider.',
+  scim: 'SCIM provisioning is not available here: the system configuration organisation is not provisioned from an identity provider.',
+};
+
+/**
+ * Whether the route's organisation (and project, when the surface is
+ * project-scoped) is the Hikyo system scope. Null binding means unknown, which
+ * renders the ordinary page: the server still refuses, and its copy names
+ * the capability, so an operator without configuration disclosure sees the
+ * same answer as before.
+ */
+export function useInSystemScope(org: string, project: string | null): 'pending' | 'system' | 'ordinary' {
+  const operator = useInstanceOperator();
+  const { pending, scope } = useSystemScope(operator === true);
+  if (operator === null || pending) return 'pending';
+  if (scope === null || scope.org !== org) return 'ordinary';
+  return project === null || scope.project === project ? 'system' : 'ordinary';
+}
+
+/** The deep-link answer for a surface the system scope refuses. */
+export function SystemScopeRefusal({ surface }: { surface: SystemScopeSurface }) {
+  const instance = surfaceById('instance-admin');
+  return (
+    <div className="page page--chrome">
+      <h1>{surfaceById(surface).label}</h1>
+      <Alert>
+        <strong>Hikyo system configuration.</strong> {REASON[surface]} Create an organisation of
+        your own for this under <Link to={instance.path}>{instance.label}</Link>.
+      </Alert>
+    </div>
+  );
+}
+
+/**
+ * Wraps a route component so a deep link into the system scope renders the
+ * refusal instead of the page. A wrapper rather than an early return inside
+ * the page: the binding resolves after first render, and a page whose hook
+ * list changes with it would break React's ordering rule.
+ */
+export function gateSystemScope(surface: SystemScopeSurface, Page: () => ReactElement) {
+  const projectScoped = surface !== 'scim';
+  return function Gated() {
+    const params = useParams();
+    const answer = useInSystemScope(params['org'] ?? '', projectScoped ? (params['project'] ?? '') : null);
+    // Nothing until the binding read settles: rendering the page first would
+    // fire its reads and then replace it, a flash of a refusal it never needed.
+    if (answer === 'pending') return <p role="status">Checking this scope…</p>;
+    return answer === 'system' ? <SystemScopeRefusal surface={surface} /> : <Page />;
+  };
+}

--- a/web/src/routes/sidebar-model.test.ts
+++ b/web/src/routes/sidebar-model.test.ts
@@ -8,6 +8,7 @@ const base = {
   routeProjectId: '',
   remote: '',
   isInstanceOperator: true,
+  systemScope: null,
 };
 
 function mustFind(links: readonly SidebarLink[] | undefined, id: string): SidebarLink {
@@ -118,5 +119,53 @@ describe('sidebarModel', () => {
     expect(isLinkActive(orgMembers, '/orgs/org_1/members', '')).toBe(true);
     expect(isLinkActive(members, '/orgs/org_1/members', '')).toBe(false);
     expect(isLinkActive(members, '/orgs/org_1/settings', '?project=prj_1')).toBe(false);
+  });
+});
+
+describe('sidebarModel in the Hikyo system scope', () => {
+  // The self-configuration hierarchy refuses machine consumers, adapters and
+  // SCIM by profile (permission-model ADR, 2026-09-06 amendment), so the
+  // sidebar must not offer them there: a link to a page that always refuses
+  // is a 404 dressed as navigation.
+  const systemScope = { org: 'org_1', project: 'prj_1' };
+
+  it('drops machine access and adapters from the system project block', () => {
+    const model = sidebarModel({
+      ...base,
+      surface: surfaceById('matrix'),
+      routeProjectId: 'prj_1',
+      systemScope,
+    });
+    expect(model.context?.links.map((l) => l.label)).toEqual([
+      'Environment matrix',
+      'Change approvals',
+      'Project audit',
+      'Members',
+      'Project settings',
+    ]);
+  });
+
+  it('drops SCIM provisioning from the system organisation block', () => {
+    const model = sidebarModel({ ...base, surface: surfaceById('projects'), systemScope });
+    expect(model.organisation?.links.map((l) => l.id)).toEqual([
+      'overview',
+      'projects',
+      'remotes',
+      'members',
+      'org-settings',
+      'audit',
+    ]);
+  });
+
+  it('leaves every other organisation and project untouched', () => {
+    const model = sidebarModel({
+      ...base,
+      surface: surfaceById('matrix'),
+      activeOrgId: 'org_2',
+      routeProjectId: 'prj_2',
+      systemScope,
+    });
+    expect(model.context?.links.map((l) => l.id)).toContain('machine-access');
+    expect(model.organisation?.links.map((l) => l.id)).toContain('scim');
   });
 });

--- a/web/src/routes/sidebar-model.ts
+++ b/web/src/routes/sidebar-model.ts
@@ -1,7 +1,7 @@
 import { generatePath } from 'react-router';
 
 import { needsOrg, sectionsFor, surfaceById, type Surface } from '../app/navigation.ts';
-import type { SystemScope } from '../api/selfConfig.ts';
+import { SYSTEM_SCOPE_REFUSED_SURFACES, type SystemScope } from '../api/selfConfig.ts';
 import { withRemote } from '../api/transport.tsx';
 
 export type SidebarLink = {
@@ -32,12 +32,8 @@ export type SidebarModel = {
 
 const localOnly = (label: string) => `${label} is local-instance only`;
 
-/**
- * The surfaces the protected system profile refuses outright. Every other
- * project and organisation surface stays reachable there under its ordinary
- * grant plus `instance-config`.
- */
-export const SYSTEM_SCOPE_REFUSES: ReadonlySet<string> = new Set(['machine-access', 'adapters', 'scim']);
+/** Every other project and organisation surface stays reachable in the system scope. */
+const SYSTEM_SCOPE_REFUSES: ReadonlySet<string> = new Set(SYSTEM_SCOPE_REFUSED_SURFACES);
 
 function link(surface: Surface, to: string, disabledReason: string | null = null): SidebarLink {
   return { id: surface.id, label: surface.label, to, disabledReason };

--- a/web/src/routes/sidebar-model.ts
+++ b/web/src/routes/sidebar-model.ts
@@ -1,6 +1,7 @@
 import { generatePath } from 'react-router';
 
 import { needsOrg, sectionsFor, surfaceById, type Surface } from '../app/navigation.ts';
+import type { SystemScope } from '../api/selfConfig.ts';
 import { withRemote } from '../api/transport.tsx';
 
 export type SidebarLink = {
@@ -31,6 +32,13 @@ export type SidebarModel = {
 
 const localOnly = (label: string) => `${label} is local-instance only`;
 
+/**
+ * The surfaces the protected system profile refuses outright. Every other
+ * project and organisation surface stays reachable there under its ordinary
+ * grant plus `instance-config`.
+ */
+export const SYSTEM_SCOPE_REFUSES: ReadonlySet<string> = new Set(['machine-access', 'adapters', 'scim']);
+
 function link(surface: Surface, to: string, disabledReason: string | null = null): SidebarLink {
   return { id: surface.id, label: surface.label, to, disabledReason };
 }
@@ -53,8 +61,17 @@ export function sidebarModel(input: {
   readonly routeProjectId: string;
   readonly remote: string;
   readonly isInstanceOperator: boolean;
+  /**
+   * The Hikyo system organisation and project (the self-configuration
+   * binding), or null while unknown. The protected profile refuses machine
+   * consumers, adapters and SCIM there by design (permission-model ADR,
+   * 2026-09-06 amendment), so those entries are absent rather than dead.
+   */
+  readonly systemScope: SystemScope | null;
 }): SidebarModel {
-  const { surface, activeOrgId, routeProjectId, remote, isInstanceOperator } = input;
+  const { surface, activeOrgId, routeProjectId, remote, isInstanceOperator, systemScope } = input;
+  const systemOrg = systemScope !== null && systemScope.org === activeOrgId;
+  const systemProject = systemOrg && systemScope.project === routeProjectId;
 
   // An org-scoped destination needs an organisation to point at. With none
   // active the entry is absent rather than dead: a link that resolves to
@@ -64,6 +81,7 @@ export function sidebarModel(input: {
     title: 'Organisation',
     links: sectionsFor('organisation')
       .filter((item) => !needsOrg(item) || activeOrgId !== '')
+      .filter((item) => !systemOrg || !SYSTEM_SCOPE_REFUSES.has(item.id))
       .map((item) =>
         link(item, needsOrg(item) ? generatePath(item.path, { org: activeOrgId }) : item.path),
       ),
@@ -88,11 +106,13 @@ export function sidebarModel(input: {
     const params = { org: activeOrgId, project: routeProjectId };
     const membersSurface = surfaceById('members');
     const membersPath = `${generatePath(membersSurface.path, { org: activeOrgId })}?project=${encodeURIComponent(routeProjectId)}`;
-    const projectLinks = sectionsFor('project').map((item) => {
-      const path = generatePath(item.path, params);
-      if (item.id === 'matrix') return link(item, withRemote(path, remote));
-      return link(item, path, remote === '' ? null : localOnly(item.label));
-    });
+    const projectLinks = sectionsFor('project')
+      .filter((item) => !systemProject || !SYSTEM_SCOPE_REFUSES.has(item.id))
+      .map((item) => {
+        const path = generatePath(item.path, params);
+        if (item.id === 'matrix') return link(item, withRemote(path, remote));
+        return link(item, path, remote === '' ? null : localOnly(item.label));
+      });
     // The filtered members projection sits before Project settings, so the
     // block reads narrow to wide: matrix, machine access, members, settings.
     const members: SidebarLink = {


### PR DESCRIPTION
## Why

Six screenshots from a nightly 35 instance: every page inside the `Hikyo` organisation and its `Hikyo <instance id>` project refused the first administrator. Reproduced on a fresh HEAD build with an MFA session. Not a nightly 35 regression (no authz/service change since nightly 30). Three causes:

1. **System scope refuses by design.** The `Hikyo` hierarchy is the self-configuration scope (#686). `internal/authz/self_config.go` applies a closed op allowlist there; service-account, provider, lease, adapter and SCIM operations are not on it, so they 404 whatever the caller holds (permission-model ADR, 2026-09-06 amendment). The same calls answer 200 in an ordinary organisation. The web app still offered the pages and rendered denial copy.
2. **Two grants no template seeds.** `audit-read` is outside `admin` (audit-model ADR); `instance-directory` is outside `operator`. Granting them resolves Audit, Project audit and Remotes.
3. **Copy that lied.** Machine access said "needs manage-identities" to a holder of it.

## What

- Sidebar omits Machine access, Deployment adapters and SCIM provisioning in the system scope, keyed on the self-config binding (`sidebar-model.ts`).
- `gateSystemScope` wraps those three routes: a deep link renders the reason and a link to Instance settings (`SystemScope.tsx`).
- No "New project" form in the system organisation; the profile refuses a second project.
- Binding read enabled only for the session's `instance_operator` hint: the status read needs `instance-config` and records its denial.
- Audit and Remotes refusal copy names the exact grant, scope and where to make it. Machine access copy no longer asserts a cause.
- Getting started § 4 documents the two grants and the system scope; browser-operations notes the refused pages.
- Handoff: `docs/handoff/system-scope-refusals.md`.

## For the reviewer

- `web/src/api/sensitiveInventory.json`: the hash for `api/selfConfig.ts` is bumped by the author. The change there is one read-only query hook (`useSystemScope`) and two exported constants; no mutation path touched. Please look at that file specifically.
- Remote workspaces: the binding read is skipped when a workspace is remote (Shell and gate). The remote's system scope is its own concern, and its project links are disabled in this shell anyway.

## Not changed

Templates and the allowlist (locked ADR decisions). Seeding `audit-read` or `instance-directory` at bootstrap is a separate decision.

## Verification

- `web`: `tsc --noEmit` and `vitest run` green (959 tests), `scripts/ci/build-spa.sh --verify` green.
- `docs/site`: `pnpm run check` green.
- Manual on `server --dev`: system org sidebar drops SCIM and the project form; system project sidebar drops Machine access and Adapters; deep link to machine access renders the refusal; Remotes and Audit render once `instance-directory` and `audit-read` are granted through the ordinary grant API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

